### PR TITLE
feat: Add resume uploading function

### DIFF
--- a/bot/cogs/email_monitor.py
+++ b/bot/cogs/email_monitor.py
@@ -11,7 +11,6 @@ import email
 import logging
 from textwrap import wrap
 from discord.ext import commands, tasks
-from discord import app_commands
 import discord
 
 from bot.config import settings
@@ -150,24 +149,24 @@ class EmailMonitor(commands.Cog):
         mail.logout()
         logger.debug("end of this iteration")
 
-    @app_commands.command(name="start-email", description="Start email polling task")
-    async def st(self, interaction: discord.Interaction) -> None:
-        """Start email polling task."""
-        await interaction.response.send_message(
-            f"Polling for emails every {settings.check_email_wait} minutes"
-        )
-        if not self.task_poll_inbox.is_running():
-            self.task_poll_inbox.start()
+    # @app_commands.command(name="start-email", description="Start email polling task")
+    # async def st(self, interaction: discord.Interaction) -> None:
+    #     """Start email polling task."""
+    #     await interaction.response.send_message(
+    #         f"Polling for emails every {settings.check_email_wait} minutes"
+    #     )
+    #     if not self.task_poll_inbox.is_running():
+    #         self.task_poll_inbox.start()
 
-    @app_commands.command(
-        name="email-status", description="Check if email polling task is running"
-    )
-    async def is_running(self, interaction: discord.Interaction) -> None:
-        """Check if email polling task is running."""
-        status = "is" if self.task_poll_inbox.is_running() else "isn't"
-        await interaction.response.send_message(
-            f"Inbox polling task *{status}* running"
-        )
+    # @app_commands.command(
+    #     name="email-status", description="Check if email polling task is running"
+    # )
+    # async def is_running(self, interaction: discord.Interaction) -> None:
+    #     """Check if email polling task is running."""
+    #     status = "is" if self.task_poll_inbox.is_running() else "isn't"
+    #     await interaction.response.send_message(
+    #         f"Inbox polling task *{status}* running"
+    #     )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/bot/cogs/example_cog.py
+++ b/bot/cogs/example_cog.py
@@ -6,8 +6,6 @@ it to create new cogs for the 508.dev Discord bot.
 """
 
 from discord.ext import commands
-from discord import app_commands
-import discord
 
 
 class ExampleCog(commands.Cog):
@@ -16,12 +14,12 @@ class ExampleCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
-    @app_commands.command(name="hello", description="Say hello and get a warm welcome!")
-    async def hello_command(self, interaction: discord.Interaction) -> None:
-        """Simple hello command example."""
-        await interaction.response.send_message(
-            f"Hello {interaction.user.mention}! Welcome to 508.dev!"
-        )
+    # @app_commands.command(name="hello", description="Say hello and get a warm welcome!")
+    # async def hello_command(self, interaction: discord.Interaction) -> None:
+    #     """Simple hello command example."""
+    #     await interaction.response.send_message(
+    #         f"Hello {interaction.user.mention}! Welcome to 508.dev!"
+    #     )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/bot/utils/espo_api_client.py
+++ b/bot/utils/espo_api_client.py
@@ -102,6 +102,41 @@ class EspoAPI:
 
         return response.content
 
+    def upload_file(
+        self,
+        file_content: bytes,
+        filename: str,
+        related_type: str = "Contact",
+        related_id: str = "",
+        field: str = "resume",
+    ) -> Dict[str, Any]:
+        """Upload a file to EspoCRM and return the attachment record."""
+        import base64
+        import mimetypes
+
+        # Determine MIME type
+        mime_type, _ = mimetypes.guess_type(filename)
+        if not mime_type:
+            mime_type = "application/octet-stream"
+
+        # Encode file content as base64 data URI
+        file_base64 = base64.b64encode(file_content).decode("utf-8")
+        data_uri = f"data:{mime_type};base64,{file_base64}"
+
+        # Prepare JSON payload
+        payload = {
+            "name": filename,
+            "type": mime_type,
+            "role": "Attachment",
+            "relatedType": related_type,
+            "relatedId": related_id,
+            "field": field,
+            "file": data_uri,
+        }
+
+        response = self.request("POST", "Attachment", payload)
+        return response
+
     def normalize_url(self, action: str) -> str:
         return self.url + "/" + action
 

--- a/tests/integration/test_email_monitor.py
+++ b/tests/integration/test_email_monitor.py
@@ -26,42 +26,6 @@ class TestEmailMonitorIntegration:
             monitor.task_poll_inbox.is_running = Mock(return_value=False)
             return monitor
 
-    @pytest.mark.asyncio
-    async def test_st_command_starts_polling(self, email_monitor, mock_discord_context):
-        """Test that st command starts email polling."""
-        # Mock the interaction response for slash commands
-        mock_discord_context.response = Mock()
-        mock_discord_context.response.send_message = AsyncMock()
-
-        await email_monitor.st.callback(email_monitor, mock_discord_context)
-
-        mock_discord_context.response.send_message.assert_called_once()
-        call_args = mock_discord_context.response.send_message.call_args[0][0]
-        assert "Polling for emails" in call_args
-
-    @pytest.mark.asyncio
-    async def test_is_running_command_shows_status(
-        self, email_monitor, mock_discord_context
-    ):
-        """Test that is_running command shows correct status."""
-        # Mock the interaction response for slash commands
-        mock_discord_context.response = Mock()
-        mock_discord_context.response.send_message = AsyncMock()
-
-        # Test when not running
-        email_monitor.task_poll_inbox.is_running.return_value = False
-        await email_monitor.is_running.callback(email_monitor, mock_discord_context)
-
-        call_args = mock_discord_context.response.send_message.call_args[0][0]
-        assert "isn't" in call_args
-
-        # Test when running
-        email_monitor.task_poll_inbox.is_running.return_value = True
-        await email_monitor.is_running.callback(email_monitor, mock_discord_context)
-
-        call_args = mock_discord_context.response.send_message.call_args[0][0]
-        assert "is" in call_args and "isn't" not in call_args
-
     # IMAP integration tests removed - too complex to mock properly
     # The core functionality is tested via unit tests and command tests
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Optionally prefix with feat/chore/fix: -->

## Description
<!--- Describe your changes in detail -->
Allow Steering Committee+ to upload resumes for everyone. Resumes are appended (though there's an option to overwrite all resumes). Allow users with discord usernames linked to upload their own resumes.

## Related Issue
<!--- If there are any related issues or Notion tasks, please link here: -->

## How Has This Been Tested?
<!--- Please describe how you tested or plan to test your changes. -->
Tested manually via Discord and also with unit tests