### PR TITLE
feat(shared): reuse resume extractor in bot and worker

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -22,6 +22,7 @@ from discord.ext import commands
 from five08.discord_bot.config import settings
 from five08.clients import espo
 from five08.skills import normalize_skill_list
+from five08.resume_extractor import ResumeExtractedProfile, ResumeProfileExtractor
 from five08.discord_bot.utils.audit import DiscordAuditLogger
 from five08.discord_bot.utils.role_decorators import (
     require_role,
@@ -1107,6 +1108,12 @@ class CRMCog(commands.Cog):
         self.espo_api = EspoAPI(api_url, settings.espo_api_key)
         # Store base URL for profile links
         self.base_url = settings.espo_base_url.rstrip("/")
+        self.resume_extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.openai_model,
+        )
+        self._resume_profile_cache: tuple[int, ResumeExtractedProfile] | None = None
         self.audit_logger = DiscordAuditLogger(
             base_url=settings.audit_api_base_url,
             shared_secret=settings.api_shared_secret,
@@ -2883,52 +2890,51 @@ class CRMCog(commands.Cog):
             except aiohttp.ClientError as exc:
                 raise ValueError(f"Migadu API request failed: {exc}") from exc
 
-    def _extract_resume_contact_hints(
-        self, file_content: bytes
-    ) -> dict[str, list[str]]:
-        """Extract basic contact-identifying signals from resume bytes."""
-        text = file_content.decode("utf-8", errors="ignore")
-        if not text:
-            return {"emails": [], "github_usernames": [], "linkedin_urls": []}
-
-        # Keep this lightweight; heuristics are only used for contact targeting.
-        snippet = text[:12000]
-        email_re = re.compile(
-            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
-            flags=re.IGNORECASE,
-        )
-        github_re = re.compile(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            flags=re.IGNORECASE,
-        )
-        linkedin_re = re.compile(
-            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\\-_%]+/?",
-            flags=re.IGNORECASE,
-        )
-
-        email_matches: list[str] = []
-        for email in email_re.findall(snippet):
-            candidate = str(email).strip().lower()
-            if candidate and candidate not in email_matches:
-                email_matches.append(candidate)
-
-        github_matches: list[str] = []
-        for username in github_re.findall(snippet):
-            candidate = str(username).strip().lower()
-            if candidate and candidate not in github_matches:
-                github_matches.append(candidate)
-
-        linkedin_matches: list[str] = []
-        for linkedin_url in linkedin_re.findall(snippet):
-            candidate = str(linkedin_url).strip().lower().rstrip("/")
-            if candidate and candidate not in linkedin_matches:
-                linkedin_matches.append(candidate)
-
+    def _extract_resume_contact_hints(self, file_content: bytes) -> dict[str, Any]:
+        """Extract contact-identifying signals and shared resume fields from bytes."""
+        profile = self._extract_resume_profile(file_content)
         return {
-            "emails": email_matches,
-            "github_usernames": github_matches,
-            "linkedin_urls": linkedin_matches,
+            "emails": [profile.email] if profile.email else [],
+            "github_usernames": [profile.github_username]
+            if profile.github_username
+            else [],
+            "linkedin_urls": [profile.linkedin_url] if profile.linkedin_url else [],
+            "phone": profile.phone,
+            "name": profile.name,
+            "address_country": profile.address_country,
+            "seniority_level": profile.seniority_level,
+            "skills": profile.skills,
         }
+
+    def _extract_resume_profile(self, file_content: bytes) -> Any:
+        """Extract resume profile fields and cache per-file-content results."""
+        cache = self._resume_profile_cache
+        cache_key = hash(file_content)
+        if cache and cache[0] == cache_key:
+            return cache[1]
+
+        text = file_content.decode("utf-8", errors="ignore")
+        profile = self.resume_extractor.extract(text)
+        self._resume_profile_cache = (cache_key, profile)
+        return profile
+
+    def _extract_resume_name_fallback(self, file_content: bytes) -> str:
+        """Simple name heuristic fallback when extraction did not return a name."""
+        text = file_content.decode("utf-8", errors="ignore")
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        for line in lines[:40]:
+            candidate = line.strip()
+            if not candidate:
+                continue
+            if len(candidate) < 2:
+                continue
+            if "@" in candidate or "http" in candidate.lower():
+                continue
+            if not any(char.isalpha() for char in candidate):
+                continue
+            if len(candidate.split()) >= 1 and len(candidate) <= 70:
+                return candidate
+        return "Unknown Contact"
 
     def _format_inferred_attempts(self, attempts: list[dict[str, Any]] | None) -> str:
         if not attempts:
@@ -2948,23 +2954,11 @@ class CRMCog(commands.Cog):
 
     def _extract_resume_name_hint(self, file_content: bytes) -> str:
         """Best-effort contact name extraction from resume text."""
-        text = file_content.decode("utf-8", errors="ignore")
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        for line in lines[:40]:
-            candidate = line.strip()
-            if not candidate:
-                continue
-            if len(candidate) < 2:
-                continue
-            if "@" in candidate or "http" in candidate.lower():
-                continue
-            if not any(char.isalpha() for char in candidate):
-                continue
-            # Prefer short, title-like lines at the top as candidate names.
-            if len(candidate.split()) >= 1 and len(candidate) <= 70:
-                return candidate
-
-        return "Unknown Contact"
+        hints = self._extract_resume_contact_hints(file_content)
+        extracted_name = str(hints.get("name") or "").strip()
+        if extracted_name:
+            return extracted_name
+        return self._extract_resume_name_fallback(file_content)
 
     def _build_resume_create_contact_payload(
         self, file_content: bytes
@@ -2973,18 +2967,45 @@ class CRMCog(commands.Cog):
         hints = self._extract_resume_contact_hints(file_content)
         name = self._extract_resume_name_hint(file_content)
         contact_name = name if name != "Unknown Contact" else "Resume Candidate"
+        emails = hints.get("emails", [])
+        github_usernames = hints.get("github_usernames", [])
+        linkedin_urls = hints.get("linkedin_urls", [])
+        skills = hints.get("skills", [])
+        if not isinstance(emails, list):
+            emails = []
+        if not isinstance(github_usernames, list):
+            github_usernames = []
+        if not isinstance(linkedin_urls, list):
+            linkedin_urls = []
+        if not isinstance(skills, list):
+            skills = []
 
         payload: dict[str, str] = {"name": contact_name}
-        if hints["emails"]:
-            primary_email = hints["emails"][0]
+        if emails:
+            primary_email = emails[0]
             if primary_email.endswith("@508.dev"):
                 payload["c508Email"] = primary_email
             else:
                 payload["emailAddress"] = primary_email
-        if hints["github_usernames"]:
-            payload["cGitHubUsername"] = hints["github_usernames"][0]
-        if hints["linkedin_urls"]:
-            payload["cLinkedInUrl"] = hints["linkedin_urls"][0]
+        if github_usernames:
+            payload["cGitHubUsername"] = github_usernames[0]
+        if linkedin_urls:
+            payload["cLinkedInUrl"] = linkedin_urls[0]
+        phone = hints.get("phone")
+        if isinstance(phone, str) and phone.strip():
+            payload["phoneNumber"] = phone.strip()
+        address_country = str(hints.get("address_country", "")).strip()
+        if address_country:
+            payload["addressCountry"] = address_country
+        seniority = str(hints.get("seniority_level", "")).strip()
+        if seniority:
+            payload["cSeniority"] = seniority
+        if skills:
+            normalized_skills = [
+                str(item).strip() for item in skills if str(item).strip()
+            ]
+            if normalized_skills:
+                payload["skills"] = ", ".join(normalized_skills)
 
         return payload
 
@@ -3050,7 +3071,10 @@ class CRMCog(commands.Cog):
         """Infer target contact from resume identifiers."""
         hints = self._extract_resume_contact_hints(file_content)
         attempts: list[dict[str, Any]] = []
-        for email in hints["emails"]:
+        emails = hints.get("emails", [])
+        if not isinstance(emails, list):
+            emails = []
+        for email in emails:
             attempts.append({"method": "email", "value": email})
             contacts = await self._search_contact_for_linking(email)
             if len(contacts) == 1:
@@ -3067,7 +3091,10 @@ class CRMCog(commands.Cog):
                     "attempts": attempts,
                 }
 
-        for github_username in hints["github_usernames"]:
+        github_usernames = hints.get("github_usernames", [])
+        if not isinstance(github_usernames, list):
+            github_usernames = []
+        for github_username in github_usernames:
             attempts.append({"method": "github", "value": github_username})
             contacts = await self._search_contacts_by_field(
                 field="cGitHubUsername", value=github_username
@@ -3086,7 +3113,10 @@ class CRMCog(commands.Cog):
                     "attempts": attempts,
                 }
 
-        for linkedin_url in hints["linkedin_urls"]:
+        linkedin_urls = hints.get("linkedin_urls", [])
+        if not isinstance(linkedin_urls, list):
+            linkedin_urls = []
+        for linkedin_url in linkedin_urls:
             attempts.append({"method": "linkedin", "value": linkedin_url})
             contacts = await self._search_contacts_by_field(
                 field="cLinkedInUrl", value=linkedin_url

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -32,6 +32,9 @@ class Settings(SharedSettings):
     migadu_api_user: str | None = None
     migadu_api_key: str | None = None
     migadu_mailbox_domain: str = "508.dev"
+    openai_api_key: str | None = None
+    openai_base_url: str | None = None
+    openai_model: str = "gpt-4o-mini"
 
     # Kimai time tracking settings
     kimai_base_url: str

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -12,9 +12,9 @@ from urllib.parse import urlsplit
 import requests
 
 from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.resume_extractor import ResumeProfileExtractor
 from five08.worker.config import settings
 from five08.worker.crm.document_processor import DocumentProcessor
-from five08.worker.crm.resume_profile_processor import ResumeProfileExtractor
 from five08.worker.crm.skills_extractor import SkillsExtractor
 from five08.worker.masking import mask_email
 
@@ -74,7 +74,11 @@ class IntakeFormProcessor:
         api_url = settings.espo_base_url.rstrip("/") + "/api/v1"
         self.api = EspoAPI(api_url, settings.espo_api_key)
         self.document_processor = DocumentProcessor()
-        self.resume_extractor = ResumeProfileExtractor()
+        self.resume_extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.resolved_resume_ai_model,
+        )
         self.skills_extractor = SkillsExtractor()
 
     def process_intake(self, *, payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
 from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.resume_extractor import ResumeProfileExtractor
 from five08.queue import get_postgres_connection
 from five08.worker.config import settings
 from five08.worker.crm.document_processor import DocumentProcessor
@@ -24,11 +24,6 @@ from five08.worker.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-try:  # pragma: no cover - import success depends on environment
-    from openai import OpenAI as OpenAIClient
-except Exception:  # pragma: no cover
-    OpenAIClient = None  # type: ignore[misc,assignment]
 
 
 class ResumeEspoClient:
@@ -48,196 +43,16 @@ class ResumeEspoClient:
         self.api.request("PUT", f"Contact/{contact_id}", updates)
 
 
-class ResumeProfileExtractor:
-    """Extract candidate profile fields from resume text."""
-
-    def __init__(self) -> None:
-        self.model = settings.resolved_resume_ai_model
-        self.client: Any = None
-
-        if settings.openai_api_key and OpenAIClient is not None:
-            self.client = OpenAIClient(
-                api_key=settings.openai_api_key,
-                base_url=settings.openai_base_url,
-            )
-
-    def extract(self, resume_text: str) -> ResumeExtractedProfile:
-        """Return extracted fields from resume text."""
-        if self.client is None:
-            return self._heuristic_extract(resume_text)
-
-        try:
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You extract candidate contact fields from resumes for a CRM. "
-                            "Return JSON only with no commentary. Be conservative: when unsure, use null. "
-                            "Prefer candidate-owned contact info and ignore references or company contact details."
-                        ),
-                    },
-                    {
-                        "role": "user",
-                        "content": self._build_prompt(resume_text),
-                    },
-                ],
-                temperature=0.1,
-                max_tokens=800,
-            )
-            raw_content = response.choices[0].message.content
-            if not raw_content:
-                raise ValueError("LLM returned empty content")
-
-            parsed = self._parse_json(raw_content)
-            return ResumeExtractedProfile(
-                email=self._normalize_email(parsed.get("email")),
-                github_username=self._normalize_github(parsed.get("github_username")),
-                linkedin_url=self._normalize_linkedin(parsed.get("linkedin_url")),
-                phone=self._normalize_phone(parsed.get("phone")),
-                confidence=self._bounded_confidence(parsed.get("confidence", 0.75)),
-                source=self.model,
-            )
-        except Exception as exc:
-            logger.warning("LLM resume extraction failed, using fallback: %s", exc)
-            return self._heuristic_extract(resume_text)
-
-    def _heuristic_extract(self, resume_text: str) -> ResumeExtractedProfile:
-        email_match = re.search(
-            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b", resume_text
-        )
-        github_match = re.search(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            resume_text,
-            flags=re.IGNORECASE,
-        )
-        linkedin_match = re.search(
-            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\-_%]+/?",
-            resume_text,
-            flags=re.IGNORECASE,
-        )
-        phone_match = re.search(
-            r"(?:\+?\d[\d\s().-]{7,}\d)",
-            resume_text,
-        )
-
-        github_value: str | None = None
-        if github_match:
-            github_value = github_match.group(1)
-
-        linkedin_value: str | None = None
-        if linkedin_match:
-            linkedin_value = linkedin_match.group(0)
-
-        phone_value: str | None = None
-        if phone_match:
-            phone_value = phone_match.group(0)
-
-        return ResumeExtractedProfile(
-            email=self._normalize_email(email_match.group(0) if email_match else None),
-            github_username=self._normalize_github(github_value),
-            linkedin_url=self._normalize_linkedin(linkedin_value),
-            phone=self._normalize_phone(phone_value),
-            confidence=0.45,
-            source="heuristic",
-        )
-
-    def _build_prompt(self, resume_text: str) -> str:
-        snippet = resume_text[:12000]
-        return (
-            "Extract candidate contact fields from this resume.\n"
-            "Return JSON with exact keys and no extras:\n"
-            '{"email": string|null, "github_username": string|null, '
-            '"linkedin_url": string|null, "phone": string|null, '
-            '"confidence": number}\n'
-            "Rules:\n"
-            "- prefer explicit values from header/contact sections\n"
-            "- for github_username return username only (no URL, no @)\n"
-            "- for linkedin_url return full linkedin profile URL when available\n"
-            "- for phone return digits with optional leading +\n"
-            "- use null for unknown/ambiguous fields\n"
-            "- confidence is 0-1 for overall extraction reliability\n\n"
-            f"Resume:\n{snippet}"
-        )
-
-    def _parse_json(self, content: str) -> dict[str, Any]:
-        raw = content.strip()
-        if raw.startswith("```"):
-            lines = [line for line in raw.splitlines() if not line.startswith("```")]
-            raw = "\n".join(lines).strip()
-
-        parsed = json.loads(raw)
-        if not isinstance(parsed, dict):
-            raise ValueError("Model output was not a JSON object")
-        return parsed
-
-    def _bounded_confidence(self, value: Any) -> float:
-        try:
-            numeric = float(value)
-        except Exception:
-            numeric = 0.0
-        return max(0.0, min(1.0, numeric))
-
-    def _normalize_email(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        normalized = value.strip().lower()
-        return normalized or None
-
-    def _normalize_github(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        github_match = re.search(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            candidate,
-            flags=re.IGNORECASE,
-        )
-        if github_match:
-            candidate = github_match.group(1)
-
-        candidate = candidate.lstrip("@").strip().strip("/")
-        return candidate or None
-
-    def _normalize_linkedin(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        if "linkedin.com" not in candidate.lower():
-            return None
-        if not candidate.lower().startswith(("http://", "https://")):
-            candidate = f"https://{candidate}"
-        return candidate.rstrip("/")
-
-    def _normalize_phone(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        digits = re.sub(r"\D", "", candidate)
-        if len(digits) < 7:
-            return None
-
-        if candidate.startswith("+"):
-            return "+" + digits
-        return digits
-
-
 class ResumeProfileProcessor:
     """End-to-end extraction and apply operations for uploaded resumes."""
 
     def __init__(self) -> None:
         self.crm = ResumeEspoClient()
-        self.extractor = ResumeProfileExtractor()
+        self.extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.resolved_resume_ai_model,
+        )
         self.skills_extractor = SkillsExtractor()
         self.document_processor = DocumentProcessor()
 

--- a/apps/worker/src/five08/worker/models.py
+++ b/apps/worker/src/five08/worker/models.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from typing import Literal
 from typing import Any
 
+from five08.resume_extractor import (
+    ResumeExtractedProfile as SharedResumeExtractedProfile,
+)
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 
@@ -64,15 +67,7 @@ class SkillsExtractionResult(BaseModel):
     error: str | None = None
 
 
-class ResumeExtractedProfile(BaseModel):
-    """Normalized profile fields extracted from resume text."""
-
-    email: str | None = None
-    github_username: str | None = None
-    linkedin_url: str | None = None
-    phone: str | None = None
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    source: str
+ResumeExtractedProfile = SharedResumeExtractedProfile
 
 
 class ResumeFieldChange(BaseModel):

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -1,0 +1,346 @@
+"""Shared resume text extraction utilities for candidate fields."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+try:
+    from openai import OpenAI as OpenAIClient
+except Exception:  # pragma: no cover
+    OpenAIClient = None  # type: ignore[misc,assignment]
+
+
+def _bounded_confidence(value: Any, fallback: float) -> float:
+    """Clamp confidence values to [0, 1]."""
+    try:
+        parsed = float(value)
+    except Exception:
+        return fallback
+    return max(0.0, min(1.0, parsed))
+
+
+def _normalize_email(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _normalize_github(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    github_match = re.search(
+        r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
+        candidate,
+        flags=re.IGNORECASE,
+    )
+    if github_match:
+        candidate = github_match.group(1)
+
+    candidate = candidate.lstrip("@").strip().strip("/")
+    return candidate or None
+
+
+def _normalize_linkedin(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if "linkedin.com" not in candidate.lower():
+        return None
+    if not candidate.lower().startswith(("http://", "https://")):
+        candidate = f"https://{candidate}"
+    return candidate.rstrip("/")
+
+
+def _normalize_phone(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    digits = re.sub(r"\D", "", candidate)
+    if len(digits) < 7:
+        return None
+    if candidate.startswith("+"):
+        return f"+{digits}"
+    return digits
+
+
+def _normalize_country(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized.title() if normalized else None
+
+
+def _normalize_seniority(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"jr", "junior", "entry", "entry-level", "entry level"}:
+        return "junior"
+    if normalized in {"intern", "internship"}:
+        return "junior"
+    if normalized in {"mid-level", "midlevel", "mid", "intermediate"}:
+        return "midlevel"
+    if normalized in {"senior", "lead", "principal"}:
+        return normalized
+    if normalized in {"staff", "staff+"}:
+        return "staff"
+    return normalized
+
+
+def _normalize_skills(value: Any) -> list[str]:
+    if isinstance(value, list):
+        raw_skills = [str(skill).strip() for skill in value]
+    elif isinstance(value, str):
+        raw_skills = [item.strip() for item in value.replace(";", ",").split(",")]
+    else:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_skill in raw_skills:
+        skill = re.sub(r"\s+", " ", raw_skill).strip()
+        if not skill:
+            continue
+        lowered = skill.casefold()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalized.append(skill)
+    return normalized
+
+
+def _normalize_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _parse_json_object(content: str) -> dict[str, Any]:
+    raw = content.strip()
+    if raw.startswith("```"):
+        lines = [line for line in raw.splitlines() if not line.startswith("```")]
+        raw = "\n".join(lines).strip()
+
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("Model output was not a JSON object")
+    return parsed
+
+
+class ResumeExtractedProfile(BaseModel):
+    """Normalized profile fields extracted from resume text."""
+
+    name: str | None = None
+    email: str | None = None
+    github_username: str | None = None
+    linkedin_url: str | None = None
+    phone: str | None = None
+    address_country: str | None = None
+    seniority_level: str | None = None
+    skills: list[str] = Field(default_factory=list)
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    source: str
+
+
+class ResumeProfileExtractor:
+    """Extract candidate profile fields from resume text."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        base_url: str | None = None,
+        model: str = "gpt-4o-mini",
+        max_tokens: int = 800,
+        snippet_chars: int = 12000,
+    ) -> None:
+        self.model = model.strip() if model else "gpt-4o-mini"
+        if not self.model:
+            self.model = "gpt-4o-mini"
+        self.max_tokens = max_tokens
+        self.snippet_chars = max(1000, snippet_chars)
+        self.client: Any = None
+
+        if api_key and OpenAIClient is not None:
+            self.client = OpenAIClient(
+                api_key=api_key,
+                base_url=base_url,
+            )
+
+    def extract(self, resume_text: str) -> ResumeExtractedProfile:
+        """Return extracted fields from resume text."""
+        text = (resume_text or "").strip()
+        if not text:
+            return self._heuristic_extract("")
+
+        if self.client is None:
+            return self._heuristic_extract(text)
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You extract candidate profile fields from resumes for a CRM. "
+                            "Return JSON only with no commentary. Be conservative: when unsure, use null."
+                        ),
+                    },
+                    {"role": "user", "content": self._build_prompt(text)},
+                ],
+                temperature=0.1,
+                max_tokens=self.max_tokens,
+            )
+            raw_content = response.choices[0].message.content
+            if not raw_content:
+                raise ValueError("LLM returned empty content")
+
+            parsed = _parse_json_object(raw_content)
+            return ResumeExtractedProfile(
+                name=_normalize_name(parsed.get("name")),
+                email=_normalize_email(parsed.get("email")),
+                github_username=_normalize_github(parsed.get("github_username")),
+                linkedin_url=_normalize_linkedin(parsed.get("linkedin_url")),
+                phone=_normalize_phone(parsed.get("phone")),
+                address_country=_normalize_country(parsed.get("address_country")),
+                seniority_level=_normalize_seniority(parsed.get("seniority_level")),
+                skills=_normalize_skills(parsed.get("skills")),
+                confidence=_bounded_confidence(
+                    parsed.get("confidence", 0.75),
+                    fallback=0.75,
+                ),
+                source=self.model,
+            )
+        except Exception:
+            return self._heuristic_extract(text)
+
+    def _heuristic_extract(self, resume_text: str) -> ResumeExtractedProfile:
+        snippet = (resume_text or "").strip()[: self.snippet_chars]
+        email_match = re.search(
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+            snippet,
+        )
+        github_match = re.search(
+            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
+            snippet,
+            flags=re.IGNORECASE,
+        )
+        linkedin_match = re.search(
+            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\\-_%]+/?",
+            snippet,
+            flags=re.IGNORECASE,
+        )
+        phone_match = re.search(
+            r"(?:\+?\d[\d\s().-]{7,}\d)",
+            snippet,
+        )
+        name_match = self._extract_name(snippet)
+        country = self._extract_country(snippet)
+        seniority = self._extract_seniority(snippet)
+        skills = self._extract_skills(snippet)
+
+        return ResumeExtractedProfile(
+            name=name_match,
+            email=_normalize_email(email_match.group(0)) if email_match else None,
+            github_username=(
+                _normalize_github(github_match.group(1)) if github_match else None
+            ),
+            linkedin_url=(
+                _normalize_linkedin(linkedin_match.group(0)) if linkedin_match else None
+            ),
+            phone=_normalize_phone(phone_match.group(0)) if phone_match else None,
+            address_country=country,
+            seniority_level=seniority,
+            skills=skills,
+            confidence=0.45,
+            source="heuristic",
+        )
+
+    def _build_prompt(self, resume_text: str) -> str:
+        snippet = resume_text[: self.snippet_chars]
+        return (
+            "Extract candidate profile fields from this resume.\n"
+            "Return JSON with exact keys and no extras:\n"
+            '{"name": string|null, "email": string|null, '
+            '"github_username": string|null, "linkedin_url": string|null, '
+            '"phone": string|null, "address_country": string|null, '
+            '"seniority_level": string|null, "skills": string[]|null, '
+            '"confidence": number}\n'
+            "Rules:\n"
+            "- prefer explicit values from header/contact sections\n"
+            "- for github_username return username only (no URL, no @)\n"
+            "- for linkedin_url return full linkedin profile URL when available\n"
+            "- for phone return digits with optional leading +\n"
+            "- use null for unknown or ambiguous fields\n"
+            "- confidence is 0-1 for overall extraction reliability\n\n"
+            f"Resume:\n{snippet}"
+        )
+
+    @staticmethod
+    def _extract_name(resume_text: str) -> str | None:
+        lines = [line.strip() for line in resume_text.splitlines() if line.strip()]
+        for line in lines[:40]:
+            if len(line) < 2 or len(line) > 70:
+                continue
+            if "@" in line or "http" in line.lower():
+                continue
+            if not any(char.isalpha() for char in line):
+                continue
+            return line
+        return None
+
+    @staticmethod
+    def _extract_country(resume_text: str) -> str | None:
+        match = re.search(
+            r"(?im)^(?:address\s*country|country)\s*[:\-]\s*(.+)$",
+            resume_text,
+        )
+        if match:
+            normalized = _normalize_country(match.group(1))
+            if normalized:
+                return normalized
+
+        return None
+
+    @staticmethod
+    def _extract_seniority(resume_text: str) -> str | None:
+        match = re.search(
+            r"(?im)^\s*seniority\s*[:\-]\s*(.+)$",
+            resume_text,
+        )
+        if match:
+            return _normalize_seniority(match.group(1))
+        return None
+
+    @staticmethod
+    def _extract_skills(resume_text: str) -> list[str]:
+        match = re.search(
+            r"(?im)^\s*(?:skills|technical\s+skills|technologies)\s*[:\-]?\s*$",
+            resume_text,
+        )
+        if not match:
+            return []
+
+        line_start = match.end()
+        tail = resume_text[line_start : line_start + 500]
+        first_line = tail.splitlines()[0] if tail else ""
+        if first_line:
+            return _normalize_skills(first_line)
+        return []

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -931,19 +931,25 @@ class TestCRMCog:
         search_params = call_args[0][2]  # Third argument is the search params
         # Check that it searched for "john" as a name
         first_where = search_params["where"][0]
-        if first_where.get("type") == "or":
-            where_filters = first_where.get("value", [])
+        if first_where.get("type") == "or" and isinstance(
+            first_where.get("value"), list
+        ):
+            where_filters = first_where["value"]
             assert isinstance(where_filters, list)
             where_filter = next(
-                (item for item in where_filters if item.get("attribute") == "name"),
+                (
+                    item
+                    for item in where_filters
+                    if isinstance(item, dict) and item.get("attribute") == "name"
+                ),
                 None,
             )
             assert where_filter is not None
-            assert where_filter["value"] == "john"
+            assert where_filter.get("value") == "john"
             return
 
-        assert first_where["attribute"] == "name"
-        assert first_where["value"] == "john"
+        assert first_where.get("attribute") == "name"
+        assert first_where.get("value") == "john"
 
     @pytest.mark.asyncio
     async def test_link_discord_user_modern_username(


### PR DESCRIPTION
## Description
- Introduced a shared resume extraction service in packages/shared/src/five08/resume_extractor.py to normalize candidate fields, emit confidence, and provide LLM + heuristic fallback extraction.
- Updated Discord bot CRM resume workflows to use that shared extractor for resume matching payloads, name inference, and inferred contact creation fields.
- Refactored worker resume intake and resume profile processors to use the shared extractor and removed duplicated extraction logic.
- Added bot OpenAI configuration fields and made the `test_link_discord_user_name_search` assertion resilient to wrapped `where` filters.
- Validation passed pre-commit hooks (ruff and mypy), with no runtime tests executed in this pass.

## Related Issue

## How Has This Been Tested?
Pre-commit checks (ruff, ruff format, mypy) passed on commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced resume parsing with AI-powered extraction of candidate information including email, GitHub profiles, LinkedIn URLs, phone numbers, location, seniority level, and skills
  * Improved contact inference and matching workflows with more reliable structured data extraction from uploaded resumes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->