### PR TITLE
fix: Add billed amount to Kimai report and fix timesheet pagination

### DIFF
--- a/bot/cogs/kimai.py
+++ b/bot/cogs/kimai.py
@@ -99,9 +99,10 @@ class KimaiCog(commands.Cog, name="Kimai"):
                 project_id=project_id, begin=begin, end=end
             )
 
-            # Calculate total hours
+            # Calculate total hours and billed amount
             total_hours = sum(data["hours"] for data in user_hours.values())
             total_entries = sum(data["entries"] for data in user_hours.values())
+            total_billed = sum(data["billed_amount"] for data in user_hours.values())
 
             # Build response embed
             embed = discord.Embed(
@@ -114,7 +115,14 @@ class KimaiCog(commands.Cog, name="Kimai"):
             embed.add_field(
                 name="Total Hours",
                 value=f"**{self._format_hours(total_hours)}** ({total_entries} entries)",
-                inline=False,
+                inline=True,
+            )
+
+            # Add total billed amount
+            embed.add_field(
+                name="Total Billed",
+                value=f"**${total_billed:,.2f}**",
+                inline=True,
             )
 
             # Add breakdown by team member
@@ -128,8 +136,9 @@ class KimaiCog(commands.Cog, name="Kimai"):
                 for user_name, data in sorted_users:
                     hours = data["hours"]
                     entries = data["entries"]
+                    billed = data["billed_amount"]
                     breakdown_lines.append(
-                        f"**{user_name}**: {self._format_hours(hours)} ({entries} entries)"
+                        f"**{user_name}**: {self._format_hours(hours)} ({entries} entries) - ${billed:,.2f}"
                     )
 
                 # Discord field value limit is 1024 characters

--- a/tests/unit/test_kimai.py
+++ b/tests/unit/test_kimai.py
@@ -73,8 +73,18 @@ class TestKimaiCog:
 
         # Mock hours breakdown
         mock_hours = {
-            "John Doe": {"hours": 10.5, "entries": 5, "duration_seconds": 37800},
-            "Jane Smith": {"hours": 8.0, "entries": 3, "duration_seconds": 28800},
+            "John Doe": {
+                "hours": 10.5,
+                "entries": 5,
+                "duration_seconds": 37800,
+                "billed_amount": 1050.0,
+            },
+            "Jane Smith": {
+                "hours": 8.0,
+                "entries": 3,
+                "duration_seconds": 28800,
+                "billed_amount": 800.0,
+            },
         }
         kimai_cog.api.get_project_hours_by_user.return_value = mock_hours
 
@@ -421,7 +431,12 @@ class TestKimaiCog:
 
         # Create a large number of users to force chunking
         mock_hours = {
-            f"User {i}": {"hours": 10.0, "entries": 5, "duration_seconds": 36000}
+            f"User {i}": {
+                "hours": 10.0,
+                "entries": 5,
+                "duration_seconds": 36000,
+                "billed_amount": 500.0,
+            }
             for i in range(50)
         }
         kimai_cog.api.get_project_hours_by_user.return_value = mock_hours
@@ -498,9 +513,24 @@ class TestKimaiCog:
         kimai_cog.api.get_project_by_name.return_value = mock_project
 
         mock_hours = {
-            "User A": {"hours": 5.0, "entries": 2, "duration_seconds": 18000},
-            "User B": {"hours": 15.0, "entries": 3, "duration_seconds": 54000},
-            "User C": {"hours": 10.0, "entries": 1, "duration_seconds": 36000},
+            "User A": {
+                "hours": 5.0,
+                "entries": 2,
+                "duration_seconds": 18000,
+                "billed_amount": 250.0,
+            },
+            "User B": {
+                "hours": 15.0,
+                "entries": 3,
+                "duration_seconds": 54000,
+                "billed_amount": 750.0,
+            },
+            "User C": {
+                "hours": 10.0,
+                "entries": 1,
+                "duration_seconds": 36000,
+                "billed_amount": 500.0,
+            },
         }
         kimai_cog.api.get_project_hours_by_user.return_value = mock_hours
 
@@ -510,7 +540,7 @@ class TestKimaiCog:
 
         call_args = mock_interaction.followup.send.call_args
         embed = call_args[1]["embed"]
-        breakdown_field = embed.fields[1].value  # Second field is the breakdown
+        breakdown_field = embed.fields[2].value  # Third field is the breakdown
 
         # User B (15h) should appear before User C (10h) before User A (5h)
         b_pos = breakdown_field.index("User B")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Optionally prefix with feat/chore/fix: -->

## Description
<!--- Describe your changes in detail -->
Add billed amount for each engineer as well as total billed. Exclude any activity named `Retainer`

## Related Issue
<!--- If there are any related issues or Notion tasks, please link here: -->

## How Has This Been Tested?
<!--- Please describe how you tested or plan to test your changes. -->
Unit tests and local Discord reserver

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project hours reports now include billed amounts per user and a new "Total Billed" field.
  * Per-user breakdown lines show individual billed totals alongside hours and entries.
  * Reports exclude retainer-type activities from billed totals and support activity-based filtering.

* **Tests**
  * Tests updated to validate billed-amount calculations, activity filtering, retainer exclusion, and related report behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->