### PR TITLE
fix: remove redis overcommit sysctl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ services:
   redis:
     image: redis:7-alpine
     command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
-    sysctls:
-      vm.overcommit_memory: "1"
     restart: unless-stopped
     volumes:
       - redis-data:/data


### PR DESCRIPTION
## Description\nRemoves  from the Redis service  in  because this kernel namespace sysctl is not supported in some container runtimes, which can prevent deployment start-up.\nThis change leaves Redis startup command and service behavior unchanged except for avoiding unsupported sysctl injection at container create time.\n## Related Issue\nN/A\n## How Has This Been Tested?\nNot run automatically for this fix; validated by reviewing the diff to ensure only the unsupported sysctl block was removed before attempting redeploy.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Docker Compose configuration by removing an unused sysctls setting from the Redis service definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->