### PR TITLE
feat: add Google Forms member intake webhook (#49)

### DIFF
--- a/apps/worker/src/five08/worker/actors.py
+++ b/apps/worker/src/five08/worker/actors.py
@@ -25,6 +25,7 @@ from five08.worker.jobs import (
     apply_resume_profile_job,
     extract_resume_profile_job,
     process_contact_skills_job,
+    process_intake_form_job,
     process_webhook_event,
     sync_people_from_crm_job,
     sync_person_from_crm_job,
@@ -46,6 +47,7 @@ _HANDLERS: dict[str, Any] = {
     process_contact_skills_job.__name__: process_contact_skills_job,
     extract_resume_profile_job.__name__: extract_resume_profile_job,
     apply_resume_profile_job.__name__: apply_resume_profile_job,
+    process_intake_form_job.__name__: process_intake_form_job,
     sync_people_from_crm_job.__name__: sync_people_from_crm_job,
     sync_person_from_crm_job.__name__: sync_person_from_crm_job,
 }

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -1,0 +1,98 @@
+"""Google Forms member intake processing workflow."""
+
+import logging
+from typing import Any
+
+from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.worker.config import settings
+
+logger = logging.getLogger(__name__)
+
+# NOTE: These CRM field names follow the c-prefix convention observed in the
+# codebase (cDiscordUsername, cGitHubUsername, cLinkedInUrl).  The intake-specific
+# field ``cIntakeCompletedAt`` is a placeholder — the actual field name should be
+# confirmed by the CRM administrator.
+
+
+class IntakeFormProcessor:
+    """Process a Google Forms member intake submission against CRM."""
+
+    def __init__(self) -> None:
+        api_url = settings.espo_base_url.rstrip("/") + "/api/v1"
+        self.api = EspoAPI(api_url, settings.espo_api_key)
+
+    def process_intake(
+        self,
+        *,
+        email: str,
+        first_name: str,
+        last_name: str,
+        phone: str | None = None,
+        discord_username: str | None = None,
+        linkedin_url: str | None = None,
+        github_username: str | None = None,
+        submitted_at: str | None = None,
+    ) -> dict[str, Any]:
+        """Look up CRM contact by email and apply intake form fields."""
+        try:
+            contacts = self.api.request(
+                "GET",
+                "Contact",
+                {
+                    "where[0][type]": "equals",
+                    "where[0][attribute]": "emailAddress",
+                    "where[0][value]": email,
+                    "select": "id,firstName,lastName,emailAddress",
+                },
+            )
+        except EspoAPIError as exc:
+            logger.error("CRM search failed email=%s error=%s", email, exc)
+            return {"success": False, "error": f"CRM search failed: {exc}"}
+
+        contact_list = contacts.get("list", [])
+        if not contact_list:
+            logger.warning("No CRM contact found for email=%s", email)
+            return {"success": False, "error": f"No contact found for {email}"}
+
+        contact = contact_list[0]
+        contact_id: str = contact["id"]
+
+        field_map: dict[str, str] = {
+            "phone": "phoneNumber",
+            "discord_username": "cDiscordUsername",
+            "linkedin_url": settings.crm_linkedin_field,
+            "github_username": "cGitHubUsername",
+        }
+
+        updates: dict[str, Any] = {
+            "firstName": first_name,
+            "lastName": last_name,
+        }
+
+        optional_fields = {
+            "phone": phone,
+            "discord_username": discord_username,
+            "linkedin_url": linkedin_url,
+            "github_username": github_username,
+        }
+        for local_key, value in optional_fields.items():
+            if value:
+                updates[field_map[local_key]] = value
+
+        if submitted_at:
+            updates["cIntakeCompletedAt"] = submitted_at
+
+        try:
+            self.api.request("PUT", f"Contact/{contact_id}", updates)
+        except EspoAPIError as exc:
+            logger.error(
+                "CRM update failed contact_id=%s error=%s", contact_id, exc
+            )
+            return {"success": False, "error": f"CRM update failed: {exc}"}
+
+        logger.info("Intake applied contact_id=%s fields=%s", contact_id, sorted(updates.keys()))
+        return {
+            "success": True,
+            "contact_id": contact_id,
+            "updated_fields": sorted(updates.keys()),
+        }

--- a/apps/worker/src/five08/worker/jobs.py
+++ b/apps/worker/src/five08/worker/jobs.py
@@ -4,6 +4,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Any
 
+from five08.worker.crm.intake_form_processor import IntakeFormProcessor
 from five08.worker.crm.people_sync import PeopleSyncProcessor
 from five08.worker.crm.processor import ContactSkillsProcessor
 from five08.worker.crm.resume_profile_processor import ResumeProfileProcessor
@@ -66,6 +67,31 @@ def apply_resume_profile_job(
         link_discord=link_discord,
     )
     return result.model_dump()
+
+
+def process_intake_form_job(
+    email: str,
+    first_name: str,
+    last_name: str,
+    phone: str | None = None,
+    discord_username: str | None = None,
+    linkedin_url: str | None = None,
+    github_username: str | None = None,
+    submitted_at: str | None = None,
+) -> dict[str, Any]:
+    """Process a Google Forms member intake submission against CRM."""
+    logger.info("Processing intake form job email=%s", email)
+    processor = IntakeFormProcessor()
+    return processor.process_intake(
+        email=email,
+        first_name=first_name,
+        last_name=last_name,
+        phone=phone,
+        discord_username=discord_username,
+        linkedin_url=linkedin_url,
+        github_username=github_username,
+        submitted_at=submitted_at,
+    )
 
 
 def sync_people_from_crm_job() -> dict[str, Any]:

--- a/apps/worker/src/five08/worker/models.py
+++ b/apps/worker/src/five08/worker/models.py
@@ -118,6 +118,20 @@ class ResumeApplyResult(BaseModel):
     error: str | None = None
 
 
+class GoogleFormsIntakePayload(BaseModel):
+    """Google Forms member intake webhook payload (sent via Apps Script)."""
+
+    email: str
+    first_name: str
+    last_name: str
+    phone: str | None = None
+    discord_username: str | None = None
+    linkedin_url: str | None = None
+    github_username: str | None = None
+    submission_id: str | None = None
+    submitted_at: str | None = None
+
+
 class AuditEventPayload(BaseModel):
     """Inbound payload for creating a human audit event."""
 

--- a/tests/unit/test_worker_models.py
+++ b/tests/unit/test_worker_models.py
@@ -1,6 +1,10 @@
 """Unit tests for worker models."""
 
-from five08.worker.models import AuditEventPayload, EspoCRMWebhookPayload
+from five08.worker.models import (
+    AuditEventPayload,
+    EspoCRMWebhookPayload,
+    GoogleFormsIntakePayload,
+)
 
 
 def test_espocrm_webhook_payload_from_list() -> None:
@@ -23,3 +27,22 @@ def test_audit_event_payload_defaults_metadata() -> None:
         actor_subject="12345",
     )
     assert payload.metadata == {}
+
+
+def test_google_forms_intake_payload_parses_submission() -> None:
+    """Intake payload should parse all fields with correct defaults."""
+    payload = GoogleFormsIntakePayload.model_validate(
+        {
+            "email": "new@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "phone": "+15551234567",
+            "discord_username": "janedoe",
+        }
+    )
+    assert payload.email == "new@example.com"
+    assert payload.first_name == "Jane"
+    assert payload.last_name == "Doe"
+    assert payload.phone == "+15551234567"
+    assert payload.linkedin_url is None
+    assert payload.submission_id is None


### PR DESCRIPTION
- POST /webhooks/google-forms endpoint with X-API-Secret auth
- GoogleFormsIntakePayload Pydantic model for form submission data
- IntakeFormProcessor to look up CRM contact by email and update profile
- process_intake_form_job registered in actors handler map
- 5 tests (4 endpoint + 1 model)

NOTE: cIntakeCompletedAt is a placeholder CRM field name — confirm with CRM administrator. Payload shape assumes Apps Script sends normalized JSON; adjust fields once actual form is configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Forms intake webhook endpoint to process member intake submissions and automatically update CRM records with submitted information including email, name, and contact details.

* **Tests**
  * Added comprehensive test coverage for the new webhook, including authentication checks, payload validation, error handling, and job queueing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->