### PR TITLE
feat: Warn in Kimai project report if a user forgot to set the rate on an entry

### DIFF
--- a/bot/cogs/kimai.py
+++ b/bot/cogs/kimai.py
@@ -137,8 +137,14 @@ class KimaiCog(commands.Cog, name="Kimai"):
                     hours = data["hours"]
                     entries = data["entries"]
                     billed = data["billed_amount"]
+                    zero_rate_entries = data.get("zero_rate_entries", 0)
+                    zero_rate_note = (
+                        f" — {zero_rate_entries} $0 record(s) found"
+                        if zero_rate_entries > 0
+                        else ""
+                    )
                     breakdown_lines.append(
-                        f"**{user_name}**: {self._format_hours(hours)} ({entries} entries) - ${billed:,.2f}"
+                        f"**{user_name}**: {self._format_hours(hours)} ({entries} entries) - ${billed:,.2f}{zero_rate_note}"
                     )
 
                 # Discord field value limit is 1024 characters

--- a/bot/utils/kimai_api_client.py
+++ b/bot/utils/kimai_api_client.py
@@ -444,7 +444,7 @@ class KimaiAPI:
         for entry in timesheets:
             user_id_raw = entry.get("user")
             duration = entry.get("duration", 0)  # Duration in seconds
-            rate = entry.get("rate", 0)  # Billed amount for this entry
+            rate_raw = entry.get("rate", 0)  # Billed amount for this entry
 
             if user_id_raw is None:
                 continue
@@ -463,13 +463,17 @@ class KimaiAPI:
                     "duration_seconds": 0,
                     "entries": 0,
                     "billed_amount": 0.0,
+                    "zero_rate_entries": 0,
                 }
 
+            rate = float(rate_raw) if rate_raw is not None else 0.0
             user_hours[user_name]["duration_seconds"] += duration
             user_hours[user_name]["hours"] = (
                 user_hours[user_name]["duration_seconds"] / 3600
             )
             user_hours[user_name]["entries"] += 1
-            user_hours[user_name]["billed_amount"] += float(rate)
+            user_hours[user_name]["billed_amount"] += rate
+            if rate == 0:
+                user_hours[user_name]["zero_rate_entries"] += 1
 
         return user_hours


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above. -->
<!--- Optionally prefix with feat/chore/fix: -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- If there are any related issues or Notion tasks, please link here: -->

## How Has This Been Tested?
<!--- Please describe how you tested or plan to test your changes. -->
Test Discord server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project hours breakdown now identifies and displays the count of zero-rate entries ($0 records) for each user directly in their summary breakdown line, providing visibility into unbilled time entries and improving reporting transparency.

* **Tests**
  * Added unit test coverage to validate accurate detection and tracking of zero-rate entries alongside standard project billing calculations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->