### PR TITLE
feat: add mark-id-verified command

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -8,6 +8,7 @@ It allows team members to quickly access CRM data without leaving Discord.
 import asyncio
 import io
 import logging
+from datetime import date, datetime
 import re
 from typing import Any
 
@@ -26,6 +27,10 @@ from five08.discord_bot.utils.role_decorators import (
 )
 
 logger = logging.getLogger(__name__)
+
+ID_VERIFIED_FIELD = "cIdVerified"
+ID_VERIFIED_AT_FIELD = "cIdVerifiedAt"
+ID_VERIFIED_BY_FIELD = "cIdVerifiedBy"
 
 EspoAPI = espo.EspoAPI
 EspoAPIError = espo.EspoAPIError
@@ -220,6 +225,97 @@ class ContactSelectionButton(discord.ui.Button[ContactSelectionView]):
             await interaction.followup.send(
                 "❌ An error occurred while linking the contact."
             )
+
+
+class MarkIdVerifiedSelectionButton(discord.ui.Button["MarkIdVerifiedSelectionView"]):
+    """Button for selecting a contact to mark ID verification on."""
+
+    def __init__(
+        self,
+        contact: dict[str, Any],
+        verified_by: str | None,
+        verified_at: str,
+        requester_id: int,
+    ) -> None:
+        contact_name = contact.get("name", "Unknown")
+        label = contact_name[:80] if len(contact_name) > 80 else contact_name
+        super().__init__(style=discord.ButtonStyle.success, label=label, emoji="✅")
+        self.contact = contact
+        self.verified_by = verified_by
+        self.verified_at = verified_at
+        self.requester_id = requester_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Handle contact selection and perform the ID verification."""
+        try:
+            if not self.view:
+                await interaction.response.send_message("❌ View not found.")
+                return
+            if interaction.user.id != self.requester_id:
+                await interaction.response.send_message(
+                    "❌ Only the command requester can confirm this action.",
+                    ephemeral=True,
+                )
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            await self.view.crm_cog._mark_id_verified_for_contact(
+                interaction=interaction,
+                contact=self.contact,
+                verified_by=self.verified_by,
+                verified_at=self.verified_at,
+            )
+
+            for item in self.view.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+
+            if interaction.message:
+                try:
+                    await interaction.message.edit(view=self.view)
+                except discord.NotFound:
+                    pass
+                except discord.HTTPException as exc:
+                    logger.warning(
+                        f"Failed to update ID verification selection view: {exc}"
+                    )
+        except Exception as exc:
+            logger.error(f"Error in ID verified selection callback: {exc}")
+            await interaction.followup.send(
+                "❌ An error occurred while marking ID verification."
+            )
+
+
+class MarkIdVerifiedSelectionView(discord.ui.View):
+    """View containing contact selection buttons for ID verification."""
+
+    def __init__(
+        self,
+        crm_cog: "CRMCog",
+        requester_id: int,
+        verified_by: str | None,
+        verified_at: str,
+    ) -> None:
+        super().__init__(timeout=300)  # 5 minute timeout
+        self.crm_cog = crm_cog
+        self.requester_id = requester_id
+        self.verified_by = verified_by
+        self.verified_at = verified_at
+
+    def add_contact_button(
+        self,
+        contact: dict[str, Any],
+    ) -> None:
+        """Add a contact selection button."""
+        if len(self.children) >= 5:
+            return
+        button = MarkIdVerifiedSelectionButton(
+            contact=contact,
+            verified_by=self.verified_by,
+            verified_at=self.verified_at,
+            requester_id=self.requester_id,
+        )
+        self.add_item(button)
 
 
 class ResumeConfirmationView(discord.ui.View):
@@ -1976,6 +2072,441 @@ class CRMCog(commands.Cog):
         )
 
         await interaction.followup.send(embed=embed, view=view)
+
+    def _normalize_508_username(self, value: str | None) -> str | None:
+        """Normalize a 508 username candidate."""
+        if not value:
+            return None
+
+        normalized = value.strip()
+        if not normalized:
+            return None
+
+        normalized = normalized.lstrip("@").strip()
+        normalized = " ".join(normalized.split())
+        if not normalized:
+            return None
+
+        if "@" in normalized:
+            username, _, domain = normalized.partition("@")
+            if not username:
+                return None
+            if domain.lower() in {"", "508", "508.dev"}:
+                return username.lower()
+            return username.lower()
+
+        return normalized.lower()
+
+    async def _resolve_verified_by(
+        self, interaction: discord.Interaction, verified_by: str
+    ) -> str | None:
+        """Resolve verifier.
+
+        If a value is provided:
+            - If it looks like a Discord mention, try to resolve from CRM using the
+              linked Discord user ID.
+            - Otherwise normalize directly as a 508 username.
+
+        If no value is provided, resolve the invoker from CRM first by Discord ID, then by
+        Discord username.
+        """
+        if verified_by.strip():
+            match = re.match(r"^<@!?(\d+)>$", verified_by.strip())
+            if match and interaction.guild:
+                member = interaction.guild.get_member(int(match.group(1)))
+                if member:
+                    contact = await self._find_contact_by_discord_id(str(member.id))
+                    if contact:
+                        candidate = self._normalize_508_username(
+                            contact.get("c508Email") or ""
+                        )
+                        if candidate:
+                            return candidate
+                    return self._normalize_508_username(member.name)
+
+            return self._normalize_508_username(verified_by)
+
+        return await self._resolve_verified_by_from_interaction_user(interaction)
+
+    async def _resolve_verified_by_from_interaction_user(
+        self, interaction: discord.Interaction
+    ) -> str | None:
+        """Resolve verifier using the invoking Discord user."""
+        user = interaction.user
+        if not user:
+            return None
+
+        if getattr(user, "id", None):
+            contact = await self._find_contact_by_discord_id(str(user.id))
+            if contact:
+                candidate = self._normalize_508_username(contact.get("c508Email") or "")
+                if candidate:
+                    return candidate
+
+        discord_username = self._normalize_508_username(str(user.name))
+        if discord_username:
+            contact = await self._find_contact_by_discord_username(discord_username)
+            if contact:
+                candidate = self._normalize_508_username(contact.get("c508Email") or "")
+                if candidate:
+                    return candidate
+            return discord_username
+
+        return None
+
+    async def _find_contact_by_discord_username(
+        self, discord_username: str
+    ) -> dict[str, Any] | None:
+        """Find a contact by Discord username."""
+        search_params = {
+            "where": [
+                {
+                    "type": "equals",
+                    "attribute": "cDiscordUsername",
+                    "value": discord_username,
+                }
+            ],
+            "maxSize": 1,
+            "select": "id,name,emailAddress,c508Email,cDiscordUsername,cDiscordUserID",
+        }
+
+        response = self.espo_api.request("GET", "Contact", search_params)
+        contacts = response.get("list", [])
+        return contacts[0] if contacts else None
+
+    async def _parse_verified_at(self, raw_verified_at: str | None) -> str:
+        """Parse an ID verification date or default to today."""
+        if not raw_verified_at or not raw_verified_at.strip():
+            return date.today().isoformat()
+
+        value = raw_verified_at.strip()
+        normalized = " ".join(value.replace(",", " ").split())
+
+        for fmt in (
+            "%B %d %Y",
+            "%b %d %Y",
+            "%d %B %Y",
+            "%d %b %Y",
+        ):
+            try:
+                return datetime.strptime(normalized, fmt).date().isoformat()
+            except ValueError:
+                continue
+
+        normalized_numeric = re.sub(r"[./\s]+", "-", value)
+        for fmt in (
+            "%Y-%m-%d",
+            "%d-%m-%Y",
+            "%d-%m-%y",
+            "%m-%d-%Y",
+            "%m-%d-%y",
+        ):
+            try:
+                return datetime.strptime(normalized_numeric, fmt).date().isoformat()
+            except ValueError:
+                continue
+
+        raise ValueError(f"Invalid verified_at format: '{raw_verified_at}'.")
+
+    async def _search_contacts_for_mark_id_verification(
+        self, search_term: str
+    ) -> list[dict[str, Any]]:
+        """Search for contacts for ID verification."""
+        contacts = await self._search_contact_for_linking(search_term)
+        if contacts:
+            return contacts
+
+        if "@" not in search_term and " " not in search_term:
+            contacts = await self._search_contact_for_linking(
+                f"{search_term.strip()}@508.dev"
+            )
+            if contacts:
+                return contacts
+
+        return contacts
+
+    async def _mark_id_verified_for_contact(
+        self,
+        interaction: discord.Interaction,
+        contact: dict[str, Any],
+        verified_by: str | None,
+        verified_at: str,
+    ) -> bool:
+        """Persist ID verification metadata to CRM."""
+        contact_id = contact.get("id")
+        contact_name = contact.get("name", "Unknown")
+
+        if not contact_id:
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="error",
+                metadata={
+                    "verified_by": verified_by,
+                    "verified_at": verified_at,
+                    "error": "contact_id_missing",
+                },
+            )
+            await interaction.followup.send("❌ Contact ID not found.")
+            return False
+
+        payload = {ID_VERIFIED_FIELD: True, ID_VERIFIED_AT_FIELD: verified_at}
+        if verified_by:
+            payload[ID_VERIFIED_BY_FIELD] = verified_by
+
+        try:
+            update_response = self.espo_api.request(
+                "PUT", f"Contact/{contact_id}", payload
+            )
+            if update_response:
+                embed = discord.Embed(
+                    title="✅ ID Verified",
+                    description=f"Marked **{contact_name}** as ID verified.",
+                    color=0x00FF00,
+                )
+                embed.add_field(name="📅 Verified at", value=verified_at, inline=True)
+                if verified_by:
+                    embed.add_field(
+                        name="✅ Verified by", value=verified_by, inline=True
+                    )
+                profile_url = f"{self.base_url}/#Contact/view/{contact_id}"
+                embed.add_field(
+                    name="🔗 CRM Profile",
+                    value=f"[View in CRM]({profile_url})",
+                    inline=True,
+                )
+                await interaction.followup.send(embed=embed)
+
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.mark_id_verified",
+                    result="success",
+                    metadata={
+                        "contact_id": str(contact_id),
+                        "verified_by": verified_by,
+                        "verified_at": verified_at,
+                    },
+                    resource_type="crm_contact",
+                    resource_id=str(contact_id),
+                )
+                return True
+
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="error",
+                metadata={
+                    "contact_id": str(contact_id),
+                    "verified_by": verified_by,
+                    "verified_at": verified_at,
+                    "error": "crm_update_failed",
+                },
+                resource_type="crm_contact",
+                resource_id=str(contact_id),
+            )
+            await interaction.followup.send(
+                "❌ Failed to update contact in CRM. Please try again."
+            )
+            return False
+
+        except EspoAPIError as exc:
+            logger.error(f"Failed to update contact ID verification: {exc}")
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="error",
+                metadata={
+                    "contact_id": str(contact_id),
+                    "verified_by": verified_by,
+                    "verified_at": verified_at,
+                    "error": str(exc),
+                },
+                resource_type="crm_contact",
+                resource_id=str(contact_id),
+            )
+            await interaction.followup.send(f"❌ CRM API error: {str(exc)}")
+            return False
+        except Exception as exc:
+            logger.error(f"Unexpected error marking ID verification: {exc}")
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="error",
+                metadata={
+                    "contact_id": str(contact_id),
+                    "verified_by": verified_by,
+                    "verified_at": verified_at,
+                    "error": str(exc),
+                },
+                resource_type="crm_contact",
+                resource_id=str(contact_id),
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while marking ID verification."
+            )
+            return False
+
+    async def _show_mark_id_verified_contact_choices(
+        self,
+        interaction: discord.Interaction,
+        search_term: str,
+        contacts: list[dict[str, Any]],
+        verified_by: str | None,
+        verified_at: str,
+    ) -> None:
+        """Show contact choices when multiple candidates are found."""
+        embed = discord.Embed(
+            title="🔍 Multiple Contacts Found",
+            description=(
+                f"Found {len(contacts)} contacts for `{search_term}`. "
+                "Select the correct person to mark as ID verified."
+            ),
+            color=0xFFA500,
+        )
+
+        view = MarkIdVerifiedSelectionView(
+            crm_cog=self,
+            requester_id=interaction.user.id,
+            verified_by=verified_by,
+            verified_at=verified_at,
+        )
+
+        for i, contact in enumerate(contacts[:5], 1):
+            name = contact.get("name", "Unknown")
+            email = contact.get("emailAddress", "No email")
+            email_508 = contact.get("c508Email", "No 508 email")
+            contact_id = contact.get("id", "")
+            contact_info = (
+                f"📧 {email}\n🏢 508 Email: {email_508}\n🆔 ID: `{contact_id}`"
+            )
+            embed.add_field(name=f"{i}. {name}", value=contact_info, inline=True)
+            view.add_contact_button(contact)
+
+        embed.add_field(
+            name="💡 Tip",
+            value="Select the contact button to continue, or rerun with a more specific term.",
+            inline=False,
+        )
+
+        await interaction.followup.send(embed=embed, view=view)
+
+    @app_commands.command(
+        name="mark-id-verified",
+        description="Mark a contact as ID verified (Admin only).",
+    )
+    @app_commands.describe(
+        search_term="Email, 508 username, or name.",
+        verified_by=(
+            "Verifier 508 username or @Discord mention. "
+            "Defaults to the command invoker if not provided."
+        ),
+        verified_at=(
+            "Date verified (e.g. YYYY-MM-DD, DD/MM/YYYY, March 5, 2026). "
+            "Defaults to today."
+        ),
+    )
+    @require_role("Admin")
+    async def mark_id_verified(
+        self,
+        interaction: discord.Interaction,
+        search_term: str,
+        verified_by: str | None = None,
+        verified_at: str | None = None,
+    ) -> None:
+        """Mark a contact as ID verified."""
+        try:
+            await interaction.response.defer(ephemeral=True)
+
+            resolved_verified_by = await self._resolve_verified_by(
+                interaction, verified_by or ""
+            )
+            if verified_by is None and not resolved_verified_by:
+                resolved_verified_by = self._normalize_508_username(
+                    str(interaction.user.name)
+                )
+            resolved_verified_at = await self._parse_verified_at(verified_at)
+
+            contacts = await self._search_contacts_for_mark_id_verification(search_term)
+
+            if not contacts:
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.mark_id_verified",
+                    result="success",
+                    metadata={
+                        "search_term": search_term,
+                        "verified_by": resolved_verified_by,
+                        "verified_at": resolved_verified_at,
+                        "contacts_found": 0,
+                    },
+                )
+                await interaction.followup.send(
+                    f"❌ No contact found for: `{search_term}`"
+                )
+                return
+
+            if len(contacts) > 1:
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.mark_id_verified",
+                    result="success",
+                    metadata={
+                        "search_term": search_term,
+                        "verified_by": resolved_verified_by,
+                        "verified_at": resolved_verified_at,
+                        "contacts_found": len(contacts),
+                        "requires_selection": True,
+                    },
+                )
+                await self._show_mark_id_verified_contact_choices(
+                    interaction=interaction,
+                    search_term=search_term,
+                    contacts=contacts,
+                    verified_by=resolved_verified_by,
+                    verified_at=resolved_verified_at,
+                )
+                return
+
+            target_contact = contacts[0]
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="success",
+                metadata={
+                    "search_term": search_term,
+                    "verified_by": resolved_verified_by,
+                    "verified_at": resolved_verified_at,
+                    "contacts_found": 1,
+                },
+                resource_type="crm_contact",
+                resource_id=str(target_contact.get("id")),
+            )
+            await self._mark_id_verified_for_contact(
+                interaction=interaction,
+                contact=target_contact,
+                verified_by=resolved_verified_by,
+                verified_at=resolved_verified_at,
+            )
+        except ValueError as exc:
+            logger.error(f"Invalid verified_at value: {exc}")
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="denied",
+                metadata={"verified_at": verified_at, "reason": str(exc)},
+            )
+            await interaction.followup.send(f"❌ {exc}")
+        except Exception as exc:
+            logger.error(f"Unexpected error in mark_id_verified: {exc}")
+            self._audit_command(
+                interaction=interaction,
+                action="crm.mark_id_verified",
+                result="error",
+                metadata={"search_term": search_term, "error": str(exc)},
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while marking ID verification."
+            )
 
     @app_commands.command(
         name="link-discord-user",

--- a/tests/unit/test_crm_mark_id_verified.py
+++ b/tests/unit/test_crm_mark_id_verified.py
@@ -1,0 +1,201 @@
+"""Tests for the mark-id-verified command."""
+
+from datetime import date
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from five08.discord_bot.cogs.crm import (
+    CRMCog,
+    ID_VERIFIED_FIELD,
+    ID_VERIFIED_AT_FIELD,
+    ID_VERIFIED_BY_FIELD,
+    MarkIdVerifiedSelectionView,
+)
+
+
+class TestMarkIdVerifiedCommand:
+    """Unit tests for mark-id-verified flow."""
+
+    @pytest.fixture
+    def mock_bot(self):
+        bot = Mock()
+        bot.get_cog = Mock()
+        return bot
+
+    @pytest.fixture
+    def mock_espo_api(self):
+        with patch("five08.discord_bot.cogs.crm.EspoAPI") as mock_api_class:
+            mock_api = Mock()
+            mock_api_class.return_value = mock_api
+            yield mock_api
+
+    @pytest.fixture
+    def crm_cog(self, mock_bot, mock_espo_api):
+        cog = CRMCog(mock_bot)
+        cog.espo_api = mock_espo_api
+        return cog
+
+    @pytest.fixture
+    def mock_interaction(self):
+        interaction = Mock()
+        interaction.response = AsyncMock()
+        interaction.followup = AsyncMock()
+        interaction.response.send_message = AsyncMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup.send = AsyncMock()
+        interaction.guild = None
+        interaction.user = Mock()
+        interaction.user.name = "admin_user"
+        interaction.user.id = 123
+        return interaction
+
+    @pytest.fixture
+    def admin_member(self):
+        member = Mock()
+        member.id = 999
+        member.name = "Caleb Rogers"
+        return member
+
+    @pytest.mark.asyncio
+    async def test_parse_verified_at_variants(self, crm_cog):
+        assert await crm_cog._parse_verified_at(None) == date.today().isoformat()
+        assert await crm_cog._parse_verified_at("March 5, 2026") == "2026-03-05"
+        assert await crm_cog._parse_verified_at("4/5/2026") == "2026-05-04"
+
+    @pytest.mark.asyncio
+    async def test_parse_verified_at_invalid_format(self, crm_cog):
+        with pytest.raises(ValueError, match="Invalid verified_at format"):
+            await crm_cog._parse_verified_at("not-a-date")
+
+    @pytest.mark.asyncio
+    async def test_resolve_verified_by_from_discord_mention(
+        self,
+        crm_cog,
+        mock_interaction,
+        admin_member,
+    ):
+        mock_interaction.guild = Mock()
+        mock_interaction.guild.get_member.return_value = admin_member
+        crm_cog._find_contact_by_discord_id = AsyncMock(
+            return_value={"c508Email": "caleb@508.dev", "id": "c1"}
+        )
+
+        resolved = await crm_cog._resolve_verified_by(mock_interaction, "<@999>")
+
+        assert resolved == "caleb"
+
+    @pytest.mark.asyncio
+    async def test_resolve_verified_by_from_invoker_via_discord_id(
+        self,
+        crm_cog,
+        mock_interaction,
+    ):
+        mock_interaction.user.id = 123
+        crm_cog._find_contact_by_discord_id = AsyncMock(
+            return_value={"c508Email": "admin_user@508.dev", "id": "admin-contact"}
+        )
+
+        resolved = await crm_cog._resolve_verified_by(mock_interaction, "")
+
+        assert resolved == "admin_user"
+        crm_cog._find_contact_by_discord_id.assert_awaited_once_with("123")
+
+    @pytest.mark.asyncio
+    async def test_resolve_verified_by_from_invoker_via_discord_username_fallback(
+        self,
+        crm_cog,
+        mock_interaction,
+    ):
+        mock_interaction.user.name = "Admin User"
+        crm_cog._find_contact_by_discord_id = AsyncMock(return_value=None)
+        crm_cog._find_contact_by_discord_username = AsyncMock(
+            return_value={"c508Email": "admin_user@508.dev", "id": "admin-contact"}
+        )
+
+        resolved = await crm_cog._resolve_verified_by(mock_interaction, "")
+
+        assert resolved == "admin_user"
+        crm_cog._find_contact_by_discord_username.assert_awaited_once_with("admin user")
+
+    @pytest.mark.asyncio
+    async def test_mark_id_verified_single_contact_updates_id_fields(
+        self,
+        crm_cog,
+        mock_interaction,
+    ):
+        contact = {
+            "id": "contact-123",
+            "name": "Caleb",
+            "c508Email": "caleb@508.dev",
+        }
+        crm_cog._search_contacts_for_mark_id_verification = AsyncMock(
+            return_value=[contact]
+        )
+        crm_cog.espo_api.request.return_value = {"id": "contact-123"}
+
+        await crm_cog.mark_id_verified.callback(
+            crm_cog,
+            mock_interaction,
+            "caleb",
+            "caleb",
+            "2026-02-26",
+        )
+
+        crm_cog.espo_api.request.assert_called_once_with(
+            "PUT",
+            "Contact/contact-123",
+            {
+                ID_VERIFIED_FIELD: True,
+                ID_VERIFIED_AT_FIELD: "2026-02-26",
+                ID_VERIFIED_BY_FIELD: "caleb",
+            },
+        )
+        args, kwargs = mock_interaction.followup.send.call_args
+        assert "embed" in kwargs
+        assert "ID Verified" in kwargs["embed"].title
+
+    @pytest.mark.asyncio
+    async def test_mark_id_verified_multiple_contacts_shows_selector(
+        self,
+        crm_cog,
+        mock_interaction,
+    ):
+        crm_cog._search_contacts_for_mark_id_verification = AsyncMock(
+            return_value=[
+                {"id": "c1", "name": "Caleb", "c508Email": "caleb@508.dev"},
+                {"id": "c2", "name": "Caleb B", "c508Email": "calebb@508.dev"},
+            ]
+        )
+
+        await crm_cog.mark_id_verified.callback(
+            crm_cog,
+            mock_interaction,
+            "caleb",
+            "Caleb",
+            "2026-02-26",
+        )
+
+        crm_cog.espo_api.request.assert_not_called()
+        args, kwargs = mock_interaction.followup.send.call_args
+        assert "view" in kwargs
+        assert isinstance(kwargs["view"], MarkIdVerifiedSelectionView)
+        assert kwargs["embed"].title == "🔍 Multiple Contacts Found"
+
+    @pytest.mark.asyncio
+    async def test_mark_id_verified_invalid_date_sends_message(
+        self,
+        crm_cog,
+        mock_interaction,
+    ):
+        await crm_cog.mark_id_verified.callback(
+            crm_cog,
+            mock_interaction,
+            "caleb",
+            verified_by="caleb",
+            verified_at="bogus-date",
+        )
+
+        assert mock_interaction.followup.send.call_args.args[0].startswith("❌ Invalid")
+        crm_cog.espo_api.request.assert_not_called()

--- a/tests/unit/test_crm_mark_id_verified.py
+++ b/tests/unit/test_crm_mark_id_verified.py
@@ -49,6 +49,7 @@ class TestMarkIdVerifiedCommand:
         interaction.user = Mock()
         interaction.user.name = "admin_user"
         interaction.user.id = 123
+        interaction.user.roles = [Mock(name="Admin")]
         return interaction
 
     @pytest.fixture


### PR DESCRIPTION
## Description
- Adds a new admin-only `/mark-id-verified` slash command in the CRM cog to mark contacts as ID verified.
- Supports searching by email, 508 username, or name with interactive selector when matches are ambiguous.
- Resolves `verified_by` from an optional Discord mention or value, and defaults to the invoker using CRM lookup by Discord ID, then Discord username.
- Parses flexible `verified_at` input formats with default to today and writes CRM fields `cIdVerified`, `cIdVerifiedAt`, and `cIdVerifiedBy`.
- Adds unit tests for date parsing, verified-by resolution, selection flow, and CRM payload writes.

## Related Issue
- https://github.com/508-dev/508-workflows/issues/52

## How Has This Been Tested?
- Not run in this branch; validation is covered by added unit tests and existing hook checks (`ruff`, `mypy`) during commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added identity verification workflow for CRM contacts
* Mark contacts as verified with customizable verification dates and verifier attribution
* Presents contact selection interface when multiple matching records are found
* Robust validation for date formats and contact information handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->