### PR TITLE
Fix worker migration script path

### DIFF
--- a/apps/worker/src/five08/worker/db_migrations.py
+++ b/apps/worker/src/five08/worker/db_migrations.py
@@ -12,6 +12,9 @@ from five08.settings import normalize_sqlalchemy_postgres_url
 from five08.worker.config import settings
 
 _ALEMBIC_CFG_PATH = Path(__file__).resolve().parents[3] / "pyproject.toml"
+_ALEMBIC_MIGRATIONS_PATH = (
+    _ALEMBIC_CFG_PATH.parent / "src" / "five08" / "worker" / "migrations"
+)
 
 
 def _sqlalchemy_postgres_url() -> str:
@@ -23,5 +26,6 @@ def run_job_migrations() -> None:
     """Run Alembic migrations to ensure the jobs table exists and is current."""
     configure_logging(settings.log_level)
     cfg = Config(toml_file=str(_ALEMBIC_CFG_PATH))
+    cfg.set_main_option("script_location", str(_ALEMBIC_MIGRATIONS_PATH))
     cfg.set_main_option("sqlalchemy.url", _sqlalchemy_postgres_url())
     command.upgrade(cfg, "head")


### PR DESCRIPTION
## Description
- Set worker migration runner to resolve Alembic `script_location` from an absolute path derived from `apps/worker/src/five08/worker/db_migrations.py`.
- Removed reliance on process working directory when initializing Alembic, so startup no longer fails with `Path doesn't exist: src/five08/worker/migrations`.
- Kept migration behavior unchanged aside from stable path resolution during startup.

## Related Issue
- None.

## How Has This Been Tested?
- Not run in this environment (commit-time hooks passed: ruff and mypy); runtime verification is pending.
