### PR TITLE
feat(shared): reuse resume extractor in bot and worker

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -22,6 +22,7 @@ from discord.ext import commands
 from five08.discord_bot.config import settings
 from five08.clients import espo
 from five08.skills import normalize_skill_list
+from five08.resume_extractor import ResumeExtractedProfile, ResumeProfileExtractor
 from five08.discord_bot.utils.audit import DiscordAuditLogger
 from five08.discord_bot.utils.role_decorators import (
     require_role,
@@ -1107,6 +1108,12 @@ class CRMCog(commands.Cog):
         self.espo_api = EspoAPI(api_url, settings.espo_api_key)
         # Store base URL for profile links
         self.base_url = settings.espo_base_url.rstrip("/")
+        self.resume_extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.openai_model,
+        )
+        self._resume_profile_cache: tuple[int, ResumeExtractedProfile] | None = None
         self.audit_logger = DiscordAuditLogger(
             base_url=settings.audit_api_base_url,
             shared_secret=settings.api_shared_secret,
@@ -2883,52 +2890,51 @@ class CRMCog(commands.Cog):
             except aiohttp.ClientError as exc:
                 raise ValueError(f"Migadu API request failed: {exc}") from exc
 
-    def _extract_resume_contact_hints(
-        self, file_content: bytes
-    ) -> dict[str, list[str]]:
-        """Extract basic contact-identifying signals from resume bytes."""
-        text = file_content.decode("utf-8", errors="ignore")
-        if not text:
-            return {"emails": [], "github_usernames": [], "linkedin_urls": []}
-
-        # Keep this lightweight; heuristics are only used for contact targeting.
-        snippet = text[:12000]
-        email_re = re.compile(
-            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
-            flags=re.IGNORECASE,
-        )
-        github_re = re.compile(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            flags=re.IGNORECASE,
-        )
-        linkedin_re = re.compile(
-            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\\-_%]+/?",
-            flags=re.IGNORECASE,
-        )
-
-        email_matches: list[str] = []
-        for email in email_re.findall(snippet):
-            candidate = str(email).strip().lower()
-            if candidate and candidate not in email_matches:
-                email_matches.append(candidate)
-
-        github_matches: list[str] = []
-        for username in github_re.findall(snippet):
-            candidate = str(username).strip().lower()
-            if candidate and candidate not in github_matches:
-                github_matches.append(candidate)
-
-        linkedin_matches: list[str] = []
-        for linkedin_url in linkedin_re.findall(snippet):
-            candidate = str(linkedin_url).strip().lower().rstrip("/")
-            if candidate and candidate not in linkedin_matches:
-                linkedin_matches.append(candidate)
-
+    def _extract_resume_contact_hints(self, file_content: bytes) -> dict[str, Any]:
+        """Extract contact-identifying signals and shared resume fields from bytes."""
+        profile = self._extract_resume_profile(file_content)
         return {
-            "emails": email_matches,
-            "github_usernames": github_matches,
-            "linkedin_urls": linkedin_matches,
+            "emails": [profile.email] if profile.email else [],
+            "github_usernames": [profile.github_username]
+            if profile.github_username
+            else [],
+            "linkedin_urls": [profile.linkedin_url] if profile.linkedin_url else [],
+            "phone": profile.phone,
+            "name": profile.name,
+            "address_country": profile.address_country,
+            "seniority_level": profile.seniority_level,
+            "skills": profile.skills,
         }
+
+    def _extract_resume_profile(self, file_content: bytes) -> Any:
+        """Extract resume profile fields and cache per-file-content results."""
+        cache = self._resume_profile_cache
+        cache_key = hash(file_content)
+        if cache and cache[0] == cache_key:
+            return cache[1]
+
+        text = file_content.decode("utf-8", errors="ignore")
+        profile = self.resume_extractor.extract(text)
+        self._resume_profile_cache = (cache_key, profile)
+        return profile
+
+    def _extract_resume_name_fallback(self, file_content: bytes) -> str:
+        """Simple name heuristic fallback when extraction did not return a name."""
+        text = file_content.decode("utf-8", errors="ignore")
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        for line in lines[:40]:
+            candidate = line.strip()
+            if not candidate:
+                continue
+            if len(candidate) < 2:
+                continue
+            if "@" in candidate or "http" in candidate.lower():
+                continue
+            if not any(char.isalpha() for char in candidate):
+                continue
+            if len(candidate.split()) >= 1 and len(candidate) <= 70:
+                return candidate
+        return "Unknown Contact"
 
     def _format_inferred_attempts(self, attempts: list[dict[str, Any]] | None) -> str:
         if not attempts:
@@ -2948,23 +2954,11 @@ class CRMCog(commands.Cog):
 
     def _extract_resume_name_hint(self, file_content: bytes) -> str:
         """Best-effort contact name extraction from resume text."""
-        text = file_content.decode("utf-8", errors="ignore")
-        lines = [line.strip() for line in text.splitlines() if line.strip()]
-        for line in lines[:40]:
-            candidate = line.strip()
-            if not candidate:
-                continue
-            if len(candidate) < 2:
-                continue
-            if "@" in candidate or "http" in candidate.lower():
-                continue
-            if not any(char.isalpha() for char in candidate):
-                continue
-            # Prefer short, title-like lines at the top as candidate names.
-            if len(candidate.split()) >= 1 and len(candidate) <= 70:
-                return candidate
-
-        return "Unknown Contact"
+        hints = self._extract_resume_contact_hints(file_content)
+        extracted_name = str(hints.get("name") or "").strip()
+        if extracted_name:
+            return extracted_name
+        return self._extract_resume_name_fallback(file_content)
 
     def _build_resume_create_contact_payload(
         self, file_content: bytes
@@ -2973,18 +2967,45 @@ class CRMCog(commands.Cog):
         hints = self._extract_resume_contact_hints(file_content)
         name = self._extract_resume_name_hint(file_content)
         contact_name = name if name != "Unknown Contact" else "Resume Candidate"
+        emails = hints.get("emails", [])
+        github_usernames = hints.get("github_usernames", [])
+        linkedin_urls = hints.get("linkedin_urls", [])
+        skills = hints.get("skills", [])
+        if not isinstance(emails, list):
+            emails = []
+        if not isinstance(github_usernames, list):
+            github_usernames = []
+        if not isinstance(linkedin_urls, list):
+            linkedin_urls = []
+        if not isinstance(skills, list):
+            skills = []
 
         payload: dict[str, str] = {"name": contact_name}
-        if hints["emails"]:
-            primary_email = hints["emails"][0]
+        if emails:
+            primary_email = emails[0]
             if primary_email.endswith("@508.dev"):
                 payload["c508Email"] = primary_email
             else:
                 payload["emailAddress"] = primary_email
-        if hints["github_usernames"]:
-            payload["cGitHubUsername"] = hints["github_usernames"][0]
-        if hints["linkedin_urls"]:
-            payload["cLinkedInUrl"] = hints["linkedin_urls"][0]
+        if github_usernames:
+            payload["cGitHubUsername"] = github_usernames[0]
+        if linkedin_urls:
+            payload["cLinkedInUrl"] = linkedin_urls[0]
+        phone = hints.get("phone")
+        if isinstance(phone, str) and phone.strip():
+            payload["phoneNumber"] = phone.strip()
+        address_country = str(hints.get("address_country", "")).strip()
+        if address_country:
+            payload["addressCountry"] = address_country
+        seniority = str(hints.get("seniority_level", "")).strip()
+        if seniority:
+            payload["cSeniority"] = seniority
+        if skills:
+            normalized_skills = [
+                str(item).strip() for item in skills if str(item).strip()
+            ]
+            if normalized_skills:
+                payload["skills"] = ", ".join(normalized_skills)
 
         return payload
 
@@ -3050,7 +3071,10 @@ class CRMCog(commands.Cog):
         """Infer target contact from resume identifiers."""
         hints = self._extract_resume_contact_hints(file_content)
         attempts: list[dict[str, Any]] = []
-        for email in hints["emails"]:
+        emails = hints.get("emails", [])
+        if not isinstance(emails, list):
+            emails = []
+        for email in emails:
             attempts.append({"method": "email", "value": email})
             contacts = await self._search_contact_for_linking(email)
             if len(contacts) == 1:
@@ -3067,7 +3091,10 @@ class CRMCog(commands.Cog):
                     "attempts": attempts,
                 }
 
-        for github_username in hints["github_usernames"]:
+        github_usernames = hints.get("github_usernames", [])
+        if not isinstance(github_usernames, list):
+            github_usernames = []
+        for github_username in github_usernames:
             attempts.append({"method": "github", "value": github_username})
             contacts = await self._search_contacts_by_field(
                 field="cGitHubUsername", value=github_username
@@ -3086,7 +3113,10 @@ class CRMCog(commands.Cog):
                     "attempts": attempts,
                 }
 
-        for linkedin_url in hints["linkedin_urls"]:
+        linkedin_urls = hints.get("linkedin_urls", [])
+        if not isinstance(linkedin_urls, list):
+            linkedin_urls = []
+        for linkedin_url in linkedin_urls:
             attempts.append({"method": "linkedin", "value": linkedin_url})
             contacts = await self._search_contacts_by_field(
                 field="cLinkedInUrl", value=linkedin_url

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -32,6 +32,9 @@ class Settings(SharedSettings):
     migadu_api_user: str | None = None
     migadu_api_key: str | None = None
     migadu_mailbox_domain: str = "508.dev"
+    openai_api_key: str | None = None
+    openai_base_url: str | None = None
+    openai_model: str = "gpt-4o-mini"
 
     # Kimai time tracking settings
     kimai_base_url: str

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -12,9 +12,9 @@ from urllib.parse import urlsplit
 import requests
 
 from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.resume_extractor import ResumeProfileExtractor
 from five08.worker.config import settings
 from five08.worker.crm.document_processor import DocumentProcessor
-from five08.worker.crm.resume_profile_processor import ResumeProfileExtractor
 from five08.worker.crm.skills_extractor import SkillsExtractor
 from five08.worker.masking import mask_email
 
@@ -74,7 +74,11 @@ class IntakeFormProcessor:
         api_url = settings.espo_base_url.rstrip("/") + "/api/v1"
         self.api = EspoAPI(api_url, settings.espo_api_key)
         self.document_processor = DocumentProcessor()
-        self.resume_extractor = ResumeProfileExtractor()
+        self.resume_extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.resolved_resume_ai_model,
+        )
         self.skills_extractor = SkillsExtractor()
 
     def process_intake(self, *, payload: Mapping[str, Any]) -> dict[str, Any]:

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -61,6 +61,8 @@ SENIORITY_MAP = {
     "mid-level": "midlevel",
     "midlevel": "midlevel",
     "senior": "senior",
+    "principal": "staff",
+    "principal engineer": "staff",
     "staff": "staff",
     "staff and beyond": "staff",
     "staff+": "staff",

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -327,7 +327,7 @@ class IntakeFormProcessor:
         form_skill_attrs = self._build_form_skill_attrs(payload)
         if form_skill_attrs:
             updates["cSkillAttrs"] = json.dumps(form_skill_attrs)
-            updates["skills"] = ", ".join(sorted(form_skill_attrs.keys()))
+            updates["skills"] = sorted(form_skill_attrs.keys())
 
         submitted_at = self._normalize_text(payload.get("submitted_at"))
         completed_field = (settings.crm_intake_completed_field or "").strip()
@@ -351,7 +351,10 @@ class IntakeFormProcessor:
             strength = self._parse_skill_strength(normalized)
             if strength is None:
                 continue
-            skills[label] = {"strength": strength}
+            normalized_label = self.skills_extractor.canonicalize_skill(label)
+            if not normalized_label:
+                continue
+            skills[normalized_label] = {"strength": strength}
         return skills
 
     def _build_description(self, payload: Mapping[str, Any]) -> str | None:
@@ -413,7 +416,7 @@ class IntakeFormProcessor:
             parsed_attrs = self._parse_skill_attrs(extracted_skills.skill_attrs)
             if parsed_attrs:
                 updates["cSkillAttrs"] = json.dumps(parsed_attrs)
-                updates["skills"] = ", ".join(sorted(parsed_attrs.keys()))
+                updates["skills"] = sorted(parsed_attrs.keys())
         except Exception as exc:
             logger.warning("Resume skill extraction failed: %s", exc)
         return updates
@@ -449,7 +452,7 @@ class IntakeFormProcessor:
         if attrs is None:
             return parsed
         for raw_name, raw_attr in attrs.items():
-            normalized_name = self._normalize_text(raw_name)
+            normalized_name = self.skills_extractor.canonicalize_skill(str(raw_name))
             if not normalized_name:
                 continue
             strength = raw_attr

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -482,7 +482,7 @@ class IntakeFormProcessor:
             return "midlevel"
         if "junior" in normalized:
             return "junior"
-        return None
+        return "unknown"
 
     def _normalize_text(self, value: object) -> str | None:
         if not isinstance(value, str):

--- a/apps/worker/src/five08/worker/crm/processor.py
+++ b/apps/worker/src/five08/worker/crm/processor.py
@@ -18,6 +18,7 @@ class EspoCRMClient:
     def __init__(self) -> None:
         api_url = settings.espo_base_url.rstrip("/") + "/api/v1"
         self.api = EspoAPI(api_url, settings.espo_api_key)
+        self.skills_extractor = SkillsExtractor()
 
     def get_contact(self, contact_id: str) -> ContactData:
         try:
@@ -45,8 +46,19 @@ class EspoCRMClient:
 
     def update_contact_skills(self, contact_id: str, skills: list[str]) -> bool:
         try:
-            skills_text = ", ".join(skills)
-            self.api.request("PATCH", f"Contact/{contact_id}", {"skills": skills_text})
+            normalized: list[str] = []
+            seen: set[str] = set()
+            for raw_skill in skills:
+                canonical = self.skills_extractor.canonicalize_skill(str(raw_skill))
+                if not canonical:
+                    continue
+                key = canonical.casefold()
+                if key in seen:
+                    continue
+                seen.add(key)
+                normalized.append(canonical)
+
+            self.api.request("PATCH", f"Contact/{contact_id}", {"skills": normalized})
             return True
         except EspoAPIError as exc:
             logger.error("Error updating contact %s skills: %s", contact_id, exc)
@@ -176,9 +188,12 @@ class ContactSkillsProcessor:
 
         deduped_skills: dict[str, str] = {}
         for skill in all_skills:
-            key = skill.casefold()
+            canonical = self.skills_extractor.canonicalize_skill(str(skill))
+            if not canonical:
+                continue
+            key = canonical.casefold()
             if key not in deduped_skills:
-                deduped_skills[key] = skill
+                deduped_skills[key] = canonical
 
         unique_skills = sorted(deduped_skills.values())
         avg_confidence = confidence_sum / processed_count if processed_count else 0.0

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -217,6 +217,15 @@ class ResumeProfileProcessor:
     ) -> ResumeApplyResult:
         """Apply confirmed updates to contact in CRM."""
         try:
+            normalized_updates = dict(updates)
+            if "skills" in normalized_updates:
+                normalized_skills = self._coerce_skills_updates(
+                    normalized_updates["skills"]
+                )
+                if normalized_skills:
+                    normalized_updates["skills"] = normalized_skills
+                else:
+                    normalized_updates.pop("skills", None)
             allowed_fields = {
                 "emailAddress",
                 "cGitHubUsername",
@@ -226,7 +235,7 @@ class ResumeProfileProcessor:
             }
             sanitized_updates: dict[str, Any] = {
                 field: value
-                for field, value in updates.items()
+                for field, value in normalized_updates.items()
                 if field in allowed_fields and value
             }
 
@@ -367,6 +376,28 @@ class ResumeProfileProcessor:
         if isinstance(value, bool):
             return str(value).lower()
         return str(value).strip()
+
+    @staticmethod
+    def _coerce_skills_updates(value: Any) -> list[str]:
+        if isinstance(value, (list, tuple, set)):
+            raw_skills = [item for item in value]
+        elif isinstance(value, str):
+            raw_skills = [item.strip() for item in value.split(",") if item.strip()]
+        else:
+            return []
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw_skill in raw_skills:
+            skill = str(raw_skill).strip()
+            if not skill:
+                continue
+            key = skill.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(skill)
+        return normalized
 
     def _verify_updated_fields(
         self,

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -594,7 +594,7 @@ class ResumeProfileProcessor:
             return None
         normalized = value.strip().lower().replace("_", "-")
         if not normalized:
-            return None
+            return "unknown"
         if normalized in {
             "jr",
             "junior",
@@ -630,7 +630,7 @@ class ResumeProfileProcessor:
             return "senior"
         if normalized.startswith("lead "):
             return "senior"
-        return None
+        return "unknown"
 
     def _format_skills_with_strength(
         self,

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -75,15 +75,25 @@ class ResumeProfileProcessor:
             model_name = extracted.source
             extracted_skills_result = self.skills_extractor.extract_skills(text)
             extracted_skills = extracted_skills_result.skills
+            normalized_extracted_skills = [
+                normalized_skill
+                for skill in extracted_skills
+                if (normalized_skill := self.skills_extractor.canonicalize_skill(skill))
+            ]
             existing_skills = self._parse_existing_skills(contact.get("skills"))
             existing_skill_attrs = self._parse_skill_attrs(contact.get("cSkillAttrs"))
+            existing_websites = self._coerce_website_links(contact.get("cWebsiteLink"))
             existing_lower = {item.casefold() for item in existing_skills}
             new_skills = [
                 skill
-                for skill in extracted_skills
+                for skill in normalized_extracted_skills
                 if skill.casefold() not in existing_lower
             ]
-            merged_skills = existing_skills + new_skills
+            merged_skills = list(dict.fromkeys(existing_skills + new_skills))
+            merged_websites = self._merge_website_links(
+                existing=existing_websites,
+                extracted=extracted.website_links,
+            )
             merged_skill_attrs = self._merge_skill_attrs(
                 existing_attrs=existing_skill_attrs,
                 extracted_attrs=extracted_skills_result.skill_attrs,
@@ -134,6 +144,12 @@ class ResumeProfileProcessor:
             )
             if new_skills:
                 proposed_updates["skills"] = merged_skills
+                if merged_skill_attrs:
+                    skill_attrs_payload = self._serialize_skill_attrs(
+                        merged_skill_attrs
+                    )
+                    if skill_attrs_payload:
+                        proposed_updates["cSkillAttrs"] = skill_attrs_payload
                 proposed_changes.append(
                     ResumeFieldChange(
                         field="skills",
@@ -149,6 +165,18 @@ class ResumeProfileProcessor:
                             merged_skills, merged_skill_attrs
                         ),
                         reason="Added skills from resume extraction",
+                    )
+                )
+
+            if merged_websites != existing_websites:
+                proposed_updates["cWebsiteLink"] = merged_websites
+                proposed_changes.append(
+                    ResumeFieldChange(
+                        field="cWebsiteLink",
+                        label="Website",
+                        current=", ".join(existing_websites),
+                        proposed=", ".join(merged_websites),
+                        reason="Extracted from uploaded resume",
                     )
                 )
 
@@ -217,7 +245,26 @@ class ResumeProfileProcessor:
     ) -> ResumeApplyResult:
         """Apply confirmed updates to contact in CRM."""
         try:
+            candidate_email = None
             normalized_updates = dict(updates)
+
+            pre_update_contact: dict[str, Any] | None = None
+            try:
+                pre_update_contact = self.crm.get_contact(contact_id)
+            except Exception as exc:
+                logger.debug(
+                    "Failed to read pre-update contact for verification contact_id=%s: %s",
+                    contact_id,
+                    exc,
+                )
+
+            if "emailAddress" in normalized_updates:
+                candidate_email = self._normalize_email_address(
+                    normalized_updates.get("emailAddress")
+                )
+            if "emailAddress" in normalized_updates:
+                normalized_updates.pop("emailAddress", None)
+
             if "skills" in normalized_updates:
                 normalized_skills = self._coerce_skills_updates(
                     normalized_updates["skills"]
@@ -226,24 +273,64 @@ class ResumeProfileProcessor:
                     normalized_updates["skills"] = normalized_skills
                 else:
                     normalized_updates.pop("skills", None)
+
+            if "cSkillAttrs" in normalized_updates:
+                serialized_attrs = self._coerce_skill_attrs_updates(
+                    normalized_updates["cSkillAttrs"]
+                )
+                if serialized_attrs:
+                    normalized_updates["cSkillAttrs"] = serialized_attrs
+                else:
+                    normalized_updates.pop("cSkillAttrs", None)
+
+            if "cWebsiteLink" in normalized_updates:
+                normalized_websites = self._coerce_website_links(
+                    normalized_updates["cWebsiteLink"]
+                )
+                if normalized_websites:
+                    normalized_updates["cWebsiteLink"] = normalized_websites
+                else:
+                    normalized_updates.pop("cWebsiteLink", None)
+
+            if candidate_email is not None:
+                if candidate_email.endswith("@508.dev"):
+                    candidate_email = None
+                else:
+                    existing_email_data = (
+                        pre_update_contact.get("emailAddressData")
+                        if pre_update_contact
+                        else None
+                    )
+                    email_address_data = self._build_email_address_data(
+                        email_candidate=candidate_email,
+                        existing_email_data=existing_email_data,
+                    )
+                    if email_address_data:
+                        normalized_updates["emailAddressData"] = email_address_data
+
+            if "emailAddressData" in normalized_updates:
+                normalized_email_data = self._coerce_email_address_data(
+                    normalized_updates["emailAddressData"]
+                )
+                if normalized_email_data is not None:
+                    normalized_updates["emailAddressData"] = normalized_email_data
+                else:
+                    normalized_updates.pop("emailAddressData", None)
+
             allowed_fields = {
-                "emailAddress",
+                "emailAddressData",
                 "cGitHubUsername",
                 settings.crm_linkedin_field,
                 "phoneNumber",
                 "skills",
+                "cSkillAttrs",
+                "cWebsiteLink",
             }
             sanitized_updates: dict[str, Any] = {
                 field: value
                 for field, value in normalized_updates.items()
                 if field in allowed_fields and value
             }
-
-            email_value = sanitized_updates.get("emailAddress")
-            if isinstance(email_value, str) and email_value.lower().endswith(
-                "@508.dev"
-            ):
-                sanitized_updates.pop("emailAddress")
 
             if not sanitized_updates:
                 return ResumeApplyResult(
@@ -264,14 +351,12 @@ class ResumeProfileProcessor:
                     )
                     link_applied = True
 
-            pre_update_contact: dict[str, Any] | None = None
-            try:
-                pre_update_contact = self.crm.get_contact(contact_id)
-            except Exception as exc:
-                logger.debug(
-                    "Failed to read pre-update contact for verification contact_id=%s: %s",
-                    contact_id,
-                    exc,
+            if not sanitized_updates:
+                return ResumeApplyResult(
+                    contact_id=contact_id,
+                    updated_fields=[],
+                    success=False,
+                    error="No valid profile fields provided",
                 )
 
             try:
@@ -566,6 +651,221 @@ class ResumeProfileProcessor:
                 merged[key] = max(1, min(5, int(attrs.strength)))
 
         return merged
+
+    def _coerce_skill_attrs_updates(self, value: Any) -> str | None:
+        if value is None:
+            return None
+
+        candidate = value
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return None
+            try:
+                candidate = json.loads(raw)
+            except Exception:
+                return None
+
+        if not isinstance(candidate, dict):
+            return None
+
+        parsed: dict[str, int] = {}
+        for raw_skill, raw_payload in candidate.items():
+            skill = self.skills_extractor.canonicalize_skill(str(raw_skill))
+            if not skill:
+                continue
+            strength_source = raw_payload
+            if isinstance(raw_payload, dict):
+                strength_source = raw_payload.get("strength")
+            try:
+                strength = int(float(strength_source))
+            except Exception:
+                continue
+            if not 1 <= strength <= 5:
+                continue
+            parsed[skill] = strength
+
+        return self._serialize_skill_attrs(parsed)
+
+    def _serialize_skill_attrs(self, attrs: dict[str, int]) -> str | None:
+        normalized: dict[str, dict[str, int]] = {}
+        for raw_skill, raw_strength in attrs.items():
+            skill = self.skills_extractor.canonicalize_skill(str(raw_skill))
+            if not skill:
+                continue
+            try:
+                strength = int(float(raw_strength))
+            except Exception:
+                continue
+            clamped = max(1, min(5, strength))
+            normalized[skill] = {"strength": clamped}
+        if not normalized:
+            return None
+        return json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+
+    def _coerce_website_links(self, value: Any) -> list[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            raw_values = [item for item in value.split(",") if item.strip()]
+        elif isinstance(value, (list, tuple, set)):
+            raw_values = list(value)
+        else:
+            return []
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw_value in raw_values:
+            if not isinstance(raw_value, str):
+                continue
+            candidate = raw_value.strip().rstrip(")]},.;:")
+            if not candidate:
+                continue
+            if candidate.lower().startswith("www."):
+                candidate = f"https://{candidate}"
+            if not candidate.startswith(("http://", "https://")):
+                continue
+            if "@" in candidate:
+                continue
+            dedupe_key = candidate.casefold()
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            normalized.append(candidate.rstrip("/"))
+
+        return normalized
+
+    def _merge_website_links(
+        self, *, existing: list[str], extracted: list[str]
+    ) -> list[str]:
+        merged: list[str] = []
+        seen: set[str] = set()
+
+        for value in existing:
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip().rstrip("/")
+            if not normalized:
+                continue
+            dedupe_key = normalized.casefold()
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            merged.append(normalized)
+
+        for value in extracted:
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip().rstrip("/")
+            if not normalized:
+                continue
+            dedupe_key = normalized.casefold()
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            merged.append(normalized)
+
+        return merged
+
+    def _normalize_email_address(self, value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower()
+        if not normalized or "@" not in normalized:
+            return None
+        return normalized
+
+    @staticmethod
+    def _coerce_bool(value: Any) -> bool:
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    def _coerce_email_address_data(self, value: Any) -> list[dict[str, Any]] | None:
+        parsed = self._parse_email_address_data(value)
+        return parsed if parsed else None
+
+    def _parse_email_address_data(self, value: Any) -> list[dict[str, Any]]:
+        if value is None:
+            return []
+
+        candidate = value
+        if isinstance(value, str):
+            raw = value.strip()
+            if not raw:
+                return []
+            try:
+                candidate = json.loads(raw)
+            except Exception:
+                return []
+
+        if not isinstance(candidate, list):
+            if isinstance(candidate, dict):
+                candidate = [candidate]
+            else:
+                return []
+
+        parsed: list[dict[str, Any]] = []
+        for entry in candidate:
+            if not isinstance(entry, dict):
+                continue
+            raw_email = str(
+                entry.get("lower")
+                or entry.get("emailAddress")
+                or entry.get("email")
+                or ""
+            ).strip()
+            normalized_email = self._normalize_email_address(raw_email)
+            if normalized_email is None:
+                continue
+
+            parsed.append(
+                {
+                    "emailAddress": str(
+                        entry.get("emailAddress", normalized_email)
+                    ).strip(),
+                    "lower": normalized_email,
+                    "primary": self._coerce_bool(entry.get("primary")),
+                    "optOut": self._coerce_bool(entry.get("optOut")),
+                    "invalid": self._coerce_bool(entry.get("invalid")),
+                }
+            )
+
+        return parsed
+
+    def _build_email_address_data(
+        self,
+        *,
+        email_candidate: str,
+        existing_email_data: Any,
+    ) -> list[dict[str, Any]]:
+        merged: dict[str, dict[str, Any]] = {}
+
+        for entry in self._parse_email_address_data(existing_email_data):
+            merged[entry["lower"]] = entry
+            merged[entry["lower"]]["emailAddress"] = (
+                str(entry.get("emailAddress", entry["lower"])).strip().lower()
+            )
+
+        candidate_lower = self._normalize_email_address(email_candidate)
+        if candidate_lower is None:
+            return list(merged.values())
+
+        for _, entry in merged.items():
+            entry["primary"] = False
+
+        merged[candidate_lower] = {
+            "emailAddress": candidate_lower,
+            "lower": candidate_lower,
+            "primary": True,
+            "optOut": False,
+            "invalid": False,
+        }
+
+        return list(merged.values())
 
     def _mark_resume_processed(self, contact_id: str) -> None:
         """Best-effort update for extraction completion tracking."""

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
 from five08.clients.espo import EspoAPI, EspoAPIError
+from five08.resume_extractor import ResumeProfileExtractor
 from five08.queue import get_postgres_connection
 from five08.worker.config import settings
 from five08.worker.crm.document_processor import DocumentProcessor
@@ -24,11 +24,6 @@ from five08.worker.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-try:  # pragma: no cover - import success depends on environment
-    from openai import OpenAI as OpenAIClient
-except Exception:  # pragma: no cover
-    OpenAIClient = None  # type: ignore[misc,assignment]
 
 
 class ResumeEspoClient:
@@ -48,196 +43,16 @@ class ResumeEspoClient:
         self.api.request("PUT", f"Contact/{contact_id}", updates)
 
 
-class ResumeProfileExtractor:
-    """Extract candidate profile fields from resume text."""
-
-    def __init__(self) -> None:
-        self.model = settings.resolved_resume_ai_model
-        self.client: Any = None
-
-        if settings.openai_api_key and OpenAIClient is not None:
-            self.client = OpenAIClient(
-                api_key=settings.openai_api_key,
-                base_url=settings.openai_base_url,
-            )
-
-    def extract(self, resume_text: str) -> ResumeExtractedProfile:
-        """Return extracted fields from resume text."""
-        if self.client is None:
-            return self._heuristic_extract(resume_text)
-
-        try:
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You extract candidate contact fields from resumes for a CRM. "
-                            "Return JSON only with no commentary. Be conservative: when unsure, use null. "
-                            "Prefer candidate-owned contact info and ignore references or company contact details."
-                        ),
-                    },
-                    {
-                        "role": "user",
-                        "content": self._build_prompt(resume_text),
-                    },
-                ],
-                temperature=0.1,
-                max_tokens=800,
-            )
-            raw_content = response.choices[0].message.content
-            if not raw_content:
-                raise ValueError("LLM returned empty content")
-
-            parsed = self._parse_json(raw_content)
-            return ResumeExtractedProfile(
-                email=self._normalize_email(parsed.get("email")),
-                github_username=self._normalize_github(parsed.get("github_username")),
-                linkedin_url=self._normalize_linkedin(parsed.get("linkedin_url")),
-                phone=self._normalize_phone(parsed.get("phone")),
-                confidence=self._bounded_confidence(parsed.get("confidence", 0.75)),
-                source=self.model,
-            )
-        except Exception as exc:
-            logger.warning("LLM resume extraction failed, using fallback: %s", exc)
-            return self._heuristic_extract(resume_text)
-
-    def _heuristic_extract(self, resume_text: str) -> ResumeExtractedProfile:
-        email_match = re.search(
-            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b", resume_text
-        )
-        github_match = re.search(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            resume_text,
-            flags=re.IGNORECASE,
-        )
-        linkedin_match = re.search(
-            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\-_%]+/?",
-            resume_text,
-            flags=re.IGNORECASE,
-        )
-        phone_match = re.search(
-            r"(?:\+?\d[\d\s().-]{7,}\d)",
-            resume_text,
-        )
-
-        github_value: str | None = None
-        if github_match:
-            github_value = github_match.group(1)
-
-        linkedin_value: str | None = None
-        if linkedin_match:
-            linkedin_value = linkedin_match.group(0)
-
-        phone_value: str | None = None
-        if phone_match:
-            phone_value = phone_match.group(0)
-
-        return ResumeExtractedProfile(
-            email=self._normalize_email(email_match.group(0) if email_match else None),
-            github_username=self._normalize_github(github_value),
-            linkedin_url=self._normalize_linkedin(linkedin_value),
-            phone=self._normalize_phone(phone_value),
-            confidence=0.45,
-            source="heuristic",
-        )
-
-    def _build_prompt(self, resume_text: str) -> str:
-        snippet = resume_text[:12000]
-        return (
-            "Extract candidate contact fields from this resume.\n"
-            "Return JSON with exact keys and no extras:\n"
-            '{"email": string|null, "github_username": string|null, '
-            '"linkedin_url": string|null, "phone": string|null, '
-            '"confidence": number}\n'
-            "Rules:\n"
-            "- prefer explicit values from header/contact sections\n"
-            "- for github_username return username only (no URL, no @)\n"
-            "- for linkedin_url return full linkedin profile URL when available\n"
-            "- for phone return digits with optional leading +\n"
-            "- use null for unknown/ambiguous fields\n"
-            "- confidence is 0-1 for overall extraction reliability\n\n"
-            f"Resume:\n{snippet}"
-        )
-
-    def _parse_json(self, content: str) -> dict[str, Any]:
-        raw = content.strip()
-        if raw.startswith("```"):
-            lines = [line for line in raw.splitlines() if not line.startswith("```")]
-            raw = "\n".join(lines).strip()
-
-        parsed = json.loads(raw)
-        if not isinstance(parsed, dict):
-            raise ValueError("Model output was not a JSON object")
-        return parsed
-
-    def _bounded_confidence(self, value: Any) -> float:
-        try:
-            numeric = float(value)
-        except Exception:
-            numeric = 0.0
-        return max(0.0, min(1.0, numeric))
-
-    def _normalize_email(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        normalized = value.strip().lower()
-        return normalized or None
-
-    def _normalize_github(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        github_match = re.search(
-            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
-            candidate,
-            flags=re.IGNORECASE,
-        )
-        if github_match:
-            candidate = github_match.group(1)
-
-        candidate = candidate.lstrip("@").strip().strip("/")
-        return candidate or None
-
-    def _normalize_linkedin(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        if "linkedin.com" not in candidate.lower():
-            return None
-        if not candidate.lower().startswith(("http://", "https://")):
-            candidate = f"https://{candidate}"
-        return candidate.rstrip("/")
-
-    def _normalize_phone(self, value: Any) -> str | None:
-        if not isinstance(value, str):
-            return None
-        candidate = value.strip()
-        if not candidate:
-            return None
-
-        digits = re.sub(r"\D", "", candidate)
-        if len(digits) < 7:
-            return None
-
-        if candidate.startswith("+"):
-            return "+" + digits
-        return digits
-
-
 class ResumeProfileProcessor:
     """End-to-end extraction and apply operations for uploaded resumes."""
 
     def __init__(self) -> None:
         self.crm = ResumeEspoClient()
-        self.extractor = ResumeProfileExtractor()
+        self.extractor = ResumeProfileExtractor(
+            api_key=settings.openai_api_key,
+            base_url=settings.openai_base_url,
+            model=settings.resolved_resume_ai_model,
+        )
         self.skills_extractor = SkillsExtractor()
         self.document_processor = DocumentProcessor()
 

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -389,7 +389,7 @@ class ResumeProfileProcessor:
         normalized: list[str] = []
         seen: set[str] = set()
         for raw_skill in raw_skills:
-            skill = str(raw_skill).strip()
+            skill = str(raw_skill).strip().casefold()
             if not skill:
                 continue
             key = skill.casefold()

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -75,11 +75,9 @@ class ResumeProfileProcessor:
             model_name = extracted.source
             extracted_skills_result = self.skills_extractor.extract_skills(text)
             extracted_skills = extracted_skills_result.skills
-            normalized_extracted_skills = [
-                normalized_skill
-                for skill in extracted_skills
-                if (normalized_skill := self.skills_extractor.canonicalize_skill(skill))
-            ]
+            normalized_extracted_skills = self._dedupe_normalized_skills(
+                extracted_skills
+            )
             existing_skills = self._parse_existing_skills(contact.get("skills"))
             existing_skill_attrs = self._parse_skill_attrs(contact.get("cSkillAttrs"))
             existing_websites = self._coerce_website_links(contact.get("cWebsiteLink"))
@@ -89,7 +87,7 @@ class ResumeProfileProcessor:
                 for skill in normalized_extracted_skills
                 if skill.casefold() not in existing_lower
             ]
-            merged_skills = list(dict.fromkeys(existing_skills + new_skills))
+            merged_skills = self._dedupe_normalized_skills(existing_skills + new_skills)
             merged_websites = self._merge_website_links(
                 existing=existing_websites,
                 extracted=extracted.website_links,
@@ -138,6 +136,15 @@ class ResumeProfileProcessor:
                 label="Phone",
                 current=contact.get("phoneNumber"),
                 proposed=extracted.phone,
+                proposed_updates=proposed_updates,
+                proposed_changes=proposed_changes,
+                skipped=skipped,
+            )
+            self._collect_change(
+                crm_field="cSeniority",
+                label="Seniority",
+                current=self._normalize_seniority(contact.get("cSeniority")),
+                proposed=self._normalize_seniority(extracted.seniority_level),
                 proposed_updates=proposed_updates,
                 proposed_changes=proposed_changes,
                 skipped=skipped,
@@ -317,10 +324,18 @@ class ResumeProfileProcessor:
                 else:
                     normalized_updates.pop("emailAddressData", None)
 
+            if "cSeniority" in normalized_updates:
+                normalized_updates["cSeniority"] = self._normalize_seniority(
+                    normalized_updates.get("cSeniority")
+                )
+                if not normalized_updates["cSeniority"]:
+                    normalized_updates.pop("cSeniority", None)
+
             allowed_fields = {
                 "emailAddressData",
                 "cGitHubUsername",
                 settings.crm_linkedin_field,
+                "cSeniority",
                 "phoneNumber",
                 "skills",
                 "cSkillAttrs",
@@ -462,8 +477,7 @@ class ResumeProfileProcessor:
             return str(value).lower()
         return str(value).strip()
 
-    @staticmethod
-    def _coerce_skills_updates(value: Any) -> list[str]:
+    def _coerce_skills_updates(self, value: Any) -> list[str]:
         if isinstance(value, (list, tuple, set)):
             raw_skills = [item for item in value]
         elif isinstance(value, str):
@@ -474,7 +488,7 @@ class ResumeProfileProcessor:
         normalized: list[str] = []
         seen: set[str] = set()
         for raw_skill in raw_skills:
-            skill = str(raw_skill).strip().casefold()
+            skill = self.skills_extractor.canonicalize_skill(str(raw_skill).strip())
             if not skill:
                 continue
             key = skill.casefold()
@@ -566,31 +580,66 @@ class ResumeProfileProcessor:
 
         if isinstance(value, list):
             raw_skills = [str(item).strip() for item in value if str(item).strip()]
+        elif isinstance(value, (tuple, set)):
+            raw_skills = [str(item).strip() for item in value if str(item).strip()]
         else:
             raw_skills = [
                 item.strip() for item in str(value).split(",") if item.strip()
             ]
+        return self._dedupe_normalized_skills(raw_skills)
 
-        normalized: list[str] = []
-        seen: set[str] = set()
-        for skill in raw_skills:
-            canonical = self.skills_extractor.canonicalize_skill(skill)
-            if not canonical:
-                continue
-            key = canonical.casefold()
-            if key in seen:
-                continue
-            seen.add(key)
-            normalized.append(canonical)
-        return normalized
+    @staticmethod
+    def _normalize_seniority(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        normalized = value.strip().lower().replace("_", "-")
+        if not normalized:
+            return None
+        if normalized in {
+            "jr",
+            "junior",
+            "intern",
+            "internship",
+            "entry",
+            "entry-level",
+            "entry level",
+        }:
+            return "junior"
+        if normalized in {"mid", "mid-level", "midlevel", "intermediate"}:
+            return "midlevel"
+        if normalized in {
+            "senior",
+            "sr",
+            "sr. engineer",
+            "senior engineer",
+            "lead",
+            "lead engineer",
+            "lead engineer/tech lead",
+            "tech lead",
+        }:
+            return "senior"
+        if normalized in {
+            "staff",
+            "staff+",
+            "staff and beyond",
+            "principal",
+            "principal engineer",
+        }:
+            return "staff"
+        if "lead " in normalized and "engineer" in normalized:
+            return "senior"
+        if normalized.startswith("lead "):
+            return "senior"
+        return None
 
     def _format_skills_with_strength(
         self,
         skills: list[str],
         attrs: dict[str, int],
     ) -> str:
+        deduped_skills = self._dedupe_normalized_skills(skills)
         formatted: list[str] = []
-        for raw_skill in skills:
+        for raw_skill in deduped_skills:
             skill = raw_skill.strip()
             if not skill:
                 continue
@@ -600,6 +649,30 @@ class ResumeProfileProcessor:
             else:
                 formatted.append(skill)
         return ", ".join(formatted)
+
+    def _dedupe_normalized_skills(self, value: Any) -> list[str]:
+        if value is None:
+            return []
+
+        if isinstance(value, str):
+            raw_skills = [item.strip() for item in value.split(",") if item.strip()]
+        elif isinstance(value, (list, tuple, set)):
+            raw_skills = [str(item).strip() for item in value if str(item).strip()]
+        else:
+            return []
+
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for raw_skill in raw_skills:
+            canonical = self.skills_extractor.canonicalize_skill(raw_skill)
+            if not canonical:
+                continue
+            key = canonical.casefold()
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(canonical)
+        return normalized
 
     def _parse_skill_attrs(self, value: Any) -> dict[str, int]:
         if value is None:
@@ -646,7 +719,10 @@ class ResumeProfileProcessor:
         merged: dict[str, int] = dict(existing_attrs)
 
         for skill, attrs in extracted_attrs.items():
-            key = str(skill).strip().casefold()
+            key = self.skills_extractor.canonicalize_skill(str(skill).strip())
+            if not key:
+                continue
+            key = key.casefold()
             if key:
                 merged[key] = max(1, min(5, int(attrs.strength)))
 

--- a/apps/worker/src/five08/worker/models.py
+++ b/apps/worker/src/five08/worker/models.py
@@ -4,6 +4,9 @@ from datetime import datetime
 from typing import Literal
 from typing import Any
 
+from five08.resume_extractor import (
+    ResumeExtractedProfile as SharedResumeExtractedProfile,
+)
 from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 
@@ -64,15 +67,7 @@ class SkillsExtractionResult(BaseModel):
     error: str | None = None
 
 
-class ResumeExtractedProfile(BaseModel):
-    """Normalized profile fields extracted from resume text."""
-
-    email: str | None = None
-    github_username: str | None = None
-    linkedin_url: str | None = None
-    phone: str | None = None
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    source: str
+ResumeExtractedProfile = SharedResumeExtractedProfile
 
 
 class ResumeFieldChange(BaseModel):

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -123,7 +123,7 @@ def _normalize_seniority(value: Any) -> str | None:
         return None
     normalized = value.strip().lower()
     if not normalized:
-        return None
+        return "unknown"
     if normalized in {"jr", "junior", "entry", "entry-level", "entry level"}:
         return "junior"
     if normalized in {"intern", "internship"}:
@@ -149,7 +149,7 @@ def _normalize_seniority(value: Any) -> str | None:
         return "staff"
     if normalized.startswith("sr "):
         return "senior"
-    return None
+    return "unknown"
 
 
 def _normalize_skills(value: Any) -> list[str]:
@@ -275,6 +275,7 @@ class ResumeProfileExtractor:
                 seniority_level=(
                     _normalize_seniority(parsed.get("seniority_level"))
                     or self._infer_seniority_from_resume(resume_text)
+                    or "unknown"
                 ),
                 skills=_normalize_skills(parsed.get("skills")),
                 confidence=_bounded_confidence(
@@ -352,7 +353,7 @@ class ResumeProfileExtractor:
             "  - +1 for leadership titles (staff/lead/principal/architect)\n"
             "  - +1 for enterprise-scale impact signals (team ownership, direct reports, cross-team work, large org terms)\n"
             "  - when company signal is ambiguous, return conservative midlevel\n"
-            "- use null for unknown or ambiguous fields\n"
+            "- use 'unknown' for unknown or ambiguous fields\n"
             "- confidence is 0-1 for overall extraction reliability\n\n"
             f"Resume:\n{snippet}"
         )
@@ -398,7 +399,7 @@ class ResumeProfileExtractor:
         if inferred:
             return inferred
 
-        return None
+        return "unknown"
 
     @staticmethod
     def _infer_seniority_from_resume(resume_text: str) -> str | None:

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -83,6 +83,40 @@ def _normalize_country(value: Any) -> str | None:
     return normalized.title() if normalized else None
 
 
+def _normalize_website_links(value: Any) -> list[str]:
+    if value is None:
+        return []
+
+    if isinstance(value, str):
+        raw_values = [value]
+    elif isinstance(value, (list, tuple)):
+        raw_values = list(value)
+    else:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_value in raw_values:
+        if not isinstance(raw_value, str):
+            continue
+        candidate = raw_value.strip().strip(")]},.;:")
+        if not candidate:
+            continue
+        if candidate.lower().startswith("www."):
+            candidate = f"https://{candidate}"
+        if not candidate.startswith(("http://", "https://")):
+            continue
+        if "@" in candidate:
+            continue
+        lower = candidate.lower()
+        if lower in seen:
+            continue
+        seen.add(lower)
+        normalized.append(candidate.rstrip("/"))
+
+    return normalized
+
+
 def _normalize_seniority(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -151,6 +185,7 @@ class ResumeExtractedProfile(BaseModel):
     github_username: str | None = None
     linkedin_url: str | None = None
     phone: str | None = None
+    website_links: list[str] = Field(default_factory=list)
     address_country: str | None = None
     seniority_level: str | None = None
     skills: list[str] = Field(default_factory=list)
@@ -219,6 +254,7 @@ class ResumeProfileExtractor:
                 github_username=_normalize_github(parsed.get("github_username")),
                 linkedin_url=_normalize_linkedin(parsed.get("linkedin_url")),
                 phone=_normalize_phone(parsed.get("phone")),
+                website_links=_normalize_website_links(parsed.get("website_links")),
                 address_country=_normalize_country(parsed.get("address_country")),
                 seniority_level=_normalize_seniority(parsed.get("seniority_level")),
                 skills=_normalize_skills(parsed.get("skills")),
@@ -266,6 +302,7 @@ class ResumeProfileExtractor:
                 _normalize_linkedin(linkedin_match.group(0)) if linkedin_match else None
             ),
             phone=_normalize_phone(phone_match.group(0)) if phone_match else None,
+            website_links=self._extract_website_links(snippet),
             address_country=country,
             seniority_level=seniority,
             skills=skills,
@@ -280,7 +317,8 @@ class ResumeProfileExtractor:
             "Return JSON with exact keys and no extras:\n"
             '{"name": string|null, "email": string|null, '
             '"github_username": string|null, "linkedin_url": string|null, '
-            '"phone": string|null, "address_country": string|null, '
+            '"phone": string|null, "website_links": string[]|null, '
+            '"address_country": string|null, '
             '"seniority_level": string|null, "skills": string[]|null, '
             '"confidence": number}\n'
             "Rules:\n"
@@ -344,3 +382,10 @@ class ResumeProfileExtractor:
         if first_line:
             return _normalize_skills(first_line)
         return []
+
+    @staticmethod
+    def _extract_website_links(resume_text: str) -> list[str]:
+        matches = re.findall(
+            r"https?://[^\s\]\[()\"<>]+", resume_text, flags=re.IGNORECASE
+        )
+        return _normalize_website_links(matches)

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -1,0 +1,346 @@
+"""Shared resume text extraction utilities for candidate fields."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+try:
+    from openai import OpenAI as OpenAIClient
+except Exception:  # pragma: no cover
+    OpenAIClient = None  # type: ignore[misc,assignment]
+
+
+def _bounded_confidence(value: Any, fallback: float) -> float:
+    """Clamp confidence values to [0, 1]."""
+    try:
+        parsed = float(value)
+    except Exception:
+        return fallback
+    return max(0.0, min(1.0, parsed))
+
+
+def _normalize_email(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    return normalized or None
+
+
+def _normalize_github(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+
+    github_match = re.search(
+        r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
+        candidate,
+        flags=re.IGNORECASE,
+    )
+    if github_match:
+        candidate = github_match.group(1)
+
+    candidate = candidate.lstrip("@").strip().strip("/")
+    return candidate or None
+
+
+def _normalize_linkedin(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    if "linkedin.com" not in candidate.lower():
+        return None
+    if not candidate.lower().startswith(("http://", "https://")):
+        candidate = f"https://{candidate}"
+    return candidate.rstrip("/")
+
+
+def _normalize_phone(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    digits = re.sub(r"\D", "", candidate)
+    if len(digits) < 7:
+        return None
+    if candidate.startswith("+"):
+        return f"+{digits}"
+    return digits
+
+
+def _normalize_country(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized.title() if normalized else None
+
+
+def _normalize_seniority(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if normalized in {"jr", "junior", "entry", "entry-level", "entry level"}:
+        return "junior"
+    if normalized in {"intern", "internship"}:
+        return "junior"
+    if normalized in {"mid-level", "midlevel", "mid", "intermediate"}:
+        return "midlevel"
+    if normalized in {"senior", "lead", "principal"}:
+        return normalized
+    if normalized in {"staff", "staff+"}:
+        return "staff"
+    return normalized
+
+
+def _normalize_skills(value: Any) -> list[str]:
+    if isinstance(value, list):
+        raw_skills = [str(skill).strip() for skill in value]
+    elif isinstance(value, str):
+        raw_skills = [item.strip() for item in value.replace(";", ",").split(",")]
+    else:
+        return []
+
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw_skill in raw_skills:
+        skill = re.sub(r"\s+", " ", raw_skill).strip()
+        if not skill:
+            continue
+        lowered = skill.casefold()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        normalized.append(skill)
+    return normalized
+
+
+def _normalize_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _parse_json_object(content: str) -> dict[str, Any]:
+    raw = content.strip()
+    if raw.startswith("```"):
+        lines = [line for line in raw.splitlines() if not line.startswith("```")]
+        raw = "\n".join(lines).strip()
+
+    parsed = json.loads(raw)
+    if not isinstance(parsed, dict):
+        raise ValueError("Model output was not a JSON object")
+    return parsed
+
+
+class ResumeExtractedProfile(BaseModel):
+    """Normalized profile fields extracted from resume text."""
+
+    name: str | None = None
+    email: str | None = None
+    github_username: str | None = None
+    linkedin_url: str | None = None
+    phone: str | None = None
+    address_country: str | None = None
+    seniority_level: str | None = None
+    skills: list[str] = Field(default_factory=list)
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    source: str
+
+
+class ResumeProfileExtractor:
+    """Extract candidate profile fields from resume text."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None,
+        base_url: str | None = None,
+        model: str = "gpt-4o-mini",
+        max_tokens: int = 800,
+        snippet_chars: int = 12000,
+    ) -> None:
+        self.model = model.strip() if model else "gpt-4o-mini"
+        if not self.model:
+            self.model = "gpt-4o-mini"
+        self.max_tokens = max_tokens
+        self.snippet_chars = max(1000, snippet_chars)
+        self.client: Any = None
+
+        if api_key and OpenAIClient is not None:
+            self.client = OpenAIClient(
+                api_key=api_key,
+                base_url=base_url,
+            )
+
+    def extract(self, resume_text: str) -> ResumeExtractedProfile:
+        """Return extracted fields from resume text."""
+        text = (resume_text or "").strip()
+        if not text:
+            return self._heuristic_extract("")
+
+        if self.client is None:
+            return self._heuristic_extract(text)
+
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {
+                        "role": "system",
+                        "content": (
+                            "You extract candidate profile fields from resumes for a CRM. "
+                            "Return JSON only with no commentary. Be conservative: when unsure, use null."
+                        ),
+                    },
+                    {"role": "user", "content": self._build_prompt(text)},
+                ],
+                temperature=0.1,
+                max_tokens=self.max_tokens,
+            )
+            raw_content = response.choices[0].message.content
+            if not raw_content:
+                raise ValueError("LLM returned empty content")
+
+            parsed = _parse_json_object(raw_content)
+            return ResumeExtractedProfile(
+                name=_normalize_name(parsed.get("name")),
+                email=_normalize_email(parsed.get("email")),
+                github_username=_normalize_github(parsed.get("github_username")),
+                linkedin_url=_normalize_linkedin(parsed.get("linkedin_url")),
+                phone=_normalize_phone(parsed.get("phone")),
+                address_country=_normalize_country(parsed.get("address_country")),
+                seniority_level=_normalize_seniority(parsed.get("seniority_level")),
+                skills=_normalize_skills(parsed.get("skills")),
+                confidence=_bounded_confidence(
+                    parsed.get("confidence", 0.75),
+                    fallback=0.75,
+                ),
+                source=self.model,
+            )
+        except Exception:
+            return self._heuristic_extract(text)
+
+    def _heuristic_extract(self, resume_text: str) -> ResumeExtractedProfile:
+        snippet = (resume_text or "").strip()[: self.snippet_chars]
+        email_match = re.search(
+            r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b",
+            snippet,
+        )
+        github_match = re.search(
+            r"(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})",
+            snippet,
+            flags=re.IGNORECASE,
+        )
+        linkedin_match = re.search(
+            r"(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/[A-Za-z0-9\\-_%]+/?",
+            snippet,
+            flags=re.IGNORECASE,
+        )
+        phone_match = re.search(
+            r"(?:\+?\d[\d\s().-]{7,}\d)",
+            snippet,
+        )
+        name_match = self._extract_name(snippet)
+        country = self._extract_country(snippet)
+        seniority = self._extract_seniority(snippet)
+        skills = self._extract_skills(snippet)
+
+        return ResumeExtractedProfile(
+            name=name_match,
+            email=_normalize_email(email_match.group(0)) if email_match else None,
+            github_username=(
+                _normalize_github(github_match.group(1)) if github_match else None
+            ),
+            linkedin_url=(
+                _normalize_linkedin(linkedin_match.group(0)) if linkedin_match else None
+            ),
+            phone=_normalize_phone(phone_match.group(0)) if phone_match else None,
+            address_country=country,
+            seniority_level=seniority,
+            skills=skills,
+            confidence=0.45,
+            source="heuristic",
+        )
+
+    def _build_prompt(self, resume_text: str) -> str:
+        snippet = resume_text[: self.snippet_chars]
+        return (
+            "Extract candidate profile fields from this resume.\n"
+            "Return JSON with exact keys and no extras:\n"
+            '{"name": string|null, "email": string|null, '
+            '"github_username": string|null, "linkedin_url": string|null, '
+            '"phone": string|null, "address_country": string|null, '
+            '"seniority_level": string|null, "skills": string[]|null, '
+            '"confidence": number}\n'
+            "Rules:\n"
+            "- prefer explicit values from header/contact sections\n"
+            "- for github_username return username only (no URL, no @)\n"
+            "- for linkedin_url return full linkedin profile URL when available\n"
+            "- for phone return digits with optional leading +\n"
+            "- use null for unknown or ambiguous fields\n"
+            "- confidence is 0-1 for overall extraction reliability\n\n"
+            f"Resume:\n{snippet}"
+        )
+
+    @staticmethod
+    def _extract_name(resume_text: str) -> str | None:
+        lines = [line.strip() for line in resume_text.splitlines() if line.strip()]
+        for line in lines[:40]:
+            if len(line) < 2 or len(line) > 70:
+                continue
+            if "@" in line or "http" in line.lower():
+                continue
+            if not any(char.isalpha() for char in line):
+                continue
+            return line
+        return None
+
+    @staticmethod
+    def _extract_country(resume_text: str) -> str | None:
+        match = re.search(
+            r"(?im)^(?:address\s*country|country)\s*[:\-]\s*(.+)$",
+            resume_text,
+        )
+        if match:
+            normalized = _normalize_country(match.group(1))
+            if normalized:
+                return normalized
+
+        return None
+
+    @staticmethod
+    def _extract_seniority(resume_text: str) -> str | None:
+        match = re.search(
+            r"(?im)^\s*seniority\s*[:\-]\s*(.+)$",
+            resume_text,
+        )
+        if match:
+            return _normalize_seniority(match.group(1))
+        return None
+
+    @staticmethod
+    def _extract_skills(resume_text: str) -> list[str]:
+        match = re.search(
+            r"(?im)^\s*(?:skills|technical\s+skills|technologies)\s*[:\-]?\s*$",
+            resume_text,
+        )
+        if not match:
+            return []
+
+        line_start = match.end()
+        tail = resume_text[line_start : line_start + 500]
+        first_line = tail.splitlines()[0] if tail else ""
+        if first_line:
+            return _normalize_skills(first_line)
+        return []

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+from datetime import datetime, timezone
 from typing import Any
 
 from pydantic import BaseModel, Field
@@ -129,11 +130,26 @@ def _normalize_seniority(value: Any) -> str | None:
         return "junior"
     if normalized in {"mid-level", "midlevel", "mid", "intermediate"}:
         return "midlevel"
-    if normalized in {"senior", "lead", "principal"}:
-        return normalized
-    if normalized in {"staff", "staff+"}:
+    if normalized in {"staff", "staff+", "staff and beyond"}:
         return "staff"
-    return normalized
+    if normalized in {
+        "senior",
+        "sr",
+        "sr. engineer",
+        "lead",
+        "lead engineer",
+        "lead engineer/tech lead",
+        "principal",
+        "principal engineer",
+    }:
+        return "senior"
+    if "lead" in normalized and ("engineer" in normalized or "lead" == normalized):
+        return "senior"
+    if "staff" in normalized:
+        return "staff"
+    if normalized.startswith("sr "):
+        return "senior"
+    return None
 
 
 def _normalize_skills(value: Any) -> list[str]:
@@ -256,7 +272,10 @@ class ResumeProfileExtractor:
                 phone=_normalize_phone(parsed.get("phone")),
                 website_links=_normalize_website_links(parsed.get("website_links")),
                 address_country=_normalize_country(parsed.get("address_country")),
-                seniority_level=_normalize_seniority(parsed.get("seniority_level")),
+                seniority_level=(
+                    _normalize_seniority(parsed.get("seniority_level"))
+                    or self._infer_seniority_from_resume(resume_text)
+                ),
                 skills=_normalize_skills(parsed.get("skills")),
                 confidence=_bounded_confidence(
                     parsed.get("confidence", 0.75),
@@ -326,6 +345,13 @@ class ResumeProfileExtractor:
             "- for github_username return username only (no URL, no @)\n"
             "- for linkedin_url return full linkedin profile URL when available\n"
             "- for phone return digits with optional leading +\n"
+            "- infer seniority_level as one of: junior, midlevel, senior, staff\n"
+            "- use 4-5 years with ownership and impact cues as senior\n"
+            "- use staff for 7+ years, or 5+ years with strong technical ownership/leadership\n"
+            "- weight company impact:\n"
+            "  - +1 for leadership titles (staff/lead/principal/architect)\n"
+            "  - +1 for enterprise-scale impact signals (team ownership, direct reports, cross-team work, large org terms)\n"
+            "  - when company signal is ambiguous, return conservative midlevel\n"
             "- use null for unknown or ambiguous fields\n"
             "- confidence is 0-1 for overall extraction reliability\n\n"
             f"Resume:\n{snippet}"
@@ -364,8 +390,81 @@ class ResumeProfileExtractor:
             resume_text,
         )
         if match:
-            return _normalize_seniority(match.group(1))
+            parsed = _normalize_seniority(match.group(1))
+            if parsed:
+                return parsed
+
+        inferred = ResumeProfileExtractor._infer_seniority_from_resume(resume_text)
+        if inferred:
+            return inferred
+
         return None
+
+    @staticmethod
+    def _infer_seniority_from_resume(resume_text: str) -> str | None:
+        lower_text = resume_text.lower()
+        years = ResumeProfileExtractor._extract_years_of_experience(resume_text)
+        if years is None:
+            return None
+
+        impact_score = 0
+        if re.search(
+            r"\b(staff|principal|lead engineer|principal engineer)\b", lower_text
+        ):
+            impact_score += 2
+        if re.search(
+            r"\b(architect|engineering lead|tech lead|lead dev|leading|led a team|team lead)\b",
+            lower_text,
+        ):
+            impact_score += 1
+        if re.search(
+            r"\b(team of\s+\d+|managed|mentored|cross-functional|enterprise|global|series [abcd]|"
+            r"\b500\+?|\b1000\+?|\b10[0-9]{2,}\s+employees",
+            lower_text,
+        ):
+            impact_score += 1
+
+        if years >= 7:
+            return "staff" if impact_score >= 1 else "senior"
+        if years >= 5:
+            return "senior"
+        if years >= 4:
+            return "senior" if impact_score >= 1 else "midlevel"
+        if years >= 2:
+            return "midlevel"
+        return "junior"
+
+    @staticmethod
+    def _extract_years_of_experience(resume_text: str) -> int | None:
+        years = []
+        year_patterns = [
+            r"(\d{1,2})\+?\s*years?\s+of\s+(?:software\s+|engineering\s+)?experience",
+            r"(?:experience|career)\s*(?:\:\s*)?(\d{1,2})\+?\s*years",
+            r"over\s+(\d{1,2})\s+years",
+        ]
+        for pattern in year_patterns:
+            for match in re.finditer(pattern, resume_text, flags=re.IGNORECASE):
+                try:
+                    years.append(int(match.group(1)))
+                except Exception:
+                    pass
+
+        date_range_pattern = re.compile(
+            r"\b((?:19|20)\d{2})\s*-\s*((?:19|20)\d{2}|present|current)\b",
+            flags=re.IGNORECASE,
+        )
+        today_year = datetime.now(timezone.utc).year
+        for match in date_range_pattern.finditer(resume_text):
+            start_year = int(match.group(1))
+            end_token = match.group(2).lower()
+            end_year = (
+                today_year if end_token in {"present", "current"} else int(end_token)
+            )
+            years.append(max(0, end_year - start_year))
+
+        if not years:
+            return None
+        return max(years)
 
     @staticmethod
     def _extract_skills(resume_text: str) -> list[str]:

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -139,8 +139,6 @@ def _normalize_seniority(value: Any) -> str | None:
         "lead",
         "lead engineer",
         "lead engineer/tech lead",
-        "principal",
-        "principal engineer",
     }:
         return "senior"
     if "lead" in normalized and ("engineer" in normalized or "lead" == normalized):

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -233,6 +233,24 @@ class TestCRMCog:
         assert where_filters[1]["attribute"] == "skills"
         assert where_filters[1]["value"] == ["python", "sql"]
 
+    @pytest.mark.asyncio
+    async def test_search_contacts_skills_query_normalizes_to_lowercase(
+        self, crm_cog, mock_interaction, mock_member_role
+    ):
+        """Skill-only search should normalize incoming terms before arrayAllOf filtering."""
+        mock_interaction.user.roles = [mock_member_role]
+        crm_cog.espo_api.request.return_value = {"list": []}
+
+        await crm_cog.search_members.callback(
+            crm_cog, mock_interaction, None, "Python, FastAPI "
+        )
+
+        crm_cog.espo_api.request.assert_called_once()
+        call_args = crm_cog.espo_api.request.call_args
+        search_params = call_args[0][2]
+        assert search_params["where"][0]["type"] == "arrayAllOf"
+        assert search_params["where"][0]["value"] == ["python", "fastapi"]
+
     def test_parse_contact_skill_attrs_recovers_python_literal(self, crm_cog):
         """Malformed JSON-like skill attrs should recover via literal parsing."""
         parsed = crm_cog._parse_contact_skill_attrs(

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -931,19 +931,25 @@ class TestCRMCog:
         search_params = call_args[0][2]  # Third argument is the search params
         # Check that it searched for "john" as a name
         first_where = search_params["where"][0]
-        if first_where.get("type") == "or":
-            where_filters = first_where.get("value", [])
+        if first_where.get("type") == "or" and isinstance(
+            first_where.get("value"), list
+        ):
+            where_filters = first_where["value"]
             assert isinstance(where_filters, list)
             where_filter = next(
-                (item for item in where_filters if item.get("attribute") == "name"),
+                (
+                    item
+                    for item in where_filters
+                    if isinstance(item, dict) and item.get("attribute") == "name"
+                ),
                 None,
             )
             assert where_filter is not None
-            assert where_filter["value"] == "john"
+            assert where_filter.get("value") == "john"
             return
 
-        assert first_where["attribute"] == "name"
-        assert first_where["value"] == "john"
+        assert first_where.get("attribute") == "name"
+        assert first_where.get("value") == "john"
 
     @pytest.mark.asyncio
     async def test_link_discord_user_modern_username(

--- a/tests/unit/test_intake_form_processor.py
+++ b/tests/unit/test_intake_form_processor.py
@@ -108,3 +108,23 @@ def test_intake_form_processor_rejects_duplicate_contacts() -> None:
 
     assert result["success"] is False
     assert result["error"] == "Multiple contacts found for email"
+
+
+def test_build_intake_updates_normalizes_form_skills_to_lowercase() -> None:
+    """Skill tags from form labels should be canonicalized to lowercase list values."""
+    processor = IntakeFormProcessor()
+
+    updates = processor._build_intake_updates(
+        email="new@example.com",
+        first_name="New",
+        last_name="Person",
+        payload={
+            "skill_proficiency_next_js": "5",
+            "skill_proficiency_project_management": "4",
+            "skill_proficiency_ai_ml_engineering": "1",
+            "github_username": "person",
+        },
+        include_email=True,
+    )
+
+    assert updates["skills"] == ["ai ml engineering", "next js", "project management"]

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -191,7 +191,7 @@ def test_apply_profile_updates_adds_discord_and_filters_email() -> None:
     assert "emailAddress" not in update_payload
     assert update_payload["cGitHubUsername"] == "new-gh"
     assert update_payload["phoneNumber"] == "14155551234"
-    assert update_payload["skills"] == ["Python", "FastAPI"]
+    assert update_payload["skills"] == ["python", "fastapi"]
     assert update_payload["cDiscordUserID"] == "123"
     assert update_payload["cDiscordUsername"] == "member#0001 (ID: 123)"
 
@@ -209,7 +209,7 @@ def test_apply_profile_updates_normalizes_csv_skills_to_array() -> None:
     assert result.success is True
     processor.crm.update_contact.assert_called_once()
     update_payload = processor.crm.update_contact.call_args[0][1]
-    assert update_payload["skills"] == ["Python", "FastAPI", "Rust"]
+    assert update_payload["skills"] == ["python", "fastapi", "rust"]
 
 
 def test_extract_profile_proposal_records_failed_run() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -1,5 +1,7 @@
 """Unit tests for resume profile worker processor."""
 
+import json
+
 from unittest.mock import Mock
 
 from five08.worker.crm.resume_profile_processor import ResumeProfileProcessor
@@ -14,6 +16,9 @@ def test_extract_profile_proposal_filters_508_email() -> None:
     processor.skills_extractor = Mock()
     processor.document_processor = Mock()
     processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
 
     processor.crm.get_contact.return_value = {
         "emailAddress": "member@example.com",
@@ -53,8 +58,13 @@ def test_extract_profile_proposal_filters_508_email() -> None:
     assert result.proposed_updates["cGitHubUsername"] == "new-gh"
     assert result.proposed_updates["cLinkedInUrl"] == "https://linkedin.com/in/new"
     assert result.proposed_updates["phoneNumber"] == "14155551234"
-    assert result.proposed_updates["skills"] == ["Python", "FastAPI"]
-    assert result.new_skills == ["Python", "FastAPI"]
+    assert result.proposed_updates["skills"] == ["python", "fastapi"]
+    assert result.new_skills == ["python", "fastapi"]
+    assert isinstance(result.proposed_updates["cSkillAttrs"], str)
+    assert json.loads(result.proposed_updates["cSkillAttrs"])["python"]["strength"] == 5
+    assert (
+        json.loads(result.proposed_updates["cSkillAttrs"])["fastapi"]["strength"] == 4
+    )
     assert any(item.field == "emailAddress" for item in result.skipped)
     processor.crm.update_contact.assert_called_once()
     update_contact_payload = processor.crm.update_contact.call_args.args[1]
@@ -67,6 +77,99 @@ def test_extract_profile_proposal_filters_508_email() -> None:
     assert record_kwargs["attachment_id"] == "att-1"
 
 
+def test_extract_profile_proposal_merges_and_serializes_website_and_skill_attrs() -> (
+    None
+):
+    """Proposal should merge website links and serialize cSkillAttrs as JSON."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+        "cWebsiteLink": ["https://portfolio.example.com"],
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-2"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email="new@example.com",
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        website_links=["https://portfolio.example.com", "https://www.blog.example.com"],
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=["TypeScript", "React Native"],
+        skill_attrs={"typescript": {"strength": 4}, "react native": {"strength": 3}},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-2",
+        attachment_id="att-2",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["cWebsiteLink"] == [
+        "https://portfolio.example.com",
+        "https://blog.example.com",
+    ]
+    assert result.proposed_updates["skills"] == ["typescript", "react native"]
+    assert isinstance(result.proposed_updates["cSkillAttrs"], str)
+    assert json.loads(result.proposed_updates["cSkillAttrs"]) == {
+        "react native": {"strength": 3},
+        "typescript": {"strength": 4},
+    }
+
+
+def test_apply_profile_updates_appends_resume_email_as_primary_emailAddressData() -> (
+    None
+):
+    """Resume email updates should append to emailAddressData instead of overwriting."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.crm.get_contact.return_value = {
+        "emailAddressData": [
+            {
+                "emailAddress": "legacy@example.com",
+                "lower": "legacy@example.com",
+                "primary": True,
+                "optOut": False,
+                "invalid": False,
+            }
+        ]
+    }
+    result = processor.apply_profile_updates(
+        contact_id="contact-3",
+        updates={
+            "emailAddress": "NewPerson@Example.Com",
+            "phoneNumber": "5551112222",
+        },
+    )
+
+    assert result.success is True
+    processor.crm.update_contact.assert_called_once()
+    payload = processor.crm.update_contact.call_args[0][1]
+    assert "emailAddress" not in payload
+    email_data = payload["emailAddressData"]
+    assert isinstance(email_data, list)
+    by_lower = {item["lower"]: item for item in email_data}
+    assert by_lower["newperson@example.com"]["primary"] is True
+    assert by_lower["legacy@example.com"]["primary"] is False
+    assert payload["phoneNumber"] == "5551112222"
+
+
 def test_extract_profile_proposal_normalizes_existing_skill_punctuation() -> None:
     """Existing punctuation-heavy skills should normalize to search-friendly canonical forms."""
     processor = ResumeProfileProcessor()
@@ -75,6 +178,9 @@ def test_extract_profile_proposal_normalizes_existing_skill_punctuation() -> Non
     processor.skills_extractor = Mock()
     processor.document_processor = Mock()
     processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
 
     processor.crm.get_contact.return_value = {
         "emailAddress": "member@example.com",
@@ -131,6 +237,9 @@ def test_extract_profile_proposal_with_strength_change_only_no_skill_proposal() 
     processor.skills_extractor = Mock()
     processor.document_processor = Mock()
     processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
 
     processor.crm.get_contact.return_value = {
         "emailAddress": "member@example.com",
@@ -210,6 +319,29 @@ def test_apply_profile_updates_normalizes_csv_skills_to_array() -> None:
     processor.crm.update_contact.assert_called_once()
     update_payload = processor.crm.update_contact.call_args[0][1]
     assert update_payload["skills"] == ["python", "fastapi", "rust"]
+
+
+def test_apply_profile_updates_serializes_skill_attrs() -> None:
+    """Apply should serialize cSkillAttrs payload as compact JSON."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+
+    result = processor.apply_profile_updates(
+        contact_id="contact-4",
+        updates={
+            "cSkillAttrs": {"python": {"strength": 5}, "react": {"strength": 3}},
+            "skills": "Python",
+        },
+    )
+
+    assert result.success is True
+    processor.crm.update_contact.assert_called_once()
+    payload = processor.crm.update_contact.call_args[0][1]
+    assert payload["skills"] == ["python"]
+    assert json.loads(payload["cSkillAttrs"]) == {
+        "python": {"strength": 5},
+        "react": {"strength": 3},
+    }
 
 
 def test_extract_profile_proposal_records_failed_run() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -133,6 +133,97 @@ def test_extract_profile_proposal_merges_and_serializes_website_and_skill_attrs(
     }
 
 
+def test_extract_profile_proposal_deduplicates_skills_in_confirmation() -> None:
+    """Duplicate extracted or existing skills should not appear in confirmation updates."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+        "skills": ["Python", "python", "JavaScript", "javascript"],
+        "cSkillAttrs": '{"python":{"strength":5},"javascript":{"strength":4}}',
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-3"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=["Python", "node", "Node.js", "python"],
+        skill_attrs={"python": {"strength": 5}, "node": {"strength": 2}},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-3",
+        attachment_id="att-3",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["skills"] == ["python", "javascript", "node"]
+    assert result.new_skills == ["node"]
+
+
+def test_extract_profile_proposal_includes_seniority_update() -> None:
+    """Extracted seniority should map to the CRM cSeniority field."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+        "cSeniority": "junior",
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-4"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        seniority_level="Senior",
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=[],
+        skill_attrs={},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-4",
+        attachment_id="att-4",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["cSeniority"] == "senior"
+
+
 def test_apply_profile_updates_appends_resume_email_as_primary_emailAddressData() -> (
     None
 ):
@@ -342,6 +433,40 @@ def test_apply_profile_updates_serializes_skill_attrs() -> None:
         "python": {"strength": 5},
         "react": {"strength": 3},
     }
+
+
+def test_apply_profile_updates_allows_cSeniority_field() -> None:
+    """Allowed updates should include cSeniority normalization."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+
+    result = processor.apply_profile_updates(
+        contact_id="contact-5",
+        updates={"cSeniority": "Senior"},
+    )
+
+    assert result.success is True
+    payload = processor.crm.update_contact.call_args[0][1]
+    assert payload["cSeniority"] == "senior"
+
+
+def test_apply_profile_updates_normalizes_skill_aliases_for_api_payload() -> None:
+    """Alias-heavy skills should be normalized into shared canonical forms."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+
+    result = processor.apply_profile_updates(
+        contact_id="contact-6",
+        updates={
+            "skills": ["Node.js", "Node.js", "node"],
+            "cSkillAttrs": {"Node.js": {"strength": 4}, "node": {"strength": 5}},
+        },
+    )
+
+    assert result.success is True
+    payload = processor.crm.update_contact.call_args[0][1]
+    assert payload["skills"] == ["node"]
+    assert json.loads(payload["cSkillAttrs"]) == {"node": {"strength": 5}}
 
 
 def test_extract_profile_proposal_records_failed_run() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -196,6 +196,22 @@ def test_apply_profile_updates_adds_discord_and_filters_email() -> None:
     assert update_payload["cDiscordUsername"] == "member#0001 (ID: 123)"
 
 
+def test_apply_profile_updates_normalizes_csv_skills_to_array() -> None:
+    """Apply should convert comma-separated skills into an array before updating."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+
+    result = processor.apply_profile_updates(
+        contact_id="contact-2",
+        updates={"skills": "Python, FastAPI, Rust"},
+    )
+
+    assert result.success is True
+    processor.crm.update_contact.assert_called_once()
+    update_payload = processor.crm.update_contact.call_args[0][1]
+    assert update_payload["skills"] == ["Python", "FastAPI", "Rust"]
+
+
 def test_extract_profile_proposal_records_failed_run() -> None:
     """Failed extraction should still be written to the processing ledger."""
     processor = ResumeProfileProcessor()

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -224,6 +224,50 @@ def test_extract_profile_proposal_includes_seniority_update() -> None:
     assert result.proposed_updates["cSeniority"] == "senior"
 
 
+def test_extract_profile_proposal_normalizes_unknown_seniority_to_unknown() -> None:
+    """Unknown extracted seniority values should normalize to unknown."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-5"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        seniority_level="guru",
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=[],
+        skill_attrs={},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-8",
+        attachment_id="att-8",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["cSeniority"] == "unknown"
+
+
 def test_apply_profile_updates_appends_resume_email_as_primary_emailAddressData() -> (
     None
 ):
@@ -448,6 +492,21 @@ def test_apply_profile_updates_allows_cSeniority_field() -> None:
     assert result.success is True
     payload = processor.crm.update_contact.call_args[0][1]
     assert payload["cSeniority"] == "senior"
+
+
+def test_apply_profile_updates_normalizes_unknown_seniority_to_unknown() -> None:
+    """Unknown seniority values should be normalized to the canonical unknown bucket."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+
+    result = processor.apply_profile_updates(
+        contact_id="contact-7",
+        updates={"cSeniority": "distinguished"},
+    )
+
+    assert result.success is True
+    payload = processor.crm.update_contact.call_args[0][1]
+    assert payload["cSeniority"] == "unknown"
 
 
 def test_apply_profile_updates_normalizes_skill_aliases_for_api_payload() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -224,6 +224,48 @@ def test_extract_profile_proposal_includes_seniority_update() -> None:
     assert result.proposed_updates["cSeniority"] == "senior"
 
 
+def test_extract_profile_proposal_maps_principal_to_staff() -> None:
+    """Principal titles should normalize to staff seniority."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = (
+        lambda v: str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {"emailAddress": "member@example.com"}
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-9"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        seniority_level="Principal Engineer",
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=[],
+        skill_attrs={},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-9",
+        attachment_id="att-9",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["cSeniority"] == "staff"
+
+
 def test_extract_profile_proposal_normalizes_unknown_seniority_to_unknown() -> None:
     """Unknown extracted seniority values should normalize to unknown."""
     processor = ResumeProfileProcessor()

--- a/tests/unit/test_worker_processor.py
+++ b/tests/unit/test_worker_processor.py
@@ -35,3 +35,7 @@ def test_process_contact_skills_merges_and_updates() -> None:
     assert result.success is True
     assert sorted(result.new_skills) == ["docker", "fastapi"]
     assert set(result.updated_skills) == {"python", "redis", "fastapi", "docker"}
+    processor.espocrm_client.update_contact_skills.assert_called_once_with(
+        "contact-1",
+        ["python", "redis", "fastapi", "docker"],
+    )


### PR DESCRIPTION
## Description
- Introduced a shared resume extraction service in packages/shared/src/five08/resume_extractor.py to normalize candidate fields, emit confidence, and provide LLM + heuristic fallback extraction.
- Updated Discord bot CRM resume workflows to use that shared extractor for resume matching payloads, name inference, and inferred contact creation fields.
- Refactored worker resume intake and resume profile processors to use the shared extractor and removed duplicated extraction logic.
- Added bot OpenAI configuration fields and made the `test_link_discord_user_name_search` assertion resilient to wrapped `where` filters.
- Validation passed pre-commit hooks (ruff, ruff format, mypy), with no runtime tests executed in this pass.

## Related Issue

## How Has This Been Tested?
Pre-commit checks (ruff, ruff format, mypy) passed on commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI-powered resume analysis now extracts comprehensive profile data including skills, seniority level, and contact information for enriched contact profiles.

* **Improvements**
  * Enhanced skill matching with normalized skill names for consistency.
  * Better contact profile enrichment from resume uploads.
  * Improved handling of contact data including email addresses and professional links.

* **Configuration**
  * Added OpenAI settings support for advanced resume processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->