### PR TITLE
feat: add Docuseal webhook endpoint for member agreement (#48)

### DIFF
--- a/apps/worker/src/five08/backend/api.py
+++ b/apps/worker/src/five08/backend/api.py
@@ -58,12 +58,17 @@ from five08.worker.jobs import (
     apply_resume_profile_job,
     extract_resume_profile_job,
     process_contact_skills_job,
+    process_docuseal_agreement_job,
     process_webhook_event,
     sync_people_from_crm_job,
     sync_person_from_crm_job,
 )
 from five08.worker.mailbox_resume_ingest import ResumeMailboxProcessor
-from five08.worker.models import AuditEventPayload, EspoCRMWebhookPayload
+from five08.worker.models import (
+    AuditEventPayload,
+    DocusealWebhookPayload,
+    EspoCRMWebhookPayload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -680,6 +685,73 @@ async def espocrm_people_sync_webhook_handler(request: Request) -> JSONResponse:
     )
 
 
+async def docuseal_webhook_handler(request: Request) -> JSONResponse:
+    """Process a Docuseal form.completed webhook and enqueue agreement job."""
+    if not _is_authorized(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    try:
+        payload_data = await request.json()
+    except Exception:
+        return JSONResponse({"error": "invalid_json"}, status_code=400)
+
+    if not isinstance(payload_data, dict):
+        return JSONResponse({"error": "payload_must_be_object"}, status_code=400)
+
+    try:
+        payload = DocusealWebhookPayload.model_validate(payload_data)
+    except (ValidationError, TypeError) as exc:
+        return JSONResponse(
+            {"error": "invalid_payload", "detail": str(exc)},
+            status_code=400,
+        )
+
+    if payload.event_type != "form.completed":
+        return JSONResponse(
+            {
+                "status": "ignored",
+                "reason": f"unhandled event_type: {payload.event_type}",
+            },
+            status_code=200,
+        )
+
+    submitter = payload.data
+    completed_at = submitter.completed_at or payload.timestamp
+    queue = request.app.state.queue
+    try:
+        job: EnqueuedJob = await asyncio.to_thread(
+            enqueue_job,
+            queue=queue,
+            fn=process_docuseal_agreement_job,
+            args=(submitter.email, completed_at, submitter.id),
+            settings=settings,
+            idempotency_key=f"docuseal-agreement:{submitter.id}",
+        )
+    except Exception:
+        logger.exception(
+            "Failed enqueueing Docuseal agreement job email=%s submission_id=%s",
+            submitter.email,
+            submitter.id,
+        )
+        return JSONResponse({"error": "enqueue_failed"}, status_code=503)
+
+    logger.info(
+        "Enqueued Docuseal agreement job job_id=%s email=%s",
+        job.id,
+        submitter.email,
+    )
+    return JSONResponse(
+        {
+            "status": "queued",
+            "source": "docuseal",
+            "job_id": job.id,
+            "email": submitter.email,
+            "submission_id": submitter.id,
+        },
+        status_code=202,
+    )
+
+
 async def audit_event_handler(request: Request) -> JSONResponse:
     """Persist one human audit event."""
     if not _is_authorized(request):
@@ -1226,6 +1298,11 @@ def create_app(*, run_lifespan: bool = True) -> FastAPI:
     app.add_api_route(
         "/webhooks/espocrm/people-sync",
         espocrm_people_sync_webhook_handler,
+        methods=["POST"],
+    )
+    app.add_api_route(
+        "/webhooks/docuseal",
+        docuseal_webhook_handler,
         methods=["POST"],
     )
     app.add_api_route("/webhooks/{source}", ingest_handler, methods=["POST"])

--- a/apps/worker/src/five08/worker/actors.py
+++ b/apps/worker/src/five08/worker/actors.py
@@ -25,6 +25,7 @@ from five08.worker.jobs import (
     apply_resume_profile_job,
     extract_resume_profile_job,
     process_contact_skills_job,
+    process_docuseal_agreement_job,
     process_webhook_event,
     sync_people_from_crm_job,
     sync_person_from_crm_job,
@@ -48,6 +49,7 @@ _HANDLERS: dict[str, Any] = {
     apply_resume_profile_job.__name__: apply_resume_profile_job,
     sync_people_from_crm_job.__name__: sync_people_from_crm_job,
     sync_person_from_crm_job.__name__: sync_person_from_crm_job,
+    process_docuseal_agreement_job.__name__: process_docuseal_agreement_job,
 }
 
 

--- a/apps/worker/src/five08/worker/crm/docuseal_processor.py
+++ b/apps/worker/src/five08/worker/crm/docuseal_processor.py
@@ -1,0 +1,84 @@
+"""Docuseal member agreement processing workflow."""
+
+import logging
+from typing import Any
+
+from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.worker.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class DocusealAgreementProcessor:
+    """Look up a CRM contact by email and mark their member agreement as signed."""
+
+    def __init__(self) -> None:
+        api_url = settings.espo_base_url.rstrip("/") + "/api/v1"
+        self.api = EspoAPI(api_url, settings.espo_api_key)
+
+    def process_agreement(
+        self,
+        email: str,
+        completed_at: str,
+        submission_id: int,
+    ) -> dict[str, Any]:
+        """Search for the signer by email and update cMemberAgreementSignedAt."""
+        try:
+            result = self.api.request(
+                "GET",
+                "Contact",
+                {
+                    "where": [
+                        {
+                            "type": "equals",
+                            "attribute": "emailAddress",
+                            "value": email,
+                        }
+                    ],
+                    "maxSize": 1,
+                    "select": "id,name,emailAddress",
+                },
+            )
+        except EspoAPIError as exc:
+            logger.error("CRM search failed for email=%s: %s", email, exc)
+            return {
+                "success": False,
+                "email": email,
+                "error": f"CRM search failed: {exc}",
+            }
+
+        contacts = result.get("list", [])
+        if not contacts:
+            logger.warning("No CRM contact found for email=%s", email)
+            return {"success": False, "email": email, "error": "contact_not_found"}
+
+        contact = contacts[0]
+        contact_id = contact["id"]
+
+        try:
+            self.api.request(
+                "PUT",
+                f"Contact/{contact_id}",
+                {"cMemberAgreementSignedAt": completed_at},
+            )
+        except EspoAPIError as exc:
+            logger.error("CRM update failed for contact_id=%s: %s", contact_id, exc)
+            return {
+                "success": False,
+                "email": email,
+                "contact_id": contact_id,
+                "error": f"CRM update failed: {exc}",
+            }
+
+        logger.info(
+            "Marked member agreement signed contact_id=%s email=%s",
+            contact_id,
+            email,
+        )
+        return {
+            "success": True,
+            "email": email,
+            "contact_id": contact_id,
+            "submission_id": submission_id,
+            "completed_at": completed_at,
+        }

--- a/apps/worker/src/five08/worker/jobs.py
+++ b/apps/worker/src/five08/worker/jobs.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from five08.worker.crm.docuseal_processor import DocusealAgreementProcessor
 from five08.worker.crm.people_sync import PeopleSyncProcessor
 from five08.worker.crm.processor import ContactSkillsProcessor
 from five08.worker.crm.resume_profile_processor import ResumeProfileProcessor
@@ -66,6 +67,21 @@ def apply_resume_profile_job(
         link_discord=link_discord,
     )
     return result.model_dump()
+
+
+def process_docuseal_agreement_job(
+    email: str,
+    completed_at: str,
+    submission_id: int,
+) -> dict[str, Any]:
+    """Mark a CRM contact as having signed the member agreement via Docuseal."""
+    logger.info(
+        "Processing Docuseal agreement job email=%s submission_id=%s",
+        email,
+        submission_id,
+    )
+    processor = DocusealAgreementProcessor()
+    return processor.process_agreement(email, completed_at, submission_id)
 
 
 def sync_people_from_crm_job() -> dict[str, Any]:

--- a/apps/worker/src/five08/worker/models.py
+++ b/apps/worker/src/five08/worker/models.py
@@ -118,6 +118,25 @@ class ResumeApplyResult(BaseModel):
     error: str | None = None
 
 
+class DocusealSubmitter(BaseModel):
+    """Single submitter entry from a Docuseal webhook payload."""
+
+    id: int
+    email: str
+    status: str
+    completed_at: str | None = None
+    name: str | None = None
+    external_id: str | None = None
+
+
+class DocusealWebhookPayload(BaseModel):
+    """Docuseal form.completed webhook payload."""
+
+    event_type: str
+    timestamp: str
+    data: DocusealSubmitter
+
+
 class AuditEventPayload(BaseModel):
     """Inbound payload for creating a human audit event."""
 

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -576,3 +576,106 @@ def test_auth_logout_writes_logout_audit(client: TestClient) -> None:
     assert audit_payload.action == "auth.logout"
     assert audit_payload.result == api.AuditResult.SUCCESS
     assert audit_payload.actor_subject == "admin@508.dev"
+
+
+# -- Docuseal webhook tests --------------------------------------------------
+
+_DOCUSEAL_PAYLOAD = {
+    "event_type": "form.completed",
+    "timestamp": "2026-02-25T12:00:00Z",
+    "data": {
+        "id": 42,
+        "email": "member@508.dev",
+        "status": "completed",
+        "completed_at": "2026-02-25T12:00:00Z",
+        "name": "Jane Doe",
+    },
+}
+
+
+def test_docuseal_webhook_rejects_unauthorized(client: TestClient) -> None:
+    """Docuseal webhook should reject requests without valid auth."""
+    response = client.post("/webhooks/docuseal", json=_DOCUSEAL_PAYLOAD)
+    assert response.status_code == 401
+    assert response.json()["error"] == "unauthorized"
+
+
+def test_docuseal_webhook_enqueues_agreement_job(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Valid form.completed payload should enqueue agreement job."""
+    with patch("five08.backend.api.enqueue_job") as mock_enqueue:
+        mock_enqueue.return_value = Mock(id="job-ds-1")
+        response = client.post(
+            "/webhooks/docuseal",
+            json=_DOCUSEAL_PAYLOAD,
+            headers=auth_headers,
+        )
+
+    payload = response.json()
+    assert response.status_code == 202
+    assert payload["status"] == "queued"
+    assert payload["source"] == "docuseal"
+    assert payload["job_id"] == "job-ds-1"
+    assert payload["email"] == "member@508.dev"
+    assert payload["submission_id"] == 42
+
+    call_kwargs = mock_enqueue.call_args.kwargs
+    assert call_kwargs["idempotency_key"] == "docuseal-agreement:42"
+
+
+def test_docuseal_webhook_rejects_invalid_payload(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Malformed payload should return 400."""
+    response = client.post(
+        "/webhooks/docuseal",
+        json={"bad": "data"},
+        headers=auth_headers,
+    )
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_payload"
+
+
+def test_docuseal_webhook_ignores_non_completed_event(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Non form.completed events should be acknowledged but ignored."""
+    payload = {
+        "event_type": "form.viewed",
+        "timestamp": "2026-02-25T12:00:00Z",
+        "data": {
+            "id": 42,
+            "email": "member@508.dev",
+            "status": "pending",
+        },
+    }
+    response = client.post(
+        "/webhooks/docuseal",
+        json=payload,
+        headers=auth_headers,
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+
+
+def test_docuseal_webhook_returns_503_on_enqueue_failure(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Enqueue failure should return 503."""
+    with patch(
+        "five08.backend.api.enqueue_job",
+        side_effect=RuntimeError("queue down"),
+    ):
+        response = client.post(
+            "/webhooks/docuseal",
+            json=_DOCUSEAL_PAYLOAD,
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 503
+    assert response.json()["error"] == "enqueue_failed"

--- a/tests/unit/test_worker_models.py
+++ b/tests/unit/test_worker_models.py
@@ -1,6 +1,10 @@
 """Unit tests for worker models."""
 
-from five08.worker.models import AuditEventPayload, EspoCRMWebhookPayload
+from five08.worker.models import (
+    AuditEventPayload,
+    DocusealWebhookPayload,
+    EspoCRMWebhookPayload,
+)
 
 
 def test_espocrm_webhook_payload_from_list() -> None:
@@ -23,3 +27,25 @@ def test_audit_event_payload_defaults_metadata() -> None:
         actor_subject="12345",
     )
     assert payload.metadata == {}
+
+
+def test_docuseal_webhook_payload_parses_completed_event() -> None:
+    """Docuseal payload should parse form.completed event with submitter data."""
+    payload = DocusealWebhookPayload.model_validate(
+        {
+            "event_type": "form.completed",
+            "timestamp": "2026-02-25T12:00:00Z",
+            "data": {
+                "id": 42,
+                "email": "member@508.dev",
+                "status": "completed",
+                "completed_at": "2026-02-25T12:00:00Z",
+                "name": "Jane Doe",
+            },
+        }
+    )
+    assert payload.event_type == "form.completed"
+    assert payload.data.id == 42
+    assert payload.data.email == "member@508.dev"
+    assert payload.data.completed_at == "2026-02-25T12:00:00Z"
+    assert payload.data.name == "Jane Doe"


### PR DESCRIPTION
Add /webhooks/docuseal endpoint that receives Docuseal form.completed events, looks up the signer by email in EspoCRM, and updates the cMemberAgreementSignedAt field on the contact.

NOTE: The CRM field name cMemberAgreementSignedAt is a placeholder following the existing c-prefix convention. The client should confirm the actual field name and adjust in docuseal_processor.py if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Docuseal webhook integration that automatically processes completed form submissions.
  * System now automatically updates customer records in the CRM to mark member agreements as signed upon form completion.

* **Tests**
  * Added comprehensive test coverage for webhook authorization, payload validation, and job handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->