### PR TITLE
chore: set Redis overcommit sysctl and pin dramatiq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ services:
   redis:
     image: redis:7-alpine
     command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
+    sysctls:
+      vm.overcommit_memory: "1"
     restart: unless-stopped
     volumes:
       - redis-data:/data

--- a/uv.lock
+++ b/uv.lock
@@ -867,7 +867,7 @@ dependencies = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.1" },
     { name = "alembic", specifier = ">=1.14.1" },
-    { name = "dramatiq", extras = ["redis"], specifier = ">=1.17.0" },
+    { name = "dramatiq", extras = ["redis"], specifier = "==2.0.1" },
     { name = "five08", editable = "packages/shared" },
     { name = "openai", specifier = ">=2.0.0" },
     { name = "pdfminer-six", specifier = ">=20250506" },


### PR DESCRIPTION
## Description
Adds `vm.overcommit_memory=1` to the Redis service in Compose to address the Redis overcommit warning. Also updates the lockfile to pin `dramatiq[redis]` to `2.0.1`.

## Related Issue
None.

## How Has This Been Tested?
Validated by reviewing `git diff origin/main...` and confirming the branch pushes cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis service configuration in deployment environment with optimized memory management settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->