### PR TITLE
Fix shared queue job ID serialization

### DIFF
--- a/packages/shared/src/five08/queue.py
+++ b/packages/shared/src/five08/queue.py
@@ -111,7 +111,7 @@ _UNSET = object()
 def _as_record(row: dict[str, Any]) -> JobRecord:
     """Build a typed job record from a DB row."""
     return JobRecord(
-        id=row["id"],
+        id=str(row["id"]),
         type=row["type"],
         status=_parse_status(row["status"]),
         payload=row["payload"] or {},
@@ -171,7 +171,7 @@ def create_job_record(
             )
             row = cursor.fetchone()
             if row is not None:
-                return row["id"], True
+                return str(row["id"]), True
 
             if idempotency_key is None:
                 raise RuntimeError("Unable to create job row without idempotency key.")
@@ -189,7 +189,7 @@ def create_job_record(
     if existing is None:
         raise RuntimeError("Unable to load existing job for duplicate idempotency key.")
 
-    return existing["id"], False
+    return str(existing["id"]), False
 
 
 def get_job(settings: SharedSettings, job_id: str) -> JobRecord | None:


### PR DESCRIPTION
## Description\nNormalize job IDs coming from Postgres to strings in shared queue helpers so the queue payload is JSON-serializable for Dramatiq and no longer fails when enqueuing duplicate jobs by idempotency.\n\n## Related Issue\nN/A\n\n## How Has This Been Tested?\nChanges are covered by repository pre-commit hooks which passed during commit, and the queue code path now consistently returns string job IDs for consumers.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent data type handling for record identifiers to ensure proper string formatting across job record operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->