### PR TITLE
fix: run worker via dramatiq and prevent worker join exit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,13 +112,12 @@ services:
     build:
       context: .
       dockerfile: apps/worker/Dockerfile
-    command: [
-      "uv", "run", "--package", "integrations-worker",
-      "dramatiq", "five08.worker.actors",
-      "--processes", "${WORKER_PROCESSES:-1}",
-      "--threads", "${WORKER_THREADS:-8}",
-      "-Q", "${WORKER_QUEUE_NAMES:-jobs.default}"
-    ]
+    command: >-
+      uv run --package integrations-worker
+      dramatiq five08.worker.actors
+      --processes ${WORKER_PROCESSES:-1}
+      --threads ${WORKER_THREADS:-8}
+      -Q ${WORKER_QUEUE_NAMES:-jobs.default}
     env_file:
       - .env
     environment:


### PR DESCRIPTION
## Description
- Update worker entrypoint lifecycle handling in `apps/worker/src/five08/worker/consumer.py` to avoid `Worker.join()` returning on idle queues by running with an explicit shutdown event loop and graceful `worker.stop()` on signal.
- Add startup actor-import validation with clearer exception logging so import-time failures are surfaced immediately.
- Switch compose `worker-consumer` command to launch via dramatiq CLI directly (`five08.worker.actors`) for production-style process behavior.

## Related Issue
- Root cause investigated around worker restarts that produced repeated `Starting worker` logs without actionable errors.

## How Has This Been Tested?
- Ran `docker compose up -d --no-deps redis worker-consumer --build` and confirmed consumer comes up and stays running.
- Tail logs from `manila-worker-consumer-1` show normal Dramatiq boot/ready lifecycle and no restart loop (restart count remains `0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable worker processes and threads for improved parallelism
  * Selectable queues via environment variables
  * Worker now launches background task processor as a distinct process for better isolation

* **Bug Fixes**
  * Improved startup with guarded actor loading and clearer failure reporting
  * Graceful shutdown on system signals with timeout-controlled stop and enhanced lifecycle logging
<!-- end of auto-generated comment: release notes by coderabbit.ai -->