### PR TITLE
feat: add job rerun endpoint and jobsctl CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,8 @@ Migrations:
 
 ### Backend API Endpoints
 
-- `GET /health`: Redis/Postgres/worker health check.
-- `GET /jobs/{job_id}`: Fetch queued job status/result payload.
-- `POST /jobs/resume-extract`: Enqueue resume profile extraction.
-- `POST /jobs/resume-apply`: Enqueue confirmed CRM field apply.
-- `POST /webhooks/{source}`: Generic webhook enqueue endpoint.
-- `POST /webhooks/espocrm`: EspoCRM webhook endpoint (expects array payload).
-- `POST /webhooks/espocrm/people-sync`: EspoCRM contact-change webhook for people cache sync.
-- `POST /webhooks/docuseal`: See worker webhook contract docs in
-  [`apps/worker/README.md`](apps/worker/README.md#webhooks).
-- `POST /process-contact/{contact_id}`: Manually enqueue one contact skills job.
-- `POST /sync/people`: Manually enqueue a full CRM->people cache sync.
-- `POST /audit/events`: Persist one human audit event (`discord` or `admin_dashboard`).
-- `GET /auth/login`: Start OIDC Auth Code + PKCE login flow.
-- `GET /auth/callback`: Complete OIDC callback and set HttpOnly session cookie.
-- `GET /auth/me`: Return active session identity.
-- `POST /auth/logout`: Clear active session cookie + server session.
-- `POST /auth/discord/links`: Create one-time dashboard deep link from Discord command context.
-- `GET /auth/discord/link/{token}`: Resolve Discord deep link into authenticated dashboard redirect.
-- Auth flows emit best-effort human audit events (`auth.login`, `auth.logout`) under source `admin_dashboard`.
+See the worker service docs: [`apps/worker/README.md#backend-api-endpoints`](apps/worker/README.md#backend-api-endpoints).
+CLI request examples are documented at [`apps/worker/README.md#cli-usage`](apps/worker/README.md#cli-usage).
 
 ## Local Development
 
@@ -94,6 +77,9 @@ uv run --package integrations-worker backend-api
 
 # Worker queue consumer
 uv run --package integrations-worker worker-consumer
+
+# Jobs CLI
+uv run --package integrations-worker jobsctl --help
 ```
 
 Or run the full stack with Docker Compose:

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -1,5 +1,173 @@
 # Worker Service
 
+## Auth
+
+- Protected ingest/job endpoints require `API_SHARED_SECRET` to be configured on the worker.
+- Send the secret in header `X-API-Secret`.
+- Header name is exactly `X-API-Secret` (not `X-API-Secret-Key`).
+- `GET /health` and most OIDC session routes (`/auth/login`, `/auth/callback`, `/auth/me`, `/auth/logout`) do not use `X-API-Secret`.
+- `POST /auth/discord/links` does use `X-API-Secret` because it is called by trusted backend/bot components.
+
+Example:
+
+```bash
+curl -X GET "http://localhost:8090/jobs/<job_id>" \
+  -H "X-API-Secret: $API_SHARED_SECRET"
+```
+
+## CLI Usage
+
+You can use the dedicated `jobsctl` command for common job operations.
+
+Defaults:
+
+- Base URL: `http://localhost:8090` (or `$WORKER_API_BASE_URL`)
+- API secret: `$API_SHARED_SECRET` (sent as `X-API-Secret`)
+- Timeout: fixed at `10.0` seconds (not configurable)
+
+Usage:
+
+```bash
+uv run --package integrations-worker jobsctl --help
+uv run --package integrations-worker jobsctl status <job_id>
+uv run --package integrations-worker jobsctl rerun <job_id>
+```
+
+Examples:
+
+```bash
+uv run --package integrations-worker jobsctl status job-123
+```
+
+```bash
+uv run --package integrations-worker jobsctl rerun job-123
+```
+
+If needed, pass overrides explicitly:
+
+```bash
+uv run --package integrations-worker jobsctl \
+  --api-url http://localhost:8090 \
+  --secret "$API_SHARED_SECRET" \
+  rerun job-123
+```
+
+You can still use `curl` directly:
+
+- Get job status:
+
+```bash
+curl -X GET "http://localhost:8090/jobs/<job_id>" \
+  -H "X-API-Secret: $API_SHARED_SECRET"
+```
+
+- Rerun a job:
+
+```bash
+curl -X POST "http://localhost:8090/jobs/<job_id>/rerun" \
+  -H "X-API-Secret: $API_SHARED_SECRET"
+```
+
+## Backend API Endpoints
+
+- `GET /health`: Redis/Postgres/worker health check.
+- `GET /jobs/{job_id}`: Fetch queued job status/result payload.
+- `POST /jobs/{job_id}/rerun`: Enqueue a duplicate rerun of an existing job id.
+- `POST /jobs/resume-extract`: Enqueue resume profile extraction.
+- `POST /jobs/resume-apply`: Enqueue confirmed CRM field apply.
+- `POST /webhooks/{source}`: Generic webhook enqueue endpoint.
+- `POST /webhooks/espocrm`: EspoCRM webhook endpoint (expects array payload).
+- `POST /webhooks/espocrm/people-sync`: EspoCRM contact-change webhook for people cache sync.
+- `POST /webhooks/docuseal`: Docuseal agreement webhook endpoint.
+- `POST /process-contact/{contact_id}`: Manually enqueue one contact skills job.
+- `POST /sync/people`: Manually enqueue a full CRM->people cache sync.
+- `POST /audit/events`: Persist one human audit event (`discord` or `admin_dashboard`).
+- `GET /auth/login`: Start OIDC Auth Code + PKCE login flow.
+- `GET /auth/callback`: Complete OIDC callback and set HttpOnly session cookie.
+- `GET /auth/me`: Return active session identity.
+- `POST /auth/logout`: Clear active session cookie + server session.
+- `POST /auth/discord/links`: Create one-time dashboard deep link from Discord command context.
+- `GET /auth/discord/link/{token}`: Resolve Discord deep link into authenticated dashboard redirect.
+- Auth flows emit best-effort human audit events (`auth.login`, `auth.logout`) under source `admin_dashboard`.
+
+## Jobs
+
+### `GET /jobs/{job_id}`
+
+Returns persisted job status and the latest result payload.
+
+- Path params:
+  - `job_id` (string): persisted job id.
+
+### `POST /jobs/{job_id}/rerun`
+
+Creates and enqueues a new duplicate job from the source job's original `args`/`kwargs`.
+
+- The source job is not mutated.
+- A new job row is persisted with a new `job_id`.
+- Rerun idempotency key format: `manual-rerun:{source_job_id}:{ULID}`.
+
+Example:
+
+```bash
+curl -X POST "http://localhost:8090/jobs/<job_id>/rerun" \
+  -H "X-API-Secret: $API_SHARED_SECRET"
+```
+
+Example success response (`202`):
+
+```json
+{
+  "status": "queued",
+  "source_job_id": "job-old-1",
+  "job_id": "job-new-1",
+  "type": "process_docuseal_agreement_job",
+  "created": true
+}
+```
+
+### `POST /jobs/resume-extract`
+
+Enqueues one resume extraction job.
+
+- JSON body:
+  - `contact_id` (string, required)
+  - `attachment_id` (string, required)
+  - `filename` (string, required)
+
+Example:
+
+```bash
+curl -X POST "http://localhost:8090/jobs/resume-extract" \
+  -H "X-API-Secret: $API_SHARED_SECRET" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contact_id": "contact-123",
+    "attachment_id": "att-456",
+    "filename": "resume.pdf"
+  }'
+```
+
+### `POST /jobs/resume-apply`
+
+Enqueues one CRM apply job after resume update confirmation.
+
+- JSON body:
+  - `contact_id` (string, required)
+  - `updates` (object[string->string], required): CRM field updates.
+  - `link_discord` (object, optional): `{ "user_id": "...", "username": "..." }`
+
+### `POST /process-contact/{contact_id}`
+
+Manually enqueues one contact skills job.
+
+- Path params:
+  - `contact_id` (string, required)
+
+### `POST /sync/people`
+
+Manually enqueues a full CRM -> people cache sync.
+
 ## Webhooks
 
 ### `POST /webhooks/docuseal`
@@ -8,15 +176,31 @@ Enqueues DocuSeal agreement-signing jobs.
 
 - Job input contract for queueing: `completed_at` is a UTC string using `YYYY-MM-DD HH:mm:ss`.
 - Example value: `2026-03-02 10:02:30`.
+- Required payload fields:
+  - `event_type` must be `form.completed`
+  - `data.email` non-empty signer email
+  - `data.completed_at` or top-level `timestamp` (ISO timestamp string)
+  - `data.template.id` must match configured `DOCUSEAL_MEMBER_AGREEMENT_TEMPLATE_ID`
 
 ### `POST /webhooks/{source}`
 
 Generic webhook enqueue endpoint.
 
+- Path params:
+  - `source` (string, required): source label written into job payload.
+- JSON body:
+  - Any JSON object payload.
+
 ### `POST /webhooks/espocrm`
 
 EspoCRM webhook endpoint (expects array payload).
 
+- JSON body:
+  - Array of event objects, each with at least `id` (string).
+
 ### `POST /webhooks/espocrm/people-sync`
 
 EspoCRM contact-change webhook for people cache sync.
+
+- JSON body:
+  - Array of event objects, each with at least `id` (string).

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -28,6 +28,7 @@ five08 = { workspace = true }
 [project.scripts]
 backend-api = "five08.backend.api:run"
 worker-consumer = "five08.worker.consumer:run"
+jobsctl = "five08.jobcli:run"
 
 [tool.alembic]
 script_location = "src/five08/worker/migrations"

--- a/apps/worker/src/five08/backend/api.py
+++ b/apps/worker/src/five08/backend/api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import os
 import secrets
 import time
 from contextlib import asynccontextmanager
@@ -72,6 +73,7 @@ from five08.worker.models import (
 )
 
 logger = logging.getLogger(__name__)
+_ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 
 
 class ResumeExtractRequest(BaseModel):
@@ -97,6 +99,17 @@ class DiscordLinkCreateRequest(BaseModel):
     next_path: str | None = None
 
 
+_JOB_FUNCTIONS: dict[str, Any] = {
+    process_webhook_event.__name__: process_webhook_event,
+    process_contact_skills_job.__name__: process_contact_skills_job,
+    extract_resume_profile_job.__name__: extract_resume_profile_job,
+    apply_resume_profile_job.__name__: apply_resume_profile_job,
+    sync_people_from_crm_job.__name__: sync_people_from_crm_job,
+    sync_person_from_crm_job.__name__: sync_person_from_crm_job,
+    process_docuseal_agreement_job.__name__: process_docuseal_agreement_job,
+}
+
+
 def _is_authorized(request: Request) -> bool:
     """Validate shared API secret."""
     if not settings.api_shared_secret:
@@ -110,6 +123,21 @@ def _is_authorized(request: Request) -> bool:
         return True
 
     return False
+
+
+def _encode_ulid_base32(value: int, length: int) -> str:
+    encoded = ["0"] * length
+    for index in range(length - 1, -1, -1):
+        encoded[index] = _ULID_ALPHABET[value & 0x1F]
+        value >>= 5
+    return "".join(encoded)
+
+
+def _generate_ulid() -> str:
+    """Generate a sortable ULID string without external dependencies."""
+    timestamp_ms = int(time.time() * 1000)
+    random_value = int.from_bytes(os.urandom(10), "big")
+    return f"{_encode_ulid_base32(timestamp_ms, 10)}{_encode_ulid_base32(random_value, 16)}"
 
 
 def _extract_idempotency_key(value: object) -> str | None:
@@ -629,6 +657,69 @@ async def job_status_handler(request: Request, job_id: str) -> JSONResponse:
             "last_error": job.last_error,
             "result": result,
         }
+    )
+
+
+async def rerun_job_handler(request: Request, job_id: str) -> JSONResponse:
+    """Create and enqueue a new job using a prior job's original call payload."""
+    if not _is_authorized(request):
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    normalized_job_id = job_id.strip()
+    if not normalized_job_id:
+        return JSONResponse({"error": "job_id_required"}, status_code=400)
+
+    source_job = await asyncio.to_thread(get_job, settings, normalized_job_id)
+    if source_job is None:
+        return JSONResponse({"error": "job_not_found"}, status_code=404)
+
+    fn = _JOB_FUNCTIONS.get(source_job.type)
+    if fn is None:
+        return JSONResponse(
+            {
+                "error": "unsupported_job_type",
+                "job_type": source_job.type,
+            },
+            status_code=400,
+        )
+
+    raw_payload = source_job.payload if isinstance(source_job.payload, dict) else {}
+    raw_args = raw_payload.get("args", [])
+    raw_kwargs = raw_payload.get("kwargs", {})
+    if not isinstance(raw_args, list) or not isinstance(raw_kwargs, dict):
+        return JSONResponse({"error": "invalid_job_payload"}, status_code=400)
+
+    queue = request.app.state.queue
+    rerun_idempotency_key = f"manual-rerun:{source_job.id}:{_generate_ulid()}"
+
+    try:
+        rerun_job: EnqueuedJob = await asyncio.to_thread(
+            enqueue_job,
+            queue=queue,
+            fn=fn,
+            args=tuple(raw_args),
+            kwargs=raw_kwargs,
+            settings=settings,
+            idempotency_key=rerun_idempotency_key,
+            max_attempts=source_job.max_attempts,
+        )
+    except Exception:
+        logger.exception(
+            "Failed rerunning job source_job_id=%s type=%s",
+            source_job.id,
+            source_job.type,
+        )
+        return JSONResponse({"error": "enqueue_failed"}, status_code=503)
+
+    return JSONResponse(
+        {
+            "status": "queued",
+            "source_job_id": source_job.id,
+            "job_id": rerun_job.id,
+            "type": source_job.type,
+            "created": rerun_job.created,
+        },
+        status_code=202,
     )
 
 
@@ -1360,6 +1451,7 @@ def create_app(*, run_lifespan: bool = True) -> FastAPI:
     app.add_api_route("/health", health_handler, methods=["GET"])
 
     app.add_api_route("/jobs/{job_id}", job_status_handler, methods=["GET"])
+    app.add_api_route("/jobs/{job_id}/rerun", rerun_job_handler, methods=["POST"])
     app.add_api_route("/jobs/resume-extract", resume_extract_handler, methods=["POST"])
     app.add_api_route("/jobs/resume-apply", resume_apply_handler, methods=["POST"])
 

--- a/apps/worker/src/five08/jobcli.py
+++ b/apps/worker/src/five08/jobcli.py
@@ -1,0 +1,167 @@
+"""Command-line helpers for worker job inspection and reruns."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Any
+
+import httpx
+
+DEFAULT_API_URL = "http://localhost:8090"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+API_SECRET_ENV_VAR = "API_SHARED_SECRET"
+
+
+def _default_api_url() -> str:
+    """Return default backend API URL, preferring explicit environment overrides."""
+    return os.getenv("WORKER_API_BASE_URL", DEFAULT_API_URL)
+
+
+def _default_api_secret() -> str | None:
+    """Return API secret from environment when available."""
+    return os.getenv(API_SECRET_ENV_VAR)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct top-level CLI parser for job operations."""
+    parser = argparse.ArgumentParser(
+        prog="jobsctl",
+        description="Jobs utility for querying status and rerunning worker jobs.",
+    )
+    parser.add_argument(
+        "--api-url",
+        default=_default_api_url(),
+        help=f"Backend API base URL (default: {_default_api_url()}).",
+    )
+    parser.add_argument(
+        "--secret",
+        default=_default_api_secret(),
+        help=f"API secret for X-API-Secret header (default: ${API_SECRET_ENV_VAR}).",
+    )
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    status_parser = subparsers.add_parser(
+        "status",
+        help="Fetch job status and result payload.",
+    )
+    status_parser.add_argument("job_id", help="Existing job id.")
+    status_parser.set_defaults(handler=_handle_status)
+
+    rerun_parser = subparsers.add_parser(
+        "rerun",
+        help="Create a duplicate rerun job from an existing job id.",
+    )
+    rerun_parser.add_argument("job_id", help="Existing job id to duplicate.")
+    rerun_parser.set_defaults(handler=_handle_rerun)
+
+    return parser
+
+
+def _build_headers(secret: str | None) -> dict[str, str]:
+    """Build headers with required API auth header."""
+    if not secret:
+        raise ValueError("Missing API secret (use --secret or set API_SHARED_SECRET).")
+
+    return {"X-API-Secret": secret}
+
+
+def _parse_response(response: httpx.Response) -> dict[str, Any]:
+    """Parse response JSON payload or raise a clear HTTP error."""
+    try:
+        payload = response.json()
+    except ValueError:
+        raise ValueError(
+            f"API response was not JSON (status={response.status_code}): {response.text}"
+        )
+
+    if response.is_success:
+        return payload
+
+    message = payload.get("error") if isinstance(payload, dict) else None
+    if isinstance(message, str) and message:
+        raise ValueError(f"API error {response.status_code}: {message}")
+    raise ValueError(f"API error {response.status_code}: {response.text}")
+
+
+def _request_json(
+    *,
+    method: str,
+    api_url: str,
+    path: str,
+    secret: str | None,
+    payload: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Execute a JSON request against the backend API."""
+    headers = _build_headers(secret)
+    url = f"{api_url.rstrip('/')}/{path.lstrip('/')}"
+    if payload is not None:
+        try:
+            response = httpx.request(
+                method=method,
+                url=url,
+                headers=headers,
+                json=payload,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"Failed to contact API: {exc}") from exc
+    else:
+        try:
+            response = httpx.request(
+                method=method,
+                url=url,
+                headers=headers,
+                timeout=DEFAULT_TIMEOUT_SECONDS,
+            )
+        except httpx.RequestError as exc:
+            raise RuntimeError(f"Failed to contact API: {exc}") from exc
+    return _parse_response(response)
+
+
+def _handle_status(args: argparse.Namespace) -> int:
+    """Handle jobsctl status <job_id>."""
+    try:
+        payload = _request_json(
+            method="GET",
+            api_url=args.api_url,
+            path=f"/jobs/{args.job_id}",
+            secret=args.secret,
+        )
+    except Exception as exc:  # broad catch keeps UX predictable
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def _handle_rerun(args: argparse.Namespace) -> int:
+    """Handle jobsctl rerun <job_id>."""
+    try:
+        payload = _request_json(
+            method="POST",
+            api_url=args.api_url,
+            path=f"/jobs/{args.job_id}/rerun",
+            secret=args.secret,
+        )
+    except Exception as exc:  # broad catch keeps UX predictable
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Run CLI and return process exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return int(args.handler(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(run())

--- a/apps/worker/src/five08/worker/actors.py
+++ b/apps/worker/src/five08/worker/actors.py
@@ -21,6 +21,7 @@ from five08.queue import (
 )
 from five08.queue import parse_queue_names
 from five08.worker.config import settings
+from five08.worker.crm.docuseal_processor import DocusealAgreementNonRetryableError
 from five08.worker.jobs import (
     apply_resume_profile_job,
     extract_resume_profile_job,
@@ -118,6 +119,21 @@ def _run_job(job_id: str) -> None:
             base_payload=job.payload,
         )
         logger.info("Completed job_id=%s type=%s", job_id, job.type)
+    except DocusealAgreementNonRetryableError as exc:
+        next_attempt = job.attempts + 1
+        error = f"{type(exc).__name__}: {exc}"
+        logger.error(
+            "Job failed non-retryable id=%s attempt=%s error=%s",
+            job_id,
+            next_attempt,
+            error,
+        )
+        mark_job_dead(
+            settings,
+            job_id,
+            attempts=next_attempt,
+            last_error=error,
+        )
     except Exception as exc:
         next_attempt = job.attempts + 1
         error = f"{type(exc).__name__}: {exc}"

--- a/apps/worker/src/five08/worker/crm/docuseal_processor.py
+++ b/apps/worker/src/five08/worker/crm/docuseal_processor.py
@@ -11,6 +11,14 @@ from five08.worker.masking import mask_email
 logger = logging.getLogger(__name__)
 
 
+class DocusealAgreementProcessingError(RuntimeError):
+    """Raised when Docuseal processing hits a retryable execution error."""
+
+
+class DocusealAgreementNonRetryableError(RuntimeError):
+    """Raised when Docuseal processing fails with non-retryable input/state."""
+
+
 class DocusealAgreementProcessor:
     """Look up a CRM contact by email and mark their member agreement as signed."""
 
@@ -59,11 +67,9 @@ class DocusealAgreementProcessor:
             )
         except EspoAPIError as exc:
             logger.error("CRM search failed for masked_email=%s: %s", masked_email, exc)
-            return {
-                "success": False,
-                "masked_email": masked_email,
-                "error": f"CRM search failed: {exc}",
-            }
+            raise DocusealAgreementProcessingError(
+                f"CRM search failed for masked_email={masked_email}: {exc}"
+            ) from exc
 
         contacts = result.get("list", [])
         if not contacts:
@@ -90,13 +96,9 @@ class DocusealAgreementProcessor:
                 completed_at,
                 exc,
             )
-            return {
-                "success": False,
-                "masked_email": masked_email,
-                "submission_id": submission_id,
-                "contact_id": contact_id,
-                "error": f"invalid_completed_at: {exc}",
-            }
+            raise DocusealAgreementNonRetryableError(
+                f"invalid_completed_at for contact_id={contact_id}: {exc}"
+            ) from exc
 
         try:
             self.api.request(
@@ -108,13 +110,9 @@ class DocusealAgreementProcessor:
             )
         except EspoAPIError as exc:
             logger.error("CRM update failed for contact_id=%s: %s", contact_id, exc)
-            return {
-                "success": False,
-                "masked_email": masked_email,
-                "submission_id": submission_id,
-                "contact_id": contact_id,
-                "error": f"CRM update failed: {exc}",
-            }
+            raise DocusealAgreementProcessingError(
+                f"CRM update failed for contact_id={contact_id}: {exc}"
+            ) from exc
 
         logger.info(
             "Marked member agreement signed contact_id=%s masked_email=%s",

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -1,5 +1,6 @@
 """Unit tests for backend dashboard/ingest API."""
 
+import re
 import pytest
 from fastapi.testclient import TestClient
 from unittest.mock import AsyncMock, Mock, patch
@@ -258,6 +259,126 @@ def test_job_status_handler_returns_result(
     assert payload["job_id"] == "job-123"
     assert payload["status"] == "succeeded"
     assert payload["result"] == {"success": True}
+
+
+def test_rerun_job_handler_enqueues_new_job(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Rerun endpoint should enqueue a fresh job from existing call payload."""
+    source_job = Mock(
+        id="job-old-1",
+        type="process_docuseal_agreement_job",
+        max_attempts=8,
+        payload={
+            "args": ["member@508.dev", "2026-02-25 12:00:00", 55],
+            "kwargs": {},
+            "result": {"success": False},
+        },
+    )
+
+    with (
+        patch("five08.backend.api.get_job", return_value=source_job),
+        patch("five08.backend.api.enqueue_job") as mock_enqueue,
+    ):
+        mock_enqueue.return_value = Mock(id="job-new-1", created=True)
+        response = client.post("/jobs/job-old-1/rerun", headers=auth_headers)
+
+    payload = response.json()
+    assert response.status_code == 202
+    assert payload["status"] == "queued"
+    assert payload["source_job_id"] == "job-old-1"
+    assert payload["job_id"] == "job-new-1"
+    assert payload["type"] == "process_docuseal_agreement_job"
+    assert payload["created"] is True
+
+    call_kwargs = mock_enqueue.call_args.kwargs
+    assert call_kwargs["fn"] is api.process_docuseal_agreement_job
+    assert call_kwargs["args"] == (
+        "member@508.dev",
+        "2026-02-25 12:00:00",
+        55,
+    )
+    assert call_kwargs["kwargs"] == {}
+    assert call_kwargs["max_attempts"] == 8
+    prefix = "manual-rerun:job-old-1:"
+    assert call_kwargs["idempotency_key"].startswith(prefix)
+    suffix = call_kwargs["idempotency_key"][len(prefix) :]
+    assert re.fullmatch(r"[0-9A-HJKMNP-TV-Z]{26}", suffix)
+
+
+def test_rerun_job_handler_returns_not_found(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Rerun endpoint should 404 when source job does not exist."""
+    with patch("five08.backend.api.get_job", return_value=None):
+        response = client.post("/jobs/missing/rerun", headers=auth_headers)
+
+    payload = response.json()
+    assert response.status_code == 404
+    assert payload["error"] == "job_not_found"
+
+
+def test_rerun_job_handler_rejects_unknown_job_type(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Rerun endpoint should reject unknown persisted job types."""
+    source_job = Mock(
+        id="job-old-2",
+        type="some_unknown_type",
+        max_attempts=8,
+        payload={"args": [], "kwargs": {}},
+    )
+    with patch("five08.backend.api.get_job", return_value=source_job):
+        response = client.post("/jobs/job-old-2/rerun", headers=auth_headers)
+
+    payload = response.json()
+    assert response.status_code == 400
+    assert payload["error"] == "unsupported_job_type"
+    assert payload["job_type"] == "some_unknown_type"
+
+
+def test_rerun_job_handler_rejects_invalid_payload_shape(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Rerun endpoint should reject source jobs with malformed call payload."""
+    source_job = Mock(
+        id="job-old-3",
+        type="sync_people_from_crm_job",
+        max_attempts=8,
+        payload={"args": "not-a-list", "kwargs": {}},
+    )
+    with patch("five08.backend.api.get_job", return_value=source_job):
+        response = client.post("/jobs/job-old-3/rerun", headers=auth_headers)
+
+    payload = response.json()
+    assert response.status_code == 400
+    assert payload["error"] == "invalid_job_payload"
+
+
+def test_rerun_job_handler_returns_503_on_enqueue_failure(
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Rerun endpoint should fail with 503 when enqueueing fails."""
+    source_job = Mock(
+        id="job-old-4",
+        type="sync_people_from_crm_job",
+        max_attempts=8,
+        payload={"args": [], "kwargs": {}},
+    )
+    with (
+        patch("five08.backend.api.get_job", return_value=source_job),
+        patch("five08.backend.api.enqueue_job", side_effect=RuntimeError("boom")),
+    ):
+        response = client.post("/jobs/job-old-4/rerun", headers=auth_headers)
+
+    payload = response.json()
+    assert response.status_code == 503
+    assert payload["error"] == "enqueue_failed"
 
 
 def test_resume_extract_model_name_uses_heuristic_without_api_key(

--- a/tests/unit/test_docuseal_processor.py
+++ b/tests/unit/test_docuseal_processor.py
@@ -1,9 +1,14 @@
 """Unit tests for Docuseal processor logic."""
 
+import pytest
 from unittest.mock import Mock, patch
 
 from five08.clients.espo import EspoAPIError
-from five08.worker.crm.docuseal_processor import DocusealAgreementProcessor
+from five08.worker.crm.docuseal_processor import (
+    DocusealAgreementNonRetryableError,
+    DocusealAgreementProcessingError,
+    DocusealAgreementProcessor,
+)
 from five08.worker.masking import mask_email
 
 
@@ -60,8 +65,8 @@ def test_docuseal_processor_normalizes_completed_at_to_utc_timestamp() -> None:
     assert result["completed_at"] == "2026-03-02 08:02:30"
 
 
-def test_docuseal_processor_returns_error_on_invalid_completed_at() -> None:
-    """Processor should return explicit invalid datetime errors instead of crashing."""
+def test_docuseal_processor_raises_on_invalid_completed_at() -> None:
+    """Processor should raise so the job runner can mark the job non-retryable/dead."""
     mock_api = Mock()
     mock_api.request.side_effect = [
         {"list": [{"id": "contact-1"}]},
@@ -69,14 +74,14 @@ def test_docuseal_processor_returns_error_on_invalid_completed_at() -> None:
 
     with patch("five08.worker.crm.docuseal_processor.EspoAPI", return_value=mock_api):
         processor = DocusealAgreementProcessor()
-        result = processor.process_agreement(
-            email="member@508.dev",
-            completed_at="not-a-date",
-            submission_id=416,
-        )
+        with pytest.raises(DocusealAgreementNonRetryableError) as exc_info:
+            processor.process_agreement(
+                email="member@508.dev",
+                completed_at="not-a-date",
+                submission_id=416,
+            )
 
-    assert result["success"] is False
-    assert "invalid_completed_at" in result["error"]
+    assert "invalid_completed_at for contact_id=contact-1" in str(exc_info.value)
     assert mock_api.request.call_count == 1
 
 
@@ -100,20 +105,45 @@ def test_docuseal_processor_returns_contact_not_found_when_missing_contact() -> 
     assert mock_api.request.call_count == 1
 
 
-def test_docuseal_processor_returns_error_on_search_failure() -> None:
-    """Processor should return failure payload when CRM search request fails."""
+def test_docuseal_processor_raises_on_search_failure() -> None:
+    """Processor should raise when CRM search fails to trigger job retries."""
     mock_api = Mock()
     mock_api.request.side_effect = EspoAPIError("CRM unavailable")
 
     with patch("five08.worker.crm.docuseal_processor.EspoAPI", return_value=mock_api):
         processor = DocusealAgreementProcessor()
-        result = processor.process_agreement(
-            email="broken@508.dev",
-            completed_at="2026-02-25T12:00:00Z",
-            submission_id=55,
-        )
+        with pytest.raises(DocusealAgreementProcessingError) as exc_info:
+            processor.process_agreement(
+                email="broken@508.dev",
+                completed_at="2026-02-25T12:00:00Z",
+                submission_id=55,
+            )
 
-    assert result["success"] is False
-    assert result["error"] == "CRM search failed: CRM unavailable"
-    assert result["masked_email"] == mask_email("broken@508.dev")
-    assert result["masked_email"] != "broken@508.dev"
+    assert (
+        str(exc_info.value)
+        == f"CRM search failed for masked_email={mask_email('broken@508.dev')}: "
+        "CRM unavailable"
+    )
+
+
+def test_docuseal_processor_raises_on_update_failure() -> None:
+    """Processor should raise when CRM update fails to trigger job retries."""
+    mock_api = Mock()
+    mock_api.request.side_effect = [
+        {"list": [{"id": "contact-1"}]},
+        EspoAPIError("write failed"),
+    ]
+
+    with patch("five08.worker.crm.docuseal_processor.EspoAPI", return_value=mock_api):
+        processor = DocusealAgreementProcessor()
+        with pytest.raises(DocusealAgreementProcessingError) as exc_info:
+            processor.process_agreement(
+                email="member@508.dev",
+                completed_at="2026-02-25T12:00:00Z",
+                submission_id=9001,
+            )
+
+    assert (
+        str(exc_info.value)
+        == "CRM update failed for contact_id=contact-1: write failed"
+    )

--- a/tests/unit/test_jobcli.py
+++ b/tests/unit/test_jobcli.py
@@ -1,0 +1,115 @@
+"""Unit tests for jobsctl CLI."""
+
+import json
+
+from unittest.mock import patch
+
+from five08 import jobcli
+import httpx
+import pytest
+
+
+def _json_response(
+    *,
+    status_code: int,
+    payload: dict[str, object],
+    method: str,
+    url: str,
+) -> httpx.Response:
+    request = httpx.Request(method=method, url=url)
+    return httpx.Response(
+        status_code=status_code,
+        content=json.dumps(payload),
+        headers={"Content-Type": "application/json"},
+        request=request,
+    )
+
+
+def test_jobsctl_status_calls_jobs_endpoint() -> None:
+    with patch("five08.jobcli.httpx.request") as mock_request:
+        mock_request.return_value = _json_response(
+            status_code=200,
+            payload={"status": "succeeded", "job_id": "job-123"},
+            method="GET",
+            url="http://localhost:8090/jobs/job-123",
+        )
+
+        exit_code = jobcli.run(["--secret", "test-secret", "status", "job-123"])
+
+    assert exit_code == 0
+    mock_request.assert_called_once()
+    called = mock_request.call_args.kwargs
+    assert called["method"] == "GET"
+    assert called["url"] == "http://localhost:8090/jobs/job-123"
+    assert called["headers"] == {"X-API-Secret": "test-secret"}
+
+
+def test_jobsctl_rerun_calls_rerun_endpoint() -> None:
+    with patch("five08.jobcli.httpx.request") as mock_request:
+        mock_request.return_value = _json_response(
+            status_code=200,
+            payload={
+                "job_id": "job-new",
+                "source_job_id": "job-old",
+                "status": "queued",
+            },
+            method="POST",
+            url="http://localhost:8090/jobs/job-old/rerun",
+        )
+
+        exit_code = jobcli.run(["--secret", "test-secret", "rerun", "job-old"])
+
+    assert exit_code == 0
+    called = mock_request.call_args.kwargs
+    assert called["method"] == "POST"
+    assert called["url"] == "http://localhost:8090/jobs/job-old/rerun"
+
+
+def test_jobsctl_rerun_uses_default_secret_from_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("API_SHARED_SECRET", "from-env")
+    with patch("five08.jobcli.httpx.request") as mock_request:
+        mock_request.return_value = _json_response(
+            status_code=200,
+            payload={
+                "job_id": "job-new",
+                "source_job_id": "job-old",
+                "status": "queued",
+            },
+            method="POST",
+            url="http://localhost:8090/jobs/job-old/rerun",
+        )
+
+        exit_code = jobcli.run(
+            ["--api-url", "http://localhost:8090", "rerun", "job-old"]
+        )
+
+    assert exit_code == 0
+    assert mock_request.call_args.kwargs["headers"]["X-API-Secret"] == "from-env"
+
+
+def test_jobsctl_status_prints_error_when_api_returns_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with patch("five08.jobcli.httpx.request") as mock_request:
+        mock_request.return_value = _json_response(
+            status_code=404,
+            payload={"error": "job_not_found"},
+            method="GET",
+            url="http://localhost:8090/jobs/job-missing",
+        )
+
+        exit_code = jobcli.run(["--secret", "test-secret", "status", "job-missing"])
+
+    assert exit_code == 1
+    assert "API error 404: job_not_found" in capsys.readouterr().err
+
+
+def test_jobsctl_status_fails_without_secret(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    exit_code = jobcli.run(["status", "job-123"])
+
+    assert exit_code == 1
+    assert "Missing API secret" in capsys.readouterr().err

--- a/tests/unit/test_worker_actors.py
+++ b/tests/unit/test_worker_actors.py
@@ -1,0 +1,116 @@
+"""Unit tests for worker actor job state transitions."""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+from five08.queue import JobRecord, JobStatus
+from five08.worker import actors
+from five08.worker.crm.docuseal_processor import (
+    DocusealAgreementNonRetryableError,
+    DocusealAgreementProcessingError,
+)
+
+
+def test_run_job_schedules_retry_for_docuseal_processing_error() -> None:
+    """Retryable Docuseal failures should be recorded as failed + retried."""
+    now = datetime.now(timezone.utc)
+    job = JobRecord(
+        id="job-123",
+        type="process_docuseal_agreement_job",
+        status=JobStatus.QUEUED,
+        payload={
+            "args": ["member@508.dev", "2026-02-25 12:00:00", 42],
+            "kwargs": {},
+        },
+        idempotency_key=None,
+        attempts=0,
+        max_attempts=8,
+        run_after=None,
+        locked_at=None,
+        locked_by=None,
+        last_error=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    def _raise_docuseal_processing_error(*args: object, **kwargs: object) -> None:
+        raise DocusealAgreementProcessingError("CRM unavailable")
+
+    with (
+        patch("five08.worker.actors.get_job", return_value=job),
+        patch("five08.worker.actors.mark_job_running") as mock_mark_running,
+        patch("five08.worker.actors.mark_job_succeeded") as mock_mark_succeeded,
+        patch("five08.worker.actors.mark_job_dead") as mock_mark_dead,
+        patch("five08.worker.actors._schedule_retry") as mock_schedule_retry,
+        patch.dict(
+            actors._HANDLERS,
+            {"process_docuseal_agreement_job": _raise_docuseal_processing_error},
+            clear=False,
+        ),
+    ):
+        actors._run_job("job-123")
+
+    mock_mark_running.assert_called_once()
+    mock_mark_succeeded.assert_not_called()
+    mock_mark_dead.assert_not_called()
+    mock_schedule_retry.assert_called_once()
+    call_args = mock_schedule_retry.call_args
+    assert call_args.args[0] == "job-123"
+    assert call_args.args[1] == 1
+    assert (
+        "DocusealAgreementProcessingError: CRM unavailable" == call_args.kwargs["error"]
+    )
+
+
+def test_run_job_marks_dead_for_non_retryable_docuseal_error() -> None:
+    """Non-retryable Docuseal failures should be marked dead immediately."""
+    now = datetime.now(timezone.utc)
+    job = JobRecord(
+        id="job-124",
+        type="process_docuseal_agreement_job",
+        status=JobStatus.QUEUED,
+        payload={
+            "args": ["member@508.dev", "not-a-date", 42],
+            "kwargs": {},
+        },
+        idempotency_key=None,
+        attempts=0,
+        max_attempts=8,
+        run_after=None,
+        locked_at=None,
+        locked_by=None,
+        last_error=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    def _raise_docuseal_non_retryable_error(*args: object, **kwargs: object) -> None:
+        raise DocusealAgreementNonRetryableError(
+            "invalid_completed_at for contact_id=c-1"
+        )
+
+    with (
+        patch("five08.worker.actors.get_job", return_value=job),
+        patch("five08.worker.actors.mark_job_running") as mock_mark_running,
+        patch("five08.worker.actors.mark_job_succeeded") as mock_mark_succeeded,
+        patch("five08.worker.actors.mark_job_dead") as mock_mark_dead,
+        patch("five08.worker.actors._schedule_retry") as mock_schedule_retry,
+        patch.dict(
+            actors._HANDLERS,
+            {"process_docuseal_agreement_job": _raise_docuseal_non_retryable_error},
+            clear=False,
+        ),
+    ):
+        actors._run_job("job-124")
+
+    mock_mark_running.assert_called_once()
+    mock_mark_succeeded.assert_not_called()
+    mock_schedule_retry.assert_not_called()
+    mock_mark_dead.assert_called_once()
+    call_args = mock_mark_dead.call_args
+    assert call_args.args[1] == "job-124"
+    assert call_args.kwargs["attempts"] == 1
+    assert (
+        call_args.kwargs["last_error"]
+        == "DocusealAgreementNonRetryableError: invalid_completed_at for contact_id=c-1"
+    )


### PR DESCRIPTION
## Description
Implemented `POST /jobs/{job_id}/rerun` to duplicate an existing job with original args/kwargs, preserved retry settings, and a new idempotency key using `manual-rerun:{source_job_id}:{ULID}` while keeping the source job unchanged.
Updated DocuSeal processing to raise explicit retryable vs non-retryable errors and changed worker behavior so non-retryable DocuSeal failures mark jobs dead immediately while retryable failures keep existing retry scheduling behavior.
Added a new `jobsctl` CLI entrypoint with `status` and `rerun` subcommands, wired through worker package scripts, and documented fixed-timeout usage alongside new auth examples.
Moved and expanded worker documentation to include API endpoint details, auth header expectations (`X-API-Secret`), and rerun/idempotency contract; root README now links to the worker docs.
Added unit tests for rerun endpoint handling, job actor failure classification, DocuSeal processor exception behavior, and jobsctl command execution.

## Related Issue

## How Has This Been Tested?
The commit passed local lint/type checks through the pre-commit hooks (ruff + mypy) during commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job rerun capability to re-execute previously run jobs via API.
  * Introduced `jobsctl` CLI tool for inspecting job status and rerunning jobs.

* **Documentation**
  * Comprehensive API endpoint documentation with request/response examples.
  * Added CLI usage guide with authentication and configuration details.
  * Enhanced authentication, webhook, and local development documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->