### PR TITLE
fix: filter generic resume skills from extractor

### DIFF
--- a/apps/worker/src/five08/worker/crm/skills_extractor.py
+++ b/apps/worker/src/five08/worker/crm/skills_extractor.py
@@ -49,6 +49,16 @@ COMMON_SKILLS = {
     "content marketing",
 }
 
+DISALLOWED_SKILLS = {
+    # These terms are disallowed because they are too generic to represent actionable,
+    # specific professional skill signals for resume-based CRM enrichment.
+    "code review",
+    "debugging",
+    "performance optimization",
+    "testing",
+    "code quality",
+}
+
 DEFAULT_SKILL_STRENGTH = 3
 
 
@@ -117,7 +127,7 @@ class SkillsExtractor:
         detected: set[str] = set()
         for token in token_matches:
             canonical = self._normalize_skill_name(token)
-            if canonical in COMMON_SKILLS:
+            if canonical in COMMON_SKILLS and canonical not in DISALLOWED_SKILLS:
                 detected.add(canonical)
 
         sorted_skills = sorted(detected)
@@ -179,6 +189,8 @@ class SkillsExtractor:
         normalized_skills: list[str] = []
         for skill in raw_skills:
             canonical, inline_strength = self._parse_skill_with_strength(str(skill))
+            if canonical in DISALLOWED_SKILLS:
+                continue
             if canonical:
                 normalized_skills.append(canonical)
                 if inline_strength is not None:
@@ -187,6 +199,8 @@ class SkillsExtractor:
         if isinstance(skill_attrs_value, dict):
             for raw_name, raw_attr in skill_attrs_value.items():
                 canonical = self._normalize_skill_name(str(raw_name))
+                if canonical in DISALLOWED_SKILLS:
+                    continue
                 if not canonical:
                     continue
                 strength = self._parse_strength(raw_attr)

--- a/tests/unit/test_skills_extractor.py
+++ b/tests/unit/test_skills_extractor.py
@@ -61,12 +61,49 @@ def test_normalize_extracted_payload_parses_inline_strength_suffixes() -> None:
     extractor = SkillsExtractor()
 
     result = extractor._normalize_extracted_payload(
-        skills_value=["Python (4)", "code review ()", "TypeScript"],
+        skills_value=[
+            "Python (4)",
+            "Code Review (5)",
+            "Testing (3)",
+            "Code Quality (2)",
+            "UI/UX (4)",
+            "TypeScript",
+        ],
         skill_attrs_value=None,
         confidence=0.9,
         source="model",
     )
 
-    assert result.skills == ["code review", "python", "typescript"]
+    assert result.skills == ["python", "typescript", "ui ux"]
     assert result.skill_attrs["python"].strength == 4
-    assert "code review" not in result.skill_attrs
+    assert "code review" not in result.skills
+    assert "testing" not in result.skills
+    assert "code quality" not in result.skills
+
+
+def test_normalize_extracted_payload_keeps_ab_testing_and_ui_ux() -> None:
+    """Keep technology-like and product-specific terms while dropping broad generic terms."""
+    extractor = SkillsExtractor()
+
+    result = extractor._normalize_extracted_payload(
+        skills_value=["AB Testing", "UI/UX", "database optimization", "testing"],
+        skill_attrs_value={
+            "ab testing": {"strength": 5},
+            "ui/ux": {"strength": 4},
+            "testing": {"strength": 5},
+            "database optimization": {"strength": 3},
+        },
+        confidence=0.85,
+        source="model",
+    )
+
+    assert result.skills == [
+        "ab testing",
+        "database optimization",
+        "ui ux",
+    ]
+    assert result.skill_attrs["ab testing"].strength == 5
+    assert result.skill_attrs["ui ux"].strength == 4
+    assert result.skill_attrs["database optimization"].strength == 3
+    assert "testing" not in result.skills
+    assert "testing" not in result.skill_attrs


### PR DESCRIPTION
## Description\n- Add a resume skills denylist in worker skills extraction to exclude generic/low-signal terms from proposals and CRM updates.\n- Apply the denylist in both heuristic token extraction and LLM payload normalization for skills and skill_attrs.\n- Keep specific/product terms like `ab testing` and `ui ux` while dropping `testing`, `code quality`, `code review`, `debugging`, and `performance optimization`.\n- Add unit coverage for inline-strength parsing and normalization behavior with both disallowed and allowed terms.\n\n## Related Issue\n- None\n\n## How Has This Been Tested?\n- Pre-commit hooks ran during commit. Full test suite was not run in this session.
