### PR TITLE
fix: refine candidate match formatting

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -511,18 +511,29 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
 
         for i, candidate in enumerate(candidates, start=1):
             label = "**[Member]**" if candidate.is_member else "[Prospect]"
-            name = discord.utils.escape_mentions(candidate.name or "Unknown")
+            crm_name = discord.utils.escape_mentions(
+                candidate.crm_name or candidate.name or "Unknown"
+            )
+            discord_username = (
+                discord.utils.escape_mentions(
+                    str(candidate.discord_username).lstrip("@")
+                )
+                if candidate.discord_username
+                else None
+            )
             crm_link = (
                 f"{crm_base}/#Contact/view/{candidate.crm_contact_id}"
                 if candidate.has_crm_link and candidate.crm_contact_id
                 else None
             )
             if crm_link:
-                parts = [f"{i}. {label} [{name}](<{crm_link}>)"]
+                display_name = f"[{crm_name}](<{crm_link}>)"
             else:
-                parts = [f"{i}. {label} {name}"]
-                if candidate.discord_user_id:
-                    parts.append(f"Discord ID: {candidate.discord_user_id}")
+                display_name = crm_name
+
+            parts = [f"{i}. {label} {display_name}"]
+            if discord_username:
+                parts.append(f"`@{discord_username}`")
 
             if candidate.linkedin:
                 parts.append(f"[LinkedIn](<{candidate.linkedin}>)")
@@ -535,7 +546,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                     candidate.latest_resume_name
                 )
                 resume_options.append(
-                    (name, candidate.latest_resume_id, safe_resume_name)
+                    (crm_name, candidate.latest_resume_id, safe_resume_name)
                 )
 
             skill_info: list[str] = []

--- a/packages/shared/src/five08/candidate_search.py
+++ b/packages/shared/src/five08/candidate_search.py
@@ -80,6 +80,8 @@ class CandidateMatch:
 
     crm_contact_id: str | None
     name: str | None
+    crm_name: str | None
+    discord_username: str | None
     email_508: str | None
     email: str | None
     linkedin: str | None
@@ -224,7 +226,7 @@ def search_candidates(
           dm_agg AS (
             SELECT
                 dm_raw.discord_user_id,
-                MAX(dm_raw.discord_username) AS discord_username,
+                MAX(dm_raw.discord_username) AS member_discord_username,
                 MAX(dm_raw.display_name) AS display_name,
                 COALESCE(
                     jsonb_agg(DISTINCT role) FILTER (WHERE role IS NOT NULL),
@@ -246,7 +248,8 @@ def search_candidates(
           scored AS (
             SELECT
                 p.crm_contact_id AS crm_contact_id,
-                COALESCE(dm.display_name, dm.discord_username, p.name) AS name,
+                COALESCE(p.name, dm.display_name, dm.member_discord_username) AS name,
+                p.name AS crm_name,
                 p.email_508,
                 p.email,
                 p.linkedin,
@@ -259,6 +262,7 @@ def search_candidates(
                 COALESCE(p.skills, '{}'::text[]) AS skills,
                 COALESCE(p.skill_attrs, '{}'::jsonb) AS skill_attrs,
                 COALESCE(dm.roles, p.discord_roles, '[]'::jsonb) AS discord_roles,
+                COALESCE(dm.member_discord_username, p.discord_username) AS discord_username,
                 COALESCE(p.discord_user_id, dm.discord_user_id) AS discord_user_id,
                 (p.crm_contact_id IS NOT NULL) AS has_crm_link,
                 -- How many required skills this candidate has
@@ -346,11 +350,13 @@ def search_candidates(
               )
           )
         SELECT
-            crm_contact_id,
-            name,
-            email_508,
-            email,
-            linkedin,
+                crm_contact_id,
+                name,
+                crm_name,
+                discord_username,
+                email_508,
+                email,
+                linkedin,
             latest_resume_id,
             latest_resume_name,
             is_member,
@@ -461,6 +467,8 @@ def search_candidates(
             CandidateMatch(
                 crm_contact_id=row.get("crm_contact_id"),
                 name=row.get("name"),
+                crm_name=row.get("crm_name"),
+                discord_username=row.get("discord_username"),
                 email_508=row.get("email_508"),
                 email=row.get("email"),
                 linkedin=row.get("linkedin"),

--- a/tests/unit/test_candidate_search.py
+++ b/tests/unit/test_candidate_search.py
@@ -248,7 +248,13 @@ def _patch_db(rows: list[dict]) -> MagicMock:
 
 
 def test_search_candidates_maps_row_to_candidate_match() -> None:
-    row = _make_row(crm_contact_id="abc", name="Bob", seniority="senior")
+    row = _make_row(
+        crm_contact_id="abc",
+        name="Bob Display",
+        crm_name="Bob CRM",
+        discord_username="bob_discord",
+        seniority="senior",
+    )
     conn = _patch_db([row])
 
     reqs = _make_requirements(required_skills=["python"], seniority="senior")
@@ -260,7 +266,9 @@ def test_search_candidates_maps_row_to_candidate_match() -> None:
     assert len(results) == 1
     c = results[0]
     assert c.crm_contact_id == "abc"
-    assert c.name == "Bob"
+    assert c.name == "Bob Display"
+    assert c.crm_name == "Bob CRM"
+    assert c.discord_username == "bob_discord"
     assert c.seniority == "senior"
     assert c.seniority_score == 1.0
     assert "python" in c.matched_required_skills

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -1,0 +1,80 @@
+"""Unit tests for jobs cog match formatting."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("DISCORD_BOT_TOKEN", "test")
+os.environ.setdefault("ESPO_API_KEY", "test")
+os.environ.setdefault("ESPO_BASE_URL", "https://crm.example.invalid")
+os.environ.setdefault("KIMAI_BASE_URL", "https://kimai.example.invalid")
+os.environ.setdefault("KIMAI_API_TOKEN", "test")
+
+from five08.discord_bot.cogs.jobs import JobsCog
+
+
+def _make_candidate(**overrides: object) -> SimpleNamespace:
+    base = {
+        "is_member": False,
+        "name": "Display Name",
+        "crm_name": None,
+        "crm_contact_id": None,
+        "has_crm_link": False,
+        "discord_user_id": None,
+        "discord_username": None,
+        "latest_resume_id": None,
+        "latest_resume_name": None,
+        "matched_required_skills": [],
+        "matched_discord_roles": [],
+        "matched_preferred_skills": [],
+        "match_score": 0.0,
+        "seniority": None,
+        "timezone": None,
+        "linkedin": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_build_match_candidate_lines_uses_crm_name_and_discord_username() -> None:
+    candidate = _make_candidate(
+        is_member=True,
+        name="Server Nickname",
+        crm_name="Caleb",
+        crm_contact_id="abc",
+        has_crm_link=True,
+        discord_username="caleb",
+    )
+
+    lines, _ = JobsCog._build_match_candidate_lines(
+        candidates=[candidate],
+        crm_base="https://crm.example",
+    )
+
+    assert len(lines) == 1
+    assert "Discord ID" not in lines[0]
+    assert (
+        "1. **[Member]** [Caleb](<https://crm.example/#Contact/view/abc>)" in lines[0]
+    )
+    assert "`@caleb`" in lines[0]
+
+
+def test_build_match_candidate_lines_omits_crm_link_for_prospect() -> None:
+    candidate = _make_candidate(
+        is_member=False,
+        name="Prospect Name",
+        has_crm_link=False,
+        discord_username="michaelmwu",
+    )
+
+    lines, _ = JobsCog._build_match_candidate_lines(
+        candidates=[candidate],
+        crm_base="https://crm.example",
+    )
+
+    assert len(lines) == 1
+    assert "1. [Prospect] Prospect Name" in lines[0]
+    assert "`@michaelmwu`" in lines[0]
+    assert "<https://crm.example/#Contact/view/" not in lines[0]
+    assert "<@" not in lines[0]


### PR DESCRIPTION
## Description
This change improves `/match-candidates` output by preferring CRM full names for the displayed person title and linking the name to the CRM record when available.
It now includes a non-mention Discord username in the same result line for easy identity context, with no fallback to Discord ID in normal output.
`search_candidates` now returns both `crm_name` and `discord_username` from the matching query so the bot can render those fields separately and consistently.
Unit tests were added for both the new candidate mapping fields and the formatter behavior.
## How Has This Been Tested?
`uv run pytest tests/unit/test_candidate_search.py tests/unit/test_jobs.py` (29 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display of Discord usernames in candidate information when available.
  * Improved candidate profile display to prioritize CRM names for better accuracy and consistency.

* **Tests**
  * Added test coverage for candidate display formatting with various member and prospect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->