### PR TITLE
feat: add structured webhook alerts and remove channel id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,9 +113,6 @@ DISCORD_SENDMSG_CHARACTER_LIMIT=2000
 BACKEND_API_BASE_URL=http://api:8090
 AUDIT_API_BASE_URL=
 AUDIT_API_TIMEOUT_SECONDS=2.0
-# Required for Discord bot commands that post to channels
-CHANNEL_ID=1391742724666822798
-
 # Worker mailbox resume intake (required if email intake is enabled)
 CHECK_EMAIL_WAIT=2
 EMAIL_USERNAME=your_email@example.com

--- a/README.md
+++ b/README.md
@@ -197,7 +197,6 @@ Use `.env.example` as the source of truth for defaults.
 ### Discord Bot Core
 
 - `Required`: `DISCORD_BOT_TOKEN`
-- `Required`: `CHANNEL_ID`
 - `Optional`: `BACKEND_API_BASE_URL` (default: `http://api:8090`)
 - `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
 - `Optional`: `DISCORD_SENDMSG_CHARACTER_LIMIT` (default: `2000`)

--- a/apps/discord_bot/src/five08/discord_bot/bot.py
+++ b/apps/discord_bot/src/five08/discord_bot/bot.py
@@ -7,12 +7,13 @@ Discord events, and provides the factory function for bot creation.
 
 import logging
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 import discord
 from discord.ext import commands
 
 from five08.discord_bot.config import settings
+from five08.discord_webhook import DiscordWebhookLogger
 from five08.discord_bot.utils.healthcheck import (
     HealthcheckServer,
     start_healthcheck_server,
@@ -71,11 +72,23 @@ class Bot508(commands.Bot):
     async def on_ready(self) -> None:
         """Handle bot ready event."""
         logger.info(f"Hello {self.user} ready for 508.dev!")
-        channel = self.get_channel(settings.channel_id)
-        if channel and isinstance(channel, discord.abc.Messageable):
-            await channel.send(
-                f"🤖 508.dev Bot activated at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}"
-            )
+        message = (
+            "🤖 508.dev Bot activated at "
+            f"{datetime.now(tz=timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}"
+        )
+        if settings.discord_logs_webhook_url:
+            DiscordWebhookLogger(
+                webhook_url=settings.discord_logs_webhook_url,
+                timeout_seconds=2.0,
+                wait_for_response=settings.discord_logs_webhook_wait,
+            ).send(content=message)
+            return
+
+        for guild in self.guilds:
+            default_channel = guild.system_channel
+            if default_channel and isinstance(default_channel, discord.abc.Messageable):
+                await default_channel.send(message)
+                return
 
     async def close(self) -> None:
         """Clean shutdown of bot and healthcheck server."""

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -23,9 +23,6 @@ class Settings(SharedSettings):
     # Healthcheck Configuration
     healthcheck_port: int = 3000
 
-    # Core channel configuration
-    channel_id: int
-
     # CRM/EspoCRM settings
     espo_api_key: str
     espo_base_url: str

--- a/apps/discord_bot/src/five08/discord_bot/utils/audit.py
+++ b/apps/discord_bot/src/five08/discord_bot/utils/audit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+from datetime import datetime, timezone
 from typing import Any
 
 import discord
@@ -13,6 +14,11 @@ import requests
 from five08.discord_webhook import DiscordWebhookLogger
 
 logger = logging.getLogger(__name__)
+DEFAULT_WEBHOOK_USERNAME = "508 Workflows"
+_WEBHOOK_SUCCESS_COLOR = 0x2ECC71
+_WEBHOOK_ERROR_COLOR = 0xE74C3C
+_WEBHOOK_WARNING_COLOR = 0xF1C40F
+_WEBHOOK_INFO_COLOR = 0x3498DB
 
 
 class DiscordAuditLogger:
@@ -171,7 +177,10 @@ class DiscordAuditLogger:
     def _send_webhook_event(self, event_payload: dict[str, Any]) -> None:
         if not self.webhook_enabled:
             return
-        self.webhook_logger.send(content=self._build_webhook_message(event_payload))
+        self.webhook_logger.send(
+            username=DEFAULT_WEBHOOK_USERNAME,
+            embeds=[self._build_webhook_embed(event_payload)],
+        )
 
     @staticmethod
     def _result_emoji(result: str) -> str:
@@ -188,34 +197,95 @@ class DiscordAuditLogger:
             return text
         return f"{text[: max_length - 3]}..."
 
-    def _build_webhook_message(self, event_payload: dict[str, Any]) -> str:
+    @staticmethod
+    def _webhook_color(result: str) -> int:
+        normalized = result.strip().lower()
+        if normalized in {"success", "ok", "created", "queued", "succeeded"}:
+            return _WEBHOOK_SUCCESS_COLOR
+        if normalized in {"error", "failed", "failure", "denied"}:
+            return _WEBHOOK_ERROR_COLOR
+        if normalized in {"retrying", "warning"}:
+            return _WEBHOOK_WARNING_COLOR
+        return _WEBHOOK_INFO_COLOR
+
+    def _build_webhook_embed(self, event_payload: dict[str, Any]) -> dict[str, Any]:
         source = str(event_payload.get("source") or "unknown")
         action = str(event_payload.get("action") or "unknown")
         result = str(event_payload.get("result") or "unknown")
+        service = "Discord Bot"
         actor = (
             str(event_payload.get("actor_display_name"))
             if event_payload.get("actor_display_name")
             else str(event_payload.get("actor_subject"))
+        )
+        actor_subject = str(event_payload.get("actor_subject") or actor)
+        resource = (
+            f"{event_payload.get('resource_type')}:{event_payload.get('resource_id')}"
+            if event_payload.get("resource_type")
+            else None
         )
         metadata = (
             event_payload.get("metadata")
             if isinstance(event_payload.get("metadata"), dict)
             else {}
         )
-
-        command = metadata.get("command") if isinstance(metadata, dict) else None
-        resource = (
-            f"{event_payload.get('resource_type')}:{event_payload.get('resource_id')}"
-            if event_payload.get("resource_type")
+        correlation_id = str(event_payload.get("correlation_id") or "") or None
+        error = (
+            metadata.get("error")
+            if isinstance(metadata, dict) and metadata.get("error") is not None
             else None
         )
-        target = command or resource or "resource unknown"
-        error = metadata.get("error") if isinstance(metadata, dict) else None
-        suffix = f" | error={self._shorten(str(error))}" if error else ""
-        return (
-            f"{self._result_emoji(result)} {source} {action} · {target}"
-            f" · actor={actor} · result={result}{suffix}"
+        command = metadata.get("command") if isinstance(metadata, dict) else None
+        actor_value = f"{actor} ({actor_subject})" if actor != actor_subject else actor
+        description = (
+            f"{self._result_emoji(result)} {source} {action}\nresult: **{result}**"
         )
+        fields: list[dict[str, Any]] = [
+            {"name": "Service", "value": service, "inline": True},
+            {"name": "Actor", "value": self._shorten(actor_value, 64), "inline": True},
+            {"name": "Action", "value": self._shorten(action, 128), "inline": True},
+        ]
+
+        if resource:
+            fields.append(
+                {
+                    "name": "Resource",
+                    "value": self._shorten(str(resource), 128),
+                    "inline": True,
+                },
+            )
+        if correlation_id:
+            fields.append(
+                {
+                    "name": "Correlation ID",
+                    "value": self._shorten(correlation_id, 128),
+                    "inline": False,
+                },
+            )
+        if command:
+            fields.append(
+                {
+                    "name": "Command",
+                    "value": self._shorten(str(command), 128),
+                    "inline": False,
+                },
+            )
+        if error:
+            fields.append(
+                {
+                    "name": "Error",
+                    "value": self._shorten(str(error), 1024),
+                    "inline": False,
+                },
+            )
+
+        return {
+            "title": f"{self._result_emoji(result)} {source}:{action}",
+            "description": description,
+            "color": self._webhook_color(result),
+            "fields": fields,
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        }
 
     def _on_task_done(
         self,

--- a/apps/worker/src/five08/worker/actors.py
+++ b/apps/worker/src/five08/worker/actors.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
+from typing import Final
 from typing import Any
 
 import dramatiq
@@ -41,6 +42,11 @@ configure_observability(
     settings=settings,
     service_name="worker-actors",
 )
+_DEFAULT_WEBHOOK_USERNAME: Final[str] = "508 Workflows"
+_WEBHOOK_INFO_COLOR: Final[int] = 0x3498DB
+_WEBHOOK_WARNING_COLOR: Final[int] = 0xF1C40F
+_WEBHOOK_ERROR_COLOR: Final[int] = 0xE74C3C
+_WEBHOOK_SUCCESS_COLOR: Final[int] = 0x2ECC71
 
 DRAMATIQ_BROKER = RedisBroker(url=settings.redis_url)
 dramatiq.set_broker(DRAMATIQ_BROKER)
@@ -100,20 +106,79 @@ def _log_job_event(
     if not _JOB_WEBHOOK_LOGGER.enabled:
         return
 
-    parts = [
-        f"{event_type.upper()} job",
-        f"type={job_type}",
-        f"id={job_id}",
-        f"attempt={attempts}/{max_attempts}",
-        f"worker={worker_name}",
+    _JOB_WEBHOOK_LOGGER.send(
+        username=_DEFAULT_WEBHOOK_USERNAME,
+        embeds=[
+            {
+                "title": f"{event_type.upper()} Job",
+                "description": f"Worker job lifecycle event for `{job_type}`",
+                "color": _job_event_color(event_type=event_type, has_error=bool(error)),
+                "fields": _job_event_fields(
+                    event_type=event_type,
+                    job_id=job_id,
+                    job_type=job_type,
+                    attempts=attempts,
+                    max_attempts=max_attempts,
+                    worker_name=worker_name,
+                    error=error,
+                    result=result,
+                ),
+                "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            }
+        ],
+    )
+
+
+def _job_event_color(*, event_type: str, has_error: bool = False) -> int:
+    if event_type.lower() == "succeeded":
+        return _WEBHOOK_SUCCESS_COLOR
+    if event_type.lower() in {"dead", "failed"} or has_error:
+        return _WEBHOOK_ERROR_COLOR
+    if event_type.lower() == "retrying":
+        return _WEBHOOK_WARNING_COLOR
+    return _WEBHOOK_INFO_COLOR
+
+
+def _job_event_fields(
+    *,
+    event_type: str,
+    job_id: str,
+    job_type: str,
+    attempts: int,
+    max_attempts: int,
+    worker_name: str,
+    error: str | None,
+    result: Any,
+) -> list[dict[str, Any]]:
+    fields: list[dict[str, Any]] = [
+        {"name": "Event", "value": event_type, "inline": True},
+        {"name": "Job ID", "value": _truncate(job_id, 64), "inline": True},
+        {"name": "Type", "value": _truncate(job_type, 64), "inline": True},
+        {
+            "name": "Attempt",
+            "value": f"{attempts}/{max_attempts}",
+            "inline": True,
+        },
+        {"name": "Worker", "value": _truncate(worker_name, 64), "inline": True},
     ]
 
     if result is not None:
-        parts.append(f"result={_summarize_job_result(result)}")
+        fields.append(
+            {
+                "name": "Result",
+                "value": _truncate(_summarize_job_result(result), 1024),
+                "inline": False,
+            },
+        )
     if error:
-        parts.append(f"error={_truncate(error, 160)}")
-
-    _JOB_WEBHOOK_LOGGER.send(content=" | ".join(parts))
+        fields.append(
+            {
+                "name": "Error",
+                "value": _truncate(error, 1024),
+                "inline": False,
+            },
+        )
+    return fields
 
 
 def _extract_call_args(job: JobRecord) -> tuple[tuple[Any, ...], dict[str, Any]]:

--- a/packages/shared/src/five08/discord_webhook.py
+++ b/packages/shared/src/five08/discord_webhook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import contextlib
 import json
 import logging
+from typing import Any
 from urllib import error, request
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 
@@ -15,6 +16,7 @@ class DiscordWebhookLogger:
     """Send short messages to a Discord webhook URL without affecting workflows."""
 
     _MAX_CONTENT_LENGTH = 2000
+    _MAX_EMBED_COUNT = 10
 
     def __init__(
         self,
@@ -32,18 +34,27 @@ class DiscordWebhookLogger:
         """Return whether webhook logging is configured."""
         return bool(self.webhook_url)
 
-    def send(self, *, content: str) -> None:
+    def send(
+        self,
+        *,
+        content: str | None = None,
+        embeds: list[dict[str, Any]] | None = None,
+        username: str | None = None,
+    ) -> None:
         """Best-effort send one Discord message."""
         if not self.enabled:
             return
 
+        payload = self._build_payload(
+            content=content,
+            embeds=embeds,
+            username=username,
+        )
+        if not payload:
+            return
+
         query_params = self._request_query_params()
-        body = json.dumps(
-            {
-                "content": self._normalize_content(content),
-                "allowed_mentions": {"parse": []},
-            },
-        ).encode("utf-8")
+        body = json.dumps(payload).encode("utf-8")
         req = request.Request(
             self._request_url(query_params),
             data=body,
@@ -84,6 +95,63 @@ class DiscordWebhookLogger:
             return f"{normalized[: self._MAX_CONTENT_LENGTH - 3]}..."
 
         return normalized
+
+    @staticmethod
+    def _normalize_embed(embed: dict[str, Any]) -> dict[str, Any]:
+        """Drop empty or non-JSON-serializable embed fields."""
+        normalized: dict[str, Any] = {}
+        for key, value in embed.items():
+            if value is None:
+                continue
+            if key == "fields" and isinstance(value, list):
+                normalized_fields: list[dict[str, Any]] = []
+                for raw_field in value:
+                    if not isinstance(raw_field, dict):
+                        continue
+                    name = str(raw_field.get("name", "")).strip()
+                    if not name:
+                        continue
+                    field_value = str(raw_field.get("value", "")).strip()
+                    field_entry: dict[str, Any] = {"name": name, "value": field_value}
+                    if isinstance(raw_field.get("inline"), bool):
+                        field_entry["inline"] = raw_field["inline"]
+                    normalized_fields.append(field_entry)
+                if normalized_fields:
+                    normalized["fields"] = normalized_fields
+                continue
+
+            if isinstance(value, (str, int, float, bool, list, dict)):
+                if isinstance(value, str) and not value.strip():
+                    continue
+                normalized[key] = value
+        return normalized
+
+    def _build_payload(
+        self,
+        *,
+        content: str | None,
+        embeds: list[dict[str, Any]] | None,
+        username: str | None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {"allowed_mentions": {"parse": []}}
+        if content is not None:
+            payload["content"] = self._normalize_content(content)
+        if username:
+            trimmed_username = username.strip()
+            if trimmed_username:
+                payload["username"] = trimmed_username
+        if embeds:
+            payload["embeds"] = [
+                self._normalize_embed(embed)
+                for embed in embeds[: self._MAX_EMBED_COUNT]
+                if embed
+            ]
+            payload["embeds"] = [embed for embed in payload["embeds"] if embed]
+            if not payload["embeds"]:
+                payload.pop("embeds")
+        if not content and "embeds" not in payload and not payload.get("content"):
+            return {}
+        return payload
 
     def _request_query_params(self) -> dict[str, str]:
         """Build webhook query params while enforcing text-only message behavior."""

--- a/tests/unit/test_discord_webhook.py
+++ b/tests/unit/test_discord_webhook.py
@@ -96,3 +96,38 @@ def test_send_truncates_long_content() -> None:
 
     assert payload["content"] == ("a" * 1997 + "...")
     assert payload["allowed_mentions"] == {"parse": []}
+
+
+def test_send_supports_embed_payload() -> None:
+    logger = DiscordWebhookLogger("https://discord.com/api/webhooks/1/token")
+    embed_payload = {
+        "title": "Test Alert",
+        "description": "Something happened.",
+        "color": 15158332,
+        "fields": [
+            {"name": "Environment", "value": "production", "inline": True},
+            {"name": "Service", "value": "api", "inline": True},
+        ],
+    }
+
+    with patch(
+        "five08.discord_webhook.request.urlopen",
+        return_value=_urlopen_context(),
+    ) as mock_urlopen:
+        logger.send(username="508 Workflows", embeds=[embed_payload])
+
+    request_obj = mock_urlopen.call_args.args[0]
+    payload = json.loads(request_obj.data.decode("utf-8"))
+
+    assert payload["username"] == "508 Workflows"
+    assert payload["embeds"] == [embed_payload]
+    assert payload["allowed_mentions"] == {"parse": []}
+
+
+def test_send_no_content_no_embeds_does_nothing() -> None:
+    logger = DiscordWebhookLogger("https://discord.com/api/webhooks/1/token")
+
+    with patch("five08.discord_webhook.request.urlopen") as mock_urlopen:
+        logger.send(content=None, embeds=None)
+
+    mock_urlopen.assert_not_called()


### PR DESCRIPTION
## Description
- Added structured Discord webhook payload support in `DiscordWebhookLogger` with optional `embeds` and `username`, while preserving existing plain-text behavior.
- Switched Discord bot startup notification to prefer `DISCORD_LOGS_WEBHOOK_URL` and removed the `CHANNEL_ID` runtime requirement, with guild system-channel fallback.
- Updated Discord audit and worker job lifecycle webhook notifications to send rich embed payloads with event metadata, color coding, and result/error context.
- Kept all existing webhook transport semantics and command/job processing paths behavior otherwise unchanged.

## Related Issue
No issue linked.

## How Has This Been Tested?
- Pre-commit checks were run via commit hooks (`ruff`, `ruff format`, `mypy`) and passed.
- Added/extended unit coverage in `tests/unit/test_discord_webhook.py` for embed payload support and no-op handling.
