### PR TITLE
fix: improve resume URL extraction guidance

### DIFF
--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -6,6 +6,7 @@ import ast
 import json
 import logging
 import re
+import unicodedata
 from collections.abc import Callable
 from datetime import datetime, timezone
 from urllib.parse import urlsplit
@@ -1198,7 +1199,10 @@ class ResumeProfileProcessor:
 
     @staticmethod
     def _normalize_website_url(value: str) -> str | None:
-        candidate = value.strip().strip(")]},.;:")
+        candidate = unicodedata.normalize("NFKC", value)
+        if any(ord(ch) > 127 for ch in candidate):
+            return None
+        candidate = candidate.strip().strip(")]},.;:")
         if not candidate:
             return None
 

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import unicodedata
 from datetime import datetime, timezone
 from typing import Any, Mapping
 from urllib.parse import urlsplit
@@ -56,6 +57,8 @@ TECH_STACK_WEBSITE_DISALLOWED_PREFIXES = frozenset(
         "asp",
         "next",
         "node",
+        "express",
+        "passport",
         "react",
         "vue",
         "angular",
@@ -70,6 +73,9 @@ LLM_WEBSITE_URL_MIN_CONFIDENCE = 0.45
 LLM_SOCIAL_URL_MIN_CONFIDENCE = 0.7
 LLM_PERSONAL_URL_MIN_CONFIDENCE = 0.85
 LLM_URL_CANDIDATE_KIND_PERSONAL = "personal_website"
+MAX_PERSONAL_WEBSITE_PATH_COMPONENTS = 1
+TOP_BOTTOM_BIAS_WINDOW = 0.1
+MIDDLE_WEBSITE_POSITION_SCALE = 0.55
 LLM_URL_CANDIDATE_KIND_SOCIAL = "social_profile"
 LLM_URL_CANDIDATE_KIND_OTHER = "other"
 MARKDOWN_URL_PATTERN = re.compile(r"\[[^\]]+\]\(\s*([^)]+?)\s*\)")
@@ -172,7 +178,7 @@ def _normalize_name_part(value: Any) -> str | None:
     normalized = re.sub(r"\s+", " ", normalized).strip()
     if not any(char.isalpha() for char in normalized):
         return None
-    return normalized
+    return normalized.title()
 
 
 def _coerce_email_list(value: Any) -> list[str]:
@@ -423,7 +429,11 @@ def _normalize_role_collection(value: Any) -> list[str]:
 
 
 def _normalize_website_url(value: str) -> str:
-    candidate = value.strip().strip(")]},.;:")
+    candidate = unicodedata.normalize("NFKC", value)
+    if any(ord(ch) > 127 for ch in candidate):
+        return ""
+    candidate = candidate.strip()
+    candidate = candidate.strip(")]},.;:")
     if not candidate:
         return ""
 
@@ -450,6 +460,10 @@ def _normalize_website_url(value: str) -> str:
     if host.lower().startswith("www."):
         host = host[4:]
     if not host:
+        return ""
+    if _has_excessive_personal_path_segments(parsed.path) and not _is_social_url(
+        candidate
+    ):
         return ""
     if _is_disallowed_personal_website_host(host):
         return ""
@@ -513,6 +527,13 @@ def _normalize_website_links(value: Any) -> list[str]:
         normalized_links.append(normalized_link)
 
     return normalized_links
+
+
+def _has_excessive_personal_path_segments(path: str) -> bool:
+    stripped = path.strip("/")
+    if not stripped:
+        return False
+    return stripped.count("/") + 1 > MAX_PERSONAL_WEBSITE_PATH_COMPONENTS
 
 
 def _normalize_url_candidate_kind(value: Any) -> str:
@@ -583,6 +604,19 @@ def _has_personal_website_context(
     context_end = min(len(resume_text), end_index + 50)
     context = resume_text[context_start:context_end].casefold()
     return any(keyword in context for keyword in PERSONAL_WEBSITE_CONTEXT_KEYWORDS)
+
+
+def _website_position_scale(
+    text_length: int, start_index: int, end_index: int
+) -> float:
+    if text_length <= 0:
+        return 1.0
+
+    start_ratio = start_index / text_length
+    end_ratio = end_index / text_length
+    if start_ratio <= TOP_BOTTOM_BIAS_WINDOW or end_ratio >= 1 - TOP_BOTTOM_BIAS_WINDOW:
+        return 1.0
+    return MIDDLE_WEBSITE_POSITION_SCALE
 
 
 def _build_website_and_social_from_candidates(
@@ -1172,7 +1206,9 @@ class ResumeProfileExtractor:
             "- treat a candidate as personal_website only when confidence is high (>=0.85)\n"
             "- treat a candidate as social_profile when confidence is high (>=0.7)\n"
             "- route candidate urls to website_links and social_links by type and host-level validation\n"
-            '- personal_website candidates should be explicit portfolio/homepage signals (for example: "portfolio", "personal website", "homepage", contact header), not technology/framework mentions\n'
+            '- personal_website candidates should be explicit portfolio/homepage/contact signals (for example: "portfolio", "personal website", "homepage", contact header), not technology/framework mentions\n'
+            '- trust the explicit source labels and sections (for example lines like "website:", "portfolio:", "my website", "homepage") when selecting personal_website candidates\n'
+            "- if a token can be either a technology name and a URL, default to excluding it from candidates unless context is clearly personal\n"
             "- website_links/social_links should mirror high-confidence candidates; if website_url_candidates are unavailable, use website_links/social_links and heuristics as fallback\n"
             "- prefer explicit values from header/contact sections\n"
             "- treat website_links as personal or portfolio homepage URLs only\n"
@@ -1559,26 +1595,52 @@ class ResumeProfileExtractor:
         resume_text: str,
     ) -> list[tuple[str, float]]:
         matches: list[tuple[str, float]] = []
+        text_length = len(resume_text)
         for match in MARKDOWN_URL_PATTERN.finditer(resume_text):
             raw_url = match.group(1).strip().strip(")]},.;:")
             if not raw_url:
                 continue
-            matches.append((raw_url, 1.0))
+            confidence = 1.0 * _website_position_scale(
+                text_length=text_length,
+                start_index=match.start(),
+                end_index=match.end(),
+            )
+            if confidence >= PERSONAL_WEBSITE_MIN_CONFIDENCE:
+                matches.append((raw_url, confidence))
 
         for match in SCHEME_URL_PATTERN.finditer(resume_text):
-            matches.append((match.group(0), 1.0))
+            confidence = 1.0 * _website_position_scale(
+                text_length=text_length,
+                start_index=match.start(),
+                end_index=match.end(),
+            )
+            if confidence >= PERSONAL_WEBSITE_MIN_CONFIDENCE:
+                matches.append((match.group(0), confidence))
 
         for match in BARE_DOMAIN_URL_PATTERN.finditer(resume_text):
             if match.start() > 0 and resume_text[match.start() - 1] == "@":
                 continue
             raw_url = match.group(0)
-            confidence = PERSONAL_WEBSITE_MIN_CONFIDENCE
+            confidence = PERSONAL_WEBSITE_MIN_CONFIDENCE * _website_position_scale(
+                text_length=len(resume_text),
+                start_index=match.start(),
+                end_index=match.end(),
+            )
             if _has_personal_website_context(
                 resume_text,
                 match.start(),
                 match.end(),
             ):
-                confidence = PERSONAL_WEBSITE_CONTEXT_CONFIDENCE
+                confidence = (
+                    PERSONAL_WEBSITE_CONTEXT_CONFIDENCE
+                    * _website_position_scale(
+                        text_length=text_length,
+                        start_index=match.start(),
+                        end_index=match.end(),
+                    )
+                )
+            if confidence < PERSONAL_WEBSITE_MIN_CONFIDENCE:
+                continue
             matches.append((raw_url, confidence))
 
         normalized_links: list[tuple[str, float]] = []


### PR DESCRIPTION
## Description\nThis PR hardens resume extraction in the shared extractor and worker CRM processor by filtering likely non-personal URL signals and normalizing name casing for parsed candidates.\nIt adds top/bottom resume-position bias so URL candidates from the header/footer are preferred over middle-body links.\nIt also adds path-depth and Unicode filtering in website normalization to reduce false positives like GitHub issues and malformed tokens from resumes.\nThe worker path now shares the same NFKC + ASCII-normalization behavior used by shared extraction for consistent website parsing.\n## Related Issue\nNot provided.\n## How Has This Been Tested?\nChanges were reviewed via  against ; no runtime tests were executed in this PR creation step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced website URL extraction from resumes with improved validation and filtering.
  * Better identification and ranking of personal websites and social media links based on context.
  * Improved confidence scoring for website candidates based on their position in the resume.
  * Better normalization of candidate names to proper title case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->