### PR TITLE
ci: make minio healthcheck honor API host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-internal}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
+      MC_HOST_local: "http://${MINIO_ROOT_USER:-internal}:${MINIO_ROOT_PASSWORD:-change-me}@127.0.0.1:9000"
     ports:
       - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_API_PORT:-9000}:9000"
       - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9001}:9001"
@@ -41,16 +42,19 @@ services:
     volumes:
       - minio-data:/data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${MINIO_API_PORT:-9000}/minio/health/live"]
+      test: ["CMD-SHELL", "mc ready local || exit 1"]
       interval: 10s
       timeout: 3s
       retries: 5
 
   minio-init:
     image: cgr.dev/chainguard/minio-client
-    command: >
-      /bin/sh -c "mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-internal}
-      ${MINIO_ROOT_PASSWORD:-change-me} && mc mb --ignore-existing local/${MINIO_INTERNAL_BUCKET:-internal-transfers}"
+    environment:
+      MC_HOST_local: "http://${MINIO_ROOT_USER:-internal}:${MINIO_ROOT_PASSWORD:-change-me}@minio:9000"
+    command:
+      - mb
+      - --ignore-existing
+      - local/${MINIO_INTERNAL_BUCKET:-internal-transfers}
     depends_on:
       minio:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- Use MinIO client alias from environment for compose healthcheck to avoid localhost mismatch
- Switch minio healthcheck from curl to 
- Simplify minio-init command using env-based alias and explicit mb args

## Testing
- ./scripts/test.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved MinIO service configuration with enhanced health monitoring and streamlined initialization process.
  * Updated service dependencies and restart policies for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->