### PR TITLE
ci: use configurable MinIO API port in healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "-f", "http://localhost:${MINIO_API_PORT:-9000}/minio/health/live"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Description
Updated the MinIO healthcheck in `docker-compose.yml` to reference `${MINIO_API_PORT:-9000}` instead of hardcoded `9000`, so local and CI environments can override the API port consistently.

## Related Issue
None.

## How Has This Been Tested?
Not run (configuration-only change). This is a compose-time update and no runtime test was executed.
