### PR TITLE
fix: increase resume extractor token budget

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,7 @@ OPENAI_BASE_URL=
 OPENAI_MODEL=gpt-5-mini
 # Resume model name without provider prefix; OpenRouter is auto-prefixed to openai/<model>
 RESUME_AI_MODEL=gpt-5-mini
+RESUME_EXTRACTOR_MAX_TOKENS=2000
 RESUME_EXTRACTOR_VERSION=v1
 CRM_SYNC_ENABLED=true
 CRM_SYNC_INTERVAL_SECONDS=900

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -2336,6 +2336,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             api_key=settings.openai_api_key,
             base_url=settings.openai_base_url,
             model=settings.openai_model,
+            max_tokens=settings.resume_extractor_max_tokens,
         )
         self._resume_profile_cache: (
             tuple[tuple[int, str], ResumeExtractedProfile] | None

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -35,6 +35,7 @@ class Settings(SharedSettings):
     openai_api_key: str | None = None
     openai_base_url: str | None = None
     openai_model: str = "gpt-5-mini"
+    resume_extractor_max_tokens: int = 2000
 
     # Kimai time tracking settings
     kimai_base_url: str

--- a/apps/worker/src/five08/worker/config.py
+++ b/apps/worker/src/five08/worker/config.py
@@ -25,6 +25,7 @@ class WorkerSettings(SharedSettings):
     openai_base_url: str | None = None
     openai_model: str = "gpt-5-mini"
     resume_ai_model: str = "gpt-5-mini"
+    resume_extractor_max_tokens: int = 2000
     resume_extractor_version: str = "v1"
     docuseal_member_agreement_template_id: int | None = None
 

--- a/apps/worker/src/five08/worker/crm/intake_form_processor.py
+++ b/apps/worker/src/five08/worker/crm/intake_form_processor.py
@@ -83,6 +83,7 @@ class IntakeFormProcessor:
             api_key=settings.openai_api_key,
             base_url=settings.openai_base_url,
             model=settings.resolved_resume_ai_model,
+            max_tokens=settings.resume_extractor_max_tokens,
         )
         self.skills_extractor = SkillsExtractor()
 

--- a/apps/worker/src/five08/worker/crm/resume_profile_processor.py
+++ b/apps/worker/src/five08/worker/crm/resume_profile_processor.py
@@ -55,6 +55,7 @@ class ResumeProfileProcessor:
             api_key=settings.openai_api_key,
             base_url=settings.openai_base_url,
             model=settings.resolved_resume_ai_model,
+            max_tokens=settings.resume_extractor_max_tokens,
         )
         self.skills_extractor = SkillsExtractor()
         self.document_processor = DocumentProcessor()

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -1886,9 +1886,9 @@ class ResumeProfileExtractor:
         raw_content: str | None = None
         parsed: dict[str, Any] | None = None
         attempt_max_tokens = self.max_tokens
-        retry_after_length = True
+        got_successful_response = False
         try:
-            while True:
+            for attempt_index in range(2):
                 response = self.client.chat.completions.create(
                     model=self.model,
                     messages=[
@@ -1921,28 +1921,32 @@ class ResumeProfileExtractor:
                 raw_content = getattr(message, "content", None) if message else None
                 if not raw_content:
                     finish_reason = getattr(first_choice, "finish_reason", None)
-                    if retry_after_length and finish_reason == "length":
-                        retry_after_length = False
+                    if attempt_index == 0 and finish_reason == "length":
                         attempt_max_tokens = self.max_tokens * 2
                         continue
                     raise _empty_llm_content_error(response)
 
                 parsed = _parse_json_object(raw_content)
-                raw_first_name = parsed.get("firstName")
-                if raw_first_name is None:
-                    raw_first_name = parsed.get("first_name")
-                raw_last_name = parsed.get("lastName")
-                if raw_last_name is None:
-                    raw_last_name = parsed.get("last_name")
-                extracted_name = _normalize_name(parsed.get("name"))
-                extracted_first_name, extracted_last_name = self.split_name(
-                    full_name=extracted_name,
-                    first_name_hint=raw_first_name,
-                    last_name_hint=raw_last_name,
-                )
-                parsed_url_candidates = _extract_website_url_candidates(
-                    parsed.get("website_url_candidates")
-                )
+                got_successful_response = True
+                break
+            if not got_successful_response or parsed is None:
+                raise _empty_llm_content_error(response)
+
+            raw_first_name = parsed.get("firstName")
+            if raw_first_name is None:
+                raw_first_name = parsed.get("first_name")
+            raw_last_name = parsed.get("lastName")
+            if raw_last_name is None:
+                raw_last_name = parsed.get("last_name")
+            extracted_name = _normalize_name(parsed.get("name"))
+            extracted_first_name, extracted_last_name = self.split_name(
+                full_name=extracted_name,
+                first_name_hint=raw_first_name,
+                last_name_hint=raw_last_name,
+            )
+            parsed_url_candidates = _extract_website_url_candidates(
+                parsed.get("website_url_candidates")
+            )
             legacy_website_links = _normalize_website_links(parsed.get("website_links"))
             legacy_social_links = _normalize_website_links(parsed.get("social_links"))
             heuristic_candidates = (

--- a/packages/shared/src/five08/resume_extractor.py
+++ b/packages/shared/src/five08/resume_extractor.py
@@ -1843,13 +1843,13 @@ class ResumeProfileExtractor:
         api_key: str | None,
         base_url: str | None = None,
         model: str = "gpt-5-mini",
-        max_tokens: int = 800,
+        max_tokens: int = 2000,
         snippet_chars: int = 12000,
     ) -> None:
         self.model = model.strip() if model else "gpt-5-mini"
         if not self.model:
             self.model = "gpt-5-mini"
-        self.max_tokens = max_tokens
+        self.max_tokens = max(1, max_tokens)
         self.snippet_chars = max(1000, snippet_chars)
         self.client: Any = None
 
@@ -1885,56 +1885,64 @@ class ResumeProfileExtractor:
 
         raw_content: str | None = None
         parsed: dict[str, Any] | None = None
+        attempt_max_tokens = self.max_tokens
+        retry_after_length = True
         try:
-            response = self.client.chat.completions.create(
-                model=self.model,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You extract structured candidate profile fields for a CRM. "
-                            "Return JSON only with no commentary. "
-                            "Prefer explicit evidence from the provided text. "
-                            "Be conservative for contact/location/website fields, but proactive for role and seniority inference. "
-                            "For primary_roles and seniority_level, infer the best fit from titles, summary, and work history even when labels are not explicit. "
-                            "Never fabricate details or use outside knowledge. "
-                            "Assume candidates are typically technical professionals unless the resume clearly indicates otherwise."
-                        ),
-                    },
-                    {
-                        "role": "user",
-                        "content": self._build_prompt(
-                            source_texts=source_texts,
-                            primary_text=text,
-                        ),
-                    },
-                ],
-                temperature=0.1,
-                max_tokens=self.max_tokens,
-            )
-            choices = getattr(response, "choices", None)
-            first_choice = choices[0] if choices else None
-            message = getattr(first_choice, "message", None)
-            raw_content = getattr(message, "content", None) if message else None
-            if not raw_content:
-                raise _empty_llm_content_error(response)
+            while True:
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": (
+                                "You extract structured candidate profile fields for a CRM. "
+                                "Return JSON only with no commentary. "
+                                "Prefer explicit evidence from the provided text. "
+                                "Be conservative for contact/location/website fields, but proactive for role and seniority inference. "
+                                "For primary_roles and seniority_level, infer the best fit from titles, summary, and work history even when labels are not explicit. "
+                                "Never fabricate details or use outside knowledge. "
+                                "Assume candidates are typically technical professionals unless the resume clearly indicates otherwise."
+                            ),
+                        },
+                        {
+                            "role": "user",
+                            "content": self._build_prompt(
+                                source_texts=source_texts,
+                                primary_text=text,
+                            ),
+                        },
+                    ],
+                    temperature=0.1,
+                    max_tokens=attempt_max_tokens,
+                )
+                choices = getattr(response, "choices", None)
+                first_choice = choices[0] if choices else None
+                message = getattr(first_choice, "message", None)
+                raw_content = getattr(message, "content", None) if message else None
+                if not raw_content:
+                    finish_reason = getattr(first_choice, "finish_reason", None)
+                    if retry_after_length and finish_reason == "length":
+                        retry_after_length = False
+                        attempt_max_tokens = self.max_tokens * 2
+                        continue
+                    raise _empty_llm_content_error(response)
 
-            parsed = _parse_json_object(raw_content)
-            raw_first_name = parsed.get("firstName")
-            if raw_first_name is None:
-                raw_first_name = parsed.get("first_name")
-            raw_last_name = parsed.get("lastName")
-            if raw_last_name is None:
-                raw_last_name = parsed.get("last_name")
-            extracted_name = _normalize_name(parsed.get("name"))
-            extracted_first_name, extracted_last_name = self.split_name(
-                full_name=extracted_name,
-                first_name_hint=raw_first_name,
-                last_name_hint=raw_last_name,
-            )
-            parsed_url_candidates = _extract_website_url_candidates(
-                parsed.get("website_url_candidates")
-            )
+                parsed = _parse_json_object(raw_content)
+                raw_first_name = parsed.get("firstName")
+                if raw_first_name is None:
+                    raw_first_name = parsed.get("first_name")
+                raw_last_name = parsed.get("lastName")
+                if raw_last_name is None:
+                    raw_last_name = parsed.get("last_name")
+                extracted_name = _normalize_name(parsed.get("name"))
+                extracted_first_name, extracted_last_name = self.split_name(
+                    full_name=extracted_name,
+                    first_name_hint=raw_first_name,
+                    last_name_hint=raw_last_name,
+                )
+                parsed_url_candidates = _extract_website_url_candidates(
+                    parsed.get("website_url_candidates")
+                )
             legacy_website_links = _normalize_website_links(parsed.get("website_links"))
             legacy_social_links = _normalize_website_links(parsed.get("social_links"))
             heuristic_candidates = (

--- a/tests/unit/test_resume_extractor.py
+++ b/tests/unit/test_resume_extractor.py
@@ -790,6 +790,64 @@ def test_extract_reports_missing_message_on_fallback() -> None:
     assert "finish_reason='stop'" in result.llm_fallback_reason
 
 
+def test_extract_retries_once_on_length_then_succeeds() -> None:
+    """Truncated responses are retried once, and success returns extracted data."""
+
+    class _Message:
+        def __init__(self, content: str | None) -> None:
+            self.content = content
+            self.refusal = ""
+            self.tool_calls = []
+
+    first_choice = type(
+        "Choice",
+        (),
+        {
+            "message": _Message(""),
+            "finish_reason": "length",
+        },
+    )()
+
+    second_choice = type(
+        "Choice",
+        (),
+        {
+            "message": _Message(
+                (
+                    '{"name":"Jane Doe", "current_title":"Senior Software Engineer", '
+                    '"address_city":"Berlin", "address_country":"Germany", '
+                    '"email":"jane@example.com"}'
+                )
+            ),
+            "finish_reason": "stop",
+        },
+    )()
+
+    fake_completions = Mock()
+    fake_completions.create.side_effect = [
+        type("Response", (), {"choices": [first_choice]})(),
+        type("Response", (), {"choices": [second_choice]})(),
+    ]
+    extractor = ResumeProfileExtractor(api_key="test-key", max_tokens=32)
+    extractor.client = type(
+        "Client",
+        (),
+        {"chat": type("Chat", (), {"completions": fake_completions})()},
+    )()
+    extractor.model = "fake-model"
+
+    result = extractor.extract("Jane Doe\nSenior Software Engineer\nBerlin, Germany")
+
+    assert fake_completions.create.call_count == 2
+    assert fake_completions.create.call_args_list[0].kwargs["max_tokens"] == 32
+    assert fake_completions.create.call_args_list[1].kwargs["max_tokens"] == 64
+    assert result.first_name == "Jane"
+    assert result.last_name == "Doe"
+    assert result.current_title == "Senior Software Engineer"
+    assert result.source == "fake-model"
+    assert result.llm_fallback_reason is None
+
+
 def test_extract_uses_current_location_and_title_evidence_fields() -> None:
     """LLM evidence fields should backfill location and role outputs deterministically."""
 


### PR DESCRIPTION
## Description\nIncreased resume extraction output budget to 2000 and added a single truncation-aware retry path that retries once with 2x tokens when the first call returns no content with finish_reason='length', while preserving existing heuristic fallback behavior for other failures.\nAdded a configurable  setting (default 2000) in both worker and bot settings and passed it to all ResumeProfileExtractor call sites in worker resume/profile workflows and Discord CRM resume extraction.\nDocumented the new setting in .env.example for easy environment tuning.\n\n## Related Issue\nN/A\n\n## How Has This Been Tested?\nNot run (not requested); hooks (ruff and mypy) ran during commit.