### PR TITLE
Fix onboarding queue paging and fields

### DIFF
--- a/.superset/config.json
+++ b/.superset/config.json
@@ -1,0 +1,7 @@
+{
+  "setup": [
+    "uv sync",
+    "[ ! -f .env ] && cp \"$SUPERSET_ROOT_PATH/.env\" .env"
+  ],
+  "teardown": []
+}

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -45,6 +45,9 @@ ONBOARDER_FIELD_CANDIDATES = (
 )
 EXCLUDED_ONBOARDING_STATES = frozenset({"onboarded", "waitlist", "rejected"})
 ONBOARDING_QUEUE_MAX_SIZE = 200
+ONBOARDING_QUEUE_EMBED_MAX_FIELDS = 25
+DISCORD_EMBED_MAX_TOTAL_CHARS = 6000
+DISCORD_MESSAGE_MAX_CHARS = 2000
 
 EspoAPI = espo.EspoAPI
 EspoAPIError = espo.EspoAPIError
@@ -1341,6 +1344,68 @@ class CRMCog(commands.Cog):
 
         return contact_info
 
+    def _build_onboarding_queue_text(
+        self, queue_entries: list[tuple[dict[str, Any], str]]
+    ) -> str:
+        """Build a compact plain-text view for onboarding queue entries."""
+        lines = [
+            "Onboarding queue",
+            "Excludes states: onboarded, waitlist, rejected",
+            f"Total contacts: {len(queue_entries)}",
+            "",
+        ]
+
+        for index, (contact_record, status) in enumerate(queue_entries, start=1):
+            name = str(contact_record.get("name") or "Unknown")
+            contact_id = str(contact_record.get("id") or "")
+
+            onboarder_field = self._resolve_field_name(
+                contact_record, candidates=ONBOARDER_FIELD_CANDIDATES
+            )
+            onboarder_value = (
+                str(contact_record.get(onboarder_field, "")).strip()
+                if onboarder_field
+                else ""
+            )
+
+            parts = [f"{index}. {name}", f"status={status or 'unknown'}"]
+            if onboarder_value:
+                parts.append(f"onboarder={onboarder_value}")
+            if contact_id:
+                parts.append(f"id={contact_id}")
+
+            lines.append(" | ".join(parts))
+
+        return "\n".join(lines)
+
+    async def _send_onboarding_queue_text(
+        self,
+        interaction: discord.Interaction,
+        queue_entries: list[tuple[dict[str, Any], str]],
+    ) -> None:
+        """Send onboarding queue in plain text split across safe message chunks."""
+        queue_text = self._build_onboarding_queue_text(queue_entries)
+        prefix = (
+            "📄 Onboarding queue is too large for embed format. Sending plain text."
+        )
+
+        messages: list[str] = []
+        current_message = prefix
+        for line in queue_text.splitlines():
+            candidate = f"{current_message}\n{line}" if current_message else line
+            if len(candidate) <= DISCORD_MESSAGE_MAX_CHARS:
+                current_message = candidate
+                continue
+
+            messages.append(current_message)
+            current_message = line
+
+        if current_message:
+            messages.append(current_message)
+
+        for message in messages:
+            await interaction.followup.send(message)
+
     def _build_resume_preview_embed(
         self,
         *,
@@ -2285,7 +2350,11 @@ class CRMCog(commands.Cog):
                 color=0x0099FF,
             )
 
-            for contact_record, status in queue_entries[:25]:
+            shown_count = 0
+            embed_too_large = False
+            for contact_record, status in queue_entries[
+                :ONBOARDING_QUEUE_EMBED_MAX_FIELDS
+            ]:
                 contact_id = contact_record.get("id", "")
                 onboarder_field = self._resolve_field_name(
                     contact_record, candidates=ONBOARDER_FIELD_CANDIDATES
@@ -2308,22 +2377,44 @@ class CRMCog(commands.Cog):
                     interaction=interaction,
                     additional_fields=additional_fields,
                 )
-                embed.add_field(
-                    name=f"👤 {contact_record.get('name', 'Unknown')}",
-                    value=contact_info,
-                    inline=False,
-                )
+                field_name = f"👤 {contact_record.get('name', 'Unknown')}"
+                projected_size = len(embed) + len(field_name) + len(contact_info)
+                if projected_size > DISCORD_EMBED_MAX_TOTAL_CHARS:
+                    embed_too_large = True
+                    break
 
-            if len(queue_entries) > 25:
-                embed.set_footer(
-                    text=f"Showing 25 of {len(queue_entries)} matching contacts."
+                embed.add_field(name=field_name, value=contact_info, inline=False)
+                shown_count += 1
+
+            if embed_too_large:
+                await self._send_onboarding_queue_text(interaction, queue_entries)
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.view_onboarding_queue",
+                    result="success",
+                    metadata={
+                        "count": len(queue_entries),
+                        "output_format": "text",
+                    },
                 )
+                return
+
+            if len(queue_entries) > shown_count:
+                footer_text = (
+                    f"Showing {shown_count} of {len(queue_entries)} matching contacts."
+                )
+                if len(embed) + len(footer_text) <= DISCORD_EMBED_MAX_TOTAL_CHARS:
+                    embed.set_footer(text=footer_text)
 
             self._audit_command(
                 interaction=interaction,
                 action="crm.view_onboarding_queue",
                 result="success",
-                metadata={"count": len(queue_entries)},
+                metadata={
+                    "count": len(queue_entries),
+                    "shown_count": shown_count,
+                    "output_format": "embed",
+                },
             )
             await interaction.followup.send(embed=embed)
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -45,6 +45,7 @@ ONBOARDER_FIELD_CANDIDATES = (
 )
 EXCLUDED_ONBOARDING_STATES = frozenset({"onboarded", "waitlist", "rejected"})
 ONBOARDING_QUEUE_MAX_SIZE = 200
+ONBOARDING_QUEUE_PAGE_SIZE = 1
 ONBOARDING_QUEUE_EMBED_MAX_FIELDS = 25
 DISCORD_EMBED_MAX_TOTAL_CHARS = 6000
 DISCORD_MESSAGE_MAX_CHARS = 2000
@@ -1087,17 +1088,65 @@ class ResumeCreateContactView(discord.ui.View):
         finally:
             await self._finalize(interaction)
 
-    @discord.ui.button(label="Cancel", style=discord.ButtonStyle.secondary)
-    async def cancel_create(
+
+class OnboardingQueuePagerView(discord.ui.View):
+    """View for paging through onboarding queue entries one person at a time."""
+
+    def __init__(
+        self,
+        crm_cog: "CRMCog",
+        interaction: discord.Interaction,
+        queue_rows: list[dict[str, str]],
+        *,
+        page_size: int = ONBOARDING_QUEUE_PAGE_SIZE,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.crm_cog = crm_cog
+        self.requester_id = getattr(interaction.user, "id", 0)
+        self.queue_rows = queue_rows
+        self.page_size = max(1, page_size)
+        self.page_index = 0
+        self.total_pages = (
+            (len(self.queue_rows) - 1) // self.page_size + 1 if self.queue_rows else 0
+        )
+        self._update_button_states()
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        """Allow only the original command requester to page through the queue."""
+        if interaction.user.id != self.requester_id:
+            await interaction.response.send_message(
+                "❌ Only the command requester can page through this queue.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    def _build_embed(self) -> discord.Embed:
+        return self.crm_cog._build_onboarding_queue_page_embed(
+            self.queue_rows, page_index=self.page_index, page_size=self.page_size
+        )
+
+    def _update_button_states(self) -> None:
+        if not self.children:
+            return
+        if len(self.children) >= 1:
+            next_button = self.children[0]
+            if isinstance(next_button, discord.ui.Button):
+                next_button.disabled = self.page_index >= self.total_pages - 1
+
+    @discord.ui.button(label="Next", style=discord.ButtonStyle.primary, emoji="▶️")
+    async def next_page(
         self,
         interaction: discord.Interaction,
-        button: discord.ui.Button["ResumeCreateContactView"],
+        button: discord.ui.Button["OnboardingQueuePagerView"],
     ) -> None:
-        await interaction.response.send_message(
-            "ℹ️ Resume upload cancelled. No new contact was created.",
-            ephemeral=True,
-        )
-        await self._finalize(interaction)
+        """Show next contact in the onboarding queue."""
+        if self.page_index >= self.total_pages - 1:
+            return
+
+        self.page_index += 1
+        self._update_button_states()
+        await interaction.response.edit_message(embed=self._build_embed(), view=self)
 
 
 class CRMCog(commands.Cog):
@@ -1267,6 +1316,30 @@ class CRMCog(commands.Cog):
             return ""
         return str(value).strip().lower()
 
+    def _format_onboarding_updated_at(self, raw_value: Any) -> str:
+        """Normalize the onboarding updated-at value for display."""
+        if raw_value is None:
+            return "Unknown"
+
+        if isinstance(raw_value, (int, float)):
+            try:
+                return datetime.fromtimestamp(raw_value).strftime("%Y-%m-%d %H:%M UTC")
+            except (OSError, OverflowError, ValueError):
+                return str(raw_value)
+
+        raw_value_text = str(raw_value).strip()
+        if not raw_value_text:
+            return "Unknown"
+
+        try:
+            parsed = datetime.fromisoformat(raw_value_text.replace("Z", "+00:00"))
+        except ValueError:
+            return raw_value_text
+
+        if parsed.time() and parsed.time() != datetime.min.time():
+            return parsed.strftime("%Y-%m-%d %H:%M UTC")
+        return parsed.strftime("%Y-%m-%d")
+
     async def _resolve_onboarder_username(
         self, interaction: discord.Interaction, raw_onboarder: str
     ) -> str | None:
@@ -1377,6 +1450,126 @@ class CRMCog(commands.Cog):
             lines.append(" | ".join(parts))
 
         return "\n".join(lines)
+
+    def _build_onboarding_queue_row(
+        self, contact_record: dict[str, Any], status: str
+    ) -> dict[str, str]:
+        """Build a compact dictionary for one onboarding queue row."""
+        email = str(contact_record.get("emailAddress") or "No email")
+        name = str(contact_record.get("name") or "Unknown")
+        contact_id = str(contact_record.get("id") or "")
+
+        discord_user_id = contact_record.get("cDiscordUserID")
+        discord_username = contact_record.get("cDiscordUsername")
+        clean_discord_username = "No Discord"
+        if isinstance(discord_username, str) and discord_username.strip():
+            clean_discord_username = (
+                discord_username.split(" (ID: ")[0]
+                if " (ID: " in discord_username
+                else discord_username.strip()
+            )
+
+        onboarder_field = self._resolve_field_name(
+            contact_record, candidates=ONBOARDER_FIELD_CANDIDATES
+        )
+        onboarder_value = (
+            str(contact_record.get(onboarder_field, "")).strip()
+            if onboarder_field
+            else ""
+        )
+
+        return {
+            "name": name,
+            "email": email,
+            "status": status or "Unknown",
+            "onboarder": onboarder_value or "Unassigned",
+            "discord_user": clean_discord_username,
+            "discord_user_id": str(discord_user_id or ""),
+            "onboarding_updated_at": self._format_onboarding_updated_at(
+                contact_record.get("cOnboardingUpdatedAt")
+            ),
+            "crm_url": f"{self.base_url}/#Contact/view/{contact_id}"
+            if contact_id
+            else "",
+            "id": contact_id,
+        }
+
+    def _build_onboarding_queue_rows(
+        self,
+        interaction: discord.Interaction,
+        queue_entries: list[tuple[dict[str, Any], str]],
+    ) -> list[dict[str, str]]:
+        """Build compact per-row onboarding data."""
+        rows: list[dict[str, str]] = []
+        for contact_record, status in queue_entries:
+            row = self._build_onboarding_queue_row(contact_record, status)
+
+            discord_user_id = row.get("discord_user_id")
+            discord_display = row.get("discord_user", "No Discord")
+            if discord_user_id and interaction.guild:
+                try:
+                    member = interaction.guild.get_member(int(discord_user_id))
+                    if member:
+                        discord_display = f"{member.mention} ({discord_display})"
+                except (TypeError, ValueError):
+                    pass
+            row["discord_user"] = discord_display
+            rows.append(row)
+        return rows
+
+    def _build_onboarding_queue_page_embed(
+        self,
+        queue_rows: list[dict[str, str]],
+        *,
+        page_index: int,
+        page_size: int,
+    ) -> discord.Embed:
+        """Build one-page onboarding queue embed."""
+        if not queue_rows:
+            return discord.Embed(
+                title="📋 Onboarding Queue",
+                description="No onboarding contacts were found.",
+                color=0x0099FF,
+            )
+
+        total_rows = len(queue_rows)
+        start = max(0, page_index) * page_size
+        end = min(start + page_size, total_rows)
+        shown_rows = queue_rows[start:end]
+
+        embed = discord.Embed(
+            title="📋 Onboarding Queue",
+            description=(
+                "Contacts currently outside `onboarded`, `waitlist`, and "
+                f"`rejected` states. Showing {start + 1}-{end} of {total_rows}."
+            ),
+            color=0x0099FF,
+        )
+
+        for row in shown_rows:
+            details = [
+                f"📧 **Email:** {row.get('email', 'No email')}",
+                f"👤 **Name:** {row.get('name', 'Unknown')}",
+                f"💬 **Linked Discord:** {row.get('discord_user', 'No Discord')}",
+                f"🕘 **cOnboardingUpdatedAt:** {row.get('onboarding_updated_at', 'Unknown')}",
+                f"📌 **cOnboardingState:** {row.get('status', 'Unknown')}",
+                f"🧑‍💼 **cOnboarder:** {row.get('onboarder', 'Unassigned')}",
+            ]
+            crm_url = row.get("crm_url", "")
+            if crm_url:
+                details.append(f"🔗 [View in CRM]({crm_url})")
+            else:
+                details.append("🔗 **CRM:** Unavailable")
+
+            embed.add_field(
+                name=f"Contact: {row.get('name', 'Unknown')}",
+                value="\n".join(details),
+                inline=False,
+            )
+
+        total_pages = (total_rows - 1) // page_size + 1
+        embed.set_footer(text=f"Page {page_index + 1} of {total_pages}")
+        return embed
 
     async def _send_onboarding_queue_text(
         self,
@@ -2308,6 +2501,11 @@ class CRMCog(commands.Cog):
                 "Contact",
                 {
                     "maxSize": ONBOARDING_QUEUE_MAX_SIZE,
+                    "select": (
+                        "id,name,emailAddress,cDiscordUsername,cDiscordUserID,"
+                        "cOnboardingState,cOnboardingStatus,cOnboarding,"
+                        "cOnboarder,cOnboardingCoordinator,cOnboardingUpdatedAt"
+                    ),
                 },
             )
             contacts = response.get("list", [])
@@ -2342,69 +2540,14 @@ class CRMCog(commands.Cog):
                 key=lambda item: (item[1] or "unknown", str(item[0].get("name", "")))
             )
 
-            embed = discord.Embed(
-                title="📋 Onboarding Queue",
-                description=(
-                    "Contacts currently outside `onboarded`, `waitlist`, and `rejected` states."
-                ),
-                color=0x0099FF,
+            queue_rows = self._build_onboarding_queue_rows(interaction, queue_entries)
+            view = OnboardingQueuePagerView(
+                crm_cog=self,
+                interaction=interaction,
+                queue_rows=queue_rows,
+                page_size=ONBOARDING_QUEUE_PAGE_SIZE,
             )
-
-            shown_count = 0
-            embed_too_large = False
-            for contact_record, status in queue_entries[
-                :ONBOARDING_QUEUE_EMBED_MAX_FIELDS
-            ]:
-                contact_id = contact_record.get("id", "")
-                onboarder_field = self._resolve_field_name(
-                    contact_record, candidates=ONBOARDER_FIELD_CANDIDATES
-                )
-                onboarder_value = (
-                    str(contact_record.get(onboarder_field, "")).strip()
-                    if onboarder_field
-                    else ""
-                )
-
-                additional_fields: list[tuple[str, str]] = [
-                    ("📌 Onboarding Status", status or "Unknown"),
-                    ("🆔 ID", str(contact_id)),
-                ]
-                if onboarder_value:
-                    additional_fields.append(("🧑‍💼 Onboarder", onboarder_value))
-
-                contact_info = self._format_contact_card(
-                    contact_record,
-                    interaction=interaction,
-                    additional_fields=additional_fields,
-                )
-                field_name = f"👤 {contact_record.get('name', 'Unknown')}"
-                projected_size = len(embed) + len(field_name) + len(contact_info)
-                if projected_size > DISCORD_EMBED_MAX_TOTAL_CHARS:
-                    embed_too_large = True
-                    break
-
-                embed.add_field(name=field_name, value=contact_info, inline=False)
-                shown_count += 1
-
-            if embed_too_large:
-                await self._send_onboarding_queue_text(interaction, queue_entries)
-                self._audit_command(
-                    interaction=interaction,
-                    action="crm.view_onboarding_queue",
-                    result="success",
-                    metadata={
-                        "count": len(queue_entries),
-                        "output_format": "text",
-                    },
-                )
-                return
-
-            if len(queue_entries) > shown_count:
-                footer_text = (
-                    f"Showing {shown_count} of {len(queue_entries)} matching contacts."
-                )
-                if len(embed) + len(footer_text) <= DISCORD_EMBED_MAX_TOTAL_CHARS:
-                    embed.set_footer(text=footer_text)
+            embed = view._build_embed()
 
             self._audit_command(
                 interaction=interaction,
@@ -2412,11 +2555,13 @@ class CRMCog(commands.Cog):
                 result="success",
                 metadata={
                     "count": len(queue_entries),
-                    "shown_count": shown_count,
-                    "output_format": "embed",
+                    "output_format": "embed_paged",
                 },
             )
-            await interaction.followup.send(embed=embed)
+            if view.total_pages > 1:
+                await interaction.followup.send(embed=embed, view=view)
+            else:
+                await interaction.followup.send(embed=embed)
 
         except EspoAPIError as e:
             logger.error(f"EspoCRM API error in view_onboarding_queue: {e}")

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -579,6 +579,44 @@ class TestCRMCog:
         assert "❌ CRM API error: Queue service down" in message
 
     @pytest.mark.asyncio
+    async def test_view_onboarding_queue_falls_back_to_text_when_embed_too_large(
+        self, crm_cog, mock_interaction
+    ):
+        """Large queue payloads should switch to plain-text output."""
+        steering_role = Mock()
+        steering_role.name = "Steering Committee"
+        mock_interaction.user.roles = [steering_role]
+
+        long_name_suffix = "X" * 120
+        long_email_suffix = "y" * 80
+        crm_cog.espo_api.request.return_value = {
+            "list": [
+                {
+                    "id": f"c{i}",
+                    "name": f"Contact {i} {long_name_suffix}",
+                    "emailAddress": f"user{i}@{long_email_suffix}.example.com",
+                    "type": "Member",
+                    "c508Email": f"member{i}@508.dev",
+                    "cDiscordUsername": f"member{i}#1234",
+                    "cOnboardingState": "pending",
+                    "cOnboarder": f"mentor{i}",
+                }
+                for i in range(1, 26)
+            ]
+        }
+
+        await crm_cog.view_onboarding_queue.callback(crm_cog, mock_interaction)
+
+        assert mock_interaction.followup.send.call_count >= 1
+        for call_args in mock_interaction.followup.send.call_args_list:
+            kwargs = call_args[1]
+            assert "embed" not in kwargs
+            assert "file" not in kwargs
+
+        first_call = mock_interaction.followup.send.call_args_list[0]
+        assert "too large for embed format" in first_call[0][0]
+
+    @pytest.mark.asyncio
     async def test_view_skills_self_uses_structured_attrs(
         self, crm_cog, mock_interaction, mock_member_role
     ):


### PR DESCRIPTION
## Description
Implemented paginated onboarding-queue rendering for `/view-onboarding-queue` so each page shows one contact and avoids Discord embed overflow.
The new embed shows email, name, linked Discord user, `cOnboardingUpdatedAt`, `cOnboardingState`, `cOnboarder`, and CRM profile link while filtering out onboarded/waitlist/rejected states.
The response now uses a one-way `Next` button with per-contact formatting helpers and a narrow field query for onboarding-relevant CRM fields.
Branch also includes `.superset/config.json` and `tests/unit/test_crm.py` updates that are part of this workspace diff.
## Related Issue
None.
## How Has This Been Tested?
Pre-commit checks (ruff, ruff format, mypy) passed on commit, and no live Discord/CRM integration run was performed.