### PR TITLE
feat: add admin SSO user provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,13 @@ API_SHARED_SECRET=
 DISCORD_LOGS_WEBHOOK_URL=
 # Optional: wait for Discord server confirmation before returning from webhook call
 DISCORD_LOGS_WEBHOOK_WAIT=true
+# Authentik admin API (required for /create-sso-user)
+# Base URL can omit /api/v3; the client adds it automatically.
+AUTHENTIK_API_BASE_URL=
+AUTHENTIK_API_TOKEN=
+AUTHENTIK_API_TIMEOUT_SECONDS=20.0
+# Required to send the password recovery email after user creation.
+AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 
 # Dashboard/API auth (OIDC via Authentik; optional until enabled)
 OIDC_ISSUER_URL=

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -53,6 +53,19 @@ This document captures Discord bot behavior, permissions, and slash command usag
     - `cIdVerifiedBy` ← `verified_by`
     - `cVerifiedIdType` ← `id_type`
 
+- `/create-sso-user`
+  - Description: Create or link an Authentik SSO user for a CRM contact.
+  - Required role: Admin
+  - Prerequisites: `AUTHENTIK_API_BASE_URL`, `AUTHENTIK_API_TOKEN`, and `AUTHENTIK_RECOVERY_EMAIL_STAGE_ID` must be configured.
+  - Args:
+    - `search_term` (required): Email, 508 username, or contact ID.
+  - Behavior:
+    - Derives `username` from the contact's `@508.dev` email.
+    - If `cSsoID` is already populated, retrieves that Authentik user and validates it still matches the CRM-derived username/email.
+    - If `cSsoID` is blank, searches Authentik by exact username and exact `@508.dev` email before creating anything.
+    - Updates CRM `cSsoID` with the Authentik numeric user id (`pk`).
+    - Sends the Authentik recovery email only when the user was newly created.
+
 - `/send-member-agreement`
   - Description: Send the member agreement for signature through DocuSeal.
   - Required role: Steering Committee

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -58,9 +58,10 @@ This document captures Discord bot behavior, permissions, and slash command usag
   - Required role: Admin
   - Prerequisites: `AUTHENTIK_API_BASE_URL`, `AUTHENTIK_API_TOKEN`, and `AUTHENTIK_RECOVERY_EMAIL_STAGE_ID` must be configured.
   - Args:
-    - `search_term` (required): Email, 508 username, or contact ID.
+    - `search_term` (required): Discord mention, email, 508 username, or contact ID.
   - Behavior:
     - Derives `username` from the contact's `@508.dev` email.
+    - Supports Discord mentions by resolving the contact from `cDiscordUserID`.
     - If `cSsoID` is already populated, retrieves that Authentik user and validates it still matches the CRM-derived username/email.
     - If `cSsoID` is blank, searches Authentik by exact username and exact `@508.dev` email before creating anything.
     - Updates CRM `cSsoID` with the Authentik numeric user id (`pk`).

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -6419,7 +6419,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         name="create-sso-user",
         description="Create or link an Authentik SSO user for a CRM contact.",
     )
-    @app_commands.describe(search_term="Email, 508 username, or contact ID.")
+    @app_commands.describe(
+        search_term="Discord mention, email, 508 username, or contact ID."
+    )
     @require_role("Admin")
     async def create_sso_user(
         self,

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -20,6 +20,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from five08.discord_bot.config import settings
+from five08.clients.authentik import AuthentikAPIError, AuthentikClient
 from five08.clients import espo
 from five08.clients.docuseal import (
     DocusealAPIError,
@@ -63,6 +64,7 @@ ID_VERIFIED_TYPE_FIELD = "cVerifiedIdType"
 MEMBER_AGREEMENT_SIGNED_AT_FIELD = "cMemberAgreementSignedAt"
 ONBOARDING_STATUS_FIELD = "cOnboardingState"
 ONBOARDER_FIELD = "cOnboarder"
+SSO_ID_FIELD = "cSsoID"
 _DISCORD_ROLES_PROTECTED_FROM_APPLY: frozenset[str] = frozenset(
     {"Member", "Admin", "Steering Committee"}
 )
@@ -2796,6 +2798,97 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             if value:
                 return value
         return None
+
+    def _authentik_client(self) -> AuthentikClient:
+        """Build an Authentik admin API client from shared settings."""
+        base_url = self._contact_text_value(settings.authentik_api_base_url)
+        if not base_url:
+            raise ValueError("AUTHENTIK_API_BASE_URL is not configured.")
+
+        api_token = self._contact_text_value(settings.authentik_api_token)
+        if not api_token:
+            raise ValueError("AUTHENTIK_API_TOKEN is not configured.")
+
+        return AuthentikClient(
+            base_url=base_url,
+            api_token=api_token,
+            timeout_seconds=max(1.0, float(settings.authentik_api_timeout_seconds)),
+        )
+
+    @staticmethod
+    def _normalize_508_email(value: Any) -> str | None:
+        text = str(value or "").strip().lower()
+        if not text or not text.endswith("@508.dev"):
+            return None
+        return text
+
+    def _contact_508_email(self, contact: dict[str, Any]) -> str | None:
+        for field_name in ("c508Email", "emailAddress"):
+            candidate = self._normalize_508_email(contact.get(field_name))
+            if candidate:
+                return candidate
+        return None
+
+    def _resolve_sso_identity_for_contact(
+        self, contact: dict[str, Any]
+    ) -> tuple[str, str]:
+        """Derive the Authentik username and email from CRM's 508 email."""
+        email = self._contact_508_email(contact)
+        if not email:
+            raise ValueError("Selected contact does not have a @508.dev email in CRM.")
+
+        username = self._normalize_508_username(email)
+        if not username:
+            raise ValueError("Unable to derive a 508 username from the CRM email.")
+        return username, email
+
+    @staticmethod
+    def _authentik_user_pk(user: dict[str, Any]) -> int:
+        raw_value = user.get("pk")
+        if isinstance(raw_value, int) and not isinstance(raw_value, bool):
+            return raw_value
+        if isinstance(raw_value, str) and raw_value.strip().isdigit():
+            return int(raw_value.strip())
+        raise ValueError("Authentik response did not include a numeric user id.")
+
+    def _crm_sso_id(self, contact: dict[str, Any]) -> int | None:
+        raw_value = self._contact_text_value(contact.get(SSO_ID_FIELD))
+        if raw_value is None:
+            return None
+        if raw_value.isdigit():
+            return int(raw_value)
+        raise ValueError(f"{SSO_ID_FIELD} must be a numeric Authentik user id.")
+
+    def _validate_authentik_user_for_contact(
+        self,
+        user: dict[str, Any],
+        *,
+        expected_username: str,
+        expected_email: str,
+    ) -> int:
+        """Ensure the located Authentik user matches the CRM-derived identity."""
+        if bool(user.get("is_superuser")):
+            raise ValueError("Refusing to use an Authentik superuser for this command.")
+
+        actual_username = self._normalize_508_username(user.get("username"))
+        if actual_username != expected_username:
+            raise ValueError(
+                "Matched Authentik username does not match the CRM-derived 508 username."
+            )
+
+        actual_email = self._normalize_508_email(user.get("email"))
+        if actual_email != expected_email:
+            raise ValueError(
+                "Matched Authentik email does not match the CRM-derived @508.dev email."
+            )
+
+        return self._authentik_user_pk(user)
+
+    def _authentik_recovery_email_stage_id(self) -> str:
+        stage_id = self._contact_text_value(settings.authentik_recovery_email_stage_id)
+        if not stage_id:
+            raise ValueError("AUTHENTIK_RECOVERY_EMAIL_STAGE_ID is not configured.")
+        return stage_id
 
     async def _create_member_agreement_submission_for_contact(
         self,
@@ -6320,6 +6413,243 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 "❌ An unexpected error occurred while marking ID verification."
+            )
+
+    @app_commands.command(
+        name="create-sso-user",
+        description="Create or link an Authentik SSO user for a CRM contact.",
+    )
+    @app_commands.describe(search_term="Email, 508 username, or contact ID.")
+    @require_role("Admin")
+    async def create_sso_user(
+        self,
+        interaction: discord.Interaction,
+        search_term: str,
+    ) -> None:
+        """Create or link an Authentik SSO user for a CRM contact."""
+        created_user: dict[str, Any] | None = None
+        try:
+            await interaction.response.defer(ephemeral=True)
+
+            contacts = await self._search_contacts_for_lookup(
+                search_term,
+                max_size=5,
+                select=(
+                    f"id,name,emailAddress,c508Email,cDiscordUsername,{SSO_ID_FIELD}"
+                ),
+            )
+            if not contacts:
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.create_sso_user",
+                    result="success",
+                    metadata={"search_term": search_term, "contacts_found": 0},
+                )
+                await interaction.followup.send(
+                    f"❌ No contact found for: `{search_term}`"
+                )
+                return
+
+            if len(contacts) > 1:
+                options = []
+                for contact in contacts[:5]:
+                    name = str(contact.get("name") or "Unknown")
+                    contact_id = str(contact.get("id") or "")
+                    email = self._contact_508_email(contact) or (
+                        self._contact_preferred_email(contact) or "No email"
+                    )
+                    options.append(f"- {name} ({email}, CRM `{contact_id}`)")
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.create_sso_user",
+                    result="success",
+                    metadata={
+                        "search_term": search_term,
+                        "contacts_found": len(contacts),
+                        "requires_selection": True,
+                    },
+                )
+                await interaction.followup.send(
+                    "❌ Multiple CRM contacts matched. Use a more specific search.\n"
+                    + "\n".join(options)
+                )
+                return
+
+            contact = contacts[0]
+            contact_id = str(contact.get("id") or "")
+            contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
+            username, email = self._resolve_sso_identity_for_contact(contact)
+            client = self._authentik_client()
+
+            user: dict[str, Any]
+            user_id: int
+            crm_updated = False
+            created = False
+            recovery_email_error: str | None = None
+
+            linked_sso_id = self._crm_sso_id(contact)
+            if linked_sso_id is not None:
+                user = await asyncio.to_thread(client.get_user, linked_sso_id)
+                user_id = self._validate_authentik_user_for_contact(
+                    user,
+                    expected_username=username,
+                    expected_email=email,
+                )
+            else:
+                matches = await asyncio.to_thread(
+                    client.find_users_by_username_or_email,
+                    username=username,
+                    email=email,
+                )
+                if len(matches) > 1:
+                    raise ValueError(
+                        "Multiple Authentik users matched this CRM contact. "
+                        "Resolve the duplicate manually before linking."
+                    )
+
+                if matches:
+                    user = matches[0]
+                    user_id = self._validate_authentik_user_for_contact(
+                        user,
+                        expected_username=username,
+                        expected_email=email,
+                    )
+                else:
+                    recovery_email_stage_id = self._authentik_recovery_email_stage_id()
+                    created_user = await asyncio.to_thread(
+                        client.create_user,
+                        username=username,
+                        name=contact_name,
+                        email=email,
+                    )
+                    created = True
+                    user = created_user
+                    user_id = self._validate_authentik_user_for_contact(
+                        user,
+                        expected_username=username,
+                        expected_email=email,
+                    )
+                    try:
+                        await asyncio.to_thread(
+                            client.send_recovery_email,
+                            user_id=user_id,
+                            email_stage=recovery_email_stage_id,
+                        )
+                    except AuthentikAPIError as exc:
+                        recovery_email_error = self._sanitize_error_message_for_discord(
+                            exc
+                        )
+
+                self.espo_api.request(
+                    "PUT",
+                    f"Contact/{contact_id}",
+                    {SSO_ID_FIELD: str(user_id)},
+                )
+                crm_updated = True
+
+            message_lines = [
+                (
+                    "✅ Created SSO user and linked the CRM contact."
+                    if created
+                    else (
+                        "✅ Linked the existing SSO user to the CRM contact."
+                        if crm_updated
+                        else "✅ CRM contact is already linked to the matching SSO user."
+                    )
+                ),
+                f"Contact: `{contact_name}`",
+                f"CRM ID: `{contact_id}`",
+                f"SSO user ID: `{user_id}`",
+                f"Username: `{username}`",
+                f"Email: `{email}`",
+            ]
+            if created:
+                if recovery_email_error is None:
+                    message_lines.append("Recovery email: sent.")
+                else:
+                    message_lines.append(
+                        f"Recovery email failed: `{recovery_email_error}`"
+                    )
+            else:
+                message_lines.append(
+                    "Recovery email not sent because the user already existed."
+                )
+
+            self._audit_command(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="success",
+                metadata={
+                    "search_term": search_term,
+                    "contact_id": contact_id,
+                    "username": username,
+                    "email": email,
+                    "sso_user_id": user_id,
+                    "created": created,
+                    "crm_updated": crm_updated,
+                    "recovery_email_error": recovery_email_error,
+                },
+                resource_type="crm_contact",
+                resource_id=contact_id,
+            )
+            await interaction.followup.send("\n".join(message_lines))
+        except ValueError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="denied",
+                metadata={"search_term": search_term, "reason": message},
+            )
+            await interaction.followup.send(f"❌ {message}")
+        except EspoAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            if created_user is not None:
+                partial_user_id = self._authentik_user_pk(created_user)
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.create_sso_user",
+                    result="error",
+                    metadata={
+                        "search_term": search_term,
+                        "partial_user_id": partial_user_id,
+                        "error": message,
+                        "partial_success": "sso_created_crm_update_failed",
+                    },
+                )
+                await interaction.followup.send(
+                    "⚠️ Created the SSO user, but failed to update CRM "
+                    f"`{SSO_ID_FIELD}`.\nSSO user ID: `{partial_user_id}`\n"
+                    f"Error: `{message}`"
+                )
+                return
+
+            self._audit_command(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="error",
+                metadata={"search_term": search_term, "error": message},
+            )
+            await interaction.followup.send(f"❌ CRM API error: {message}")
+        except AuthentikAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="error",
+                metadata={"search_term": search_term, "error": message},
+            )
+            await interaction.followup.send(f"❌ Authentik API error: {message}")
+        except Exception as exc:
+            logger.error(f"Unexpected error in create_sso_user: {exc}")
+            self._audit_command(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="error",
+                metadata={"search_term": search_term, "error": str(exc)},
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while creating the SSO user."
             )
 
     @app_commands.command(

--- a/packages/shared/src/five08/clients/__init__.py
+++ b/packages/shared/src/five08/clients/__init__.py
@@ -1,5 +1,5 @@
 """API clients shared across services."""
 
-from . import docuseal, espo, kimai, migadu
+from . import authentik, docuseal, espo, kimai, migadu
 
-__all__ = ["docuseal", "espo", "kimai", "migadu"]
+__all__ = ["authentik", "docuseal", "espo", "kimai", "migadu"]

--- a/packages/shared/src/five08/clients/authentik.py
+++ b/packages/shared/src/five08/clients/authentik.py
@@ -1,0 +1,183 @@
+"""Shared Authentik admin API helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+class AuthentikAPIError(Exception):
+    """Raised when an Authentik API call fails."""
+
+
+def _normalize_api_base_url(base_url: str) -> str:
+    normalized = base_url.rstrip("/")
+    if normalized.endswith("/api/v3"):
+        return normalized
+    return f"{normalized}/api/v3"
+
+
+class AuthentikClient:
+    """Minimal client for Authentik's admin user endpoints."""
+
+    def __init__(
+        self,
+        base_url: str,
+        api_token: str,
+        timeout_seconds: float = 20.0,
+    ) -> None:
+        self.base_url = _normalize_api_base_url(base_url)
+        self.api_token = api_token
+        self.timeout_seconds = timeout_seconds
+        self.status_code: int | None = None
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        payload: dict[str, Any] | None = None,
+    ) -> Any:
+        """Send one request to the Authentik admin API."""
+        url = f"{self.base_url}/{path.lstrip('/')}"
+
+        try:
+            response = requests.request(
+                method.upper(),
+                url,
+                headers=self._headers(),
+                params=params,
+                json=payload,
+                timeout=self.timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise AuthentikAPIError(f"HTTP request failed: {exc}") from exc
+
+        self.status_code = response.status_code
+        if not 200 <= response.status_code < 300:
+            message = " ".join((response.text or "").split()).strip() or "Unknown Error"
+            raise AuthentikAPIError(
+                f"Wrong request, status code is {response.status_code}, reason is {message}"
+            )
+
+        if not response.content:
+            return {}
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            body_preview = " ".join((response.text or "").strip().split())
+            if len(body_preview) > 200:
+                body_preview = body_preview[:200] + "..."
+            if not body_preview:
+                body_preview = "<empty>"
+            raise AuthentikAPIError(
+                f"Failed to decode JSON response (status {response.status_code}). "
+                f"Body preview: {body_preview}"
+            ) from exc
+
+    def list_users(self, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        response = self.request("GET", "core/users/", params=params)
+        if not isinstance(response, dict):
+            raise AuthentikAPIError("API response is not a JSON object")
+        return response
+
+    def get_user(self, user_id: int | str) -> dict[str, Any]:
+        response = self.request("GET", f"core/users/{user_id}/")
+        if not isinstance(response, dict):
+            raise AuthentikAPIError("API response is not a JSON object")
+        return response
+
+    def create_user(
+        self,
+        *,
+        username: str,
+        name: str,
+        email: str | None = None,
+        is_active: bool = True,
+        path: str | None = None,
+        user_type: str = "internal",
+        groups: list[str] | None = None,
+        roles: list[str] | None = None,
+        attributes: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "username": username,
+            "name": name,
+            "is_active": is_active,
+            "type": user_type,
+        }
+        if email:
+            payload["email"] = email
+        if path:
+            payload["path"] = path
+        if groups:
+            payload["groups"] = groups
+        if roles:
+            payload["roles"] = roles
+        if attributes is not None:
+            payload["attributes"] = attributes
+
+        response = self.request("POST", "core/users/", payload=payload)
+        if not isinstance(response, dict):
+            raise AuthentikAPIError("API response is not a JSON object")
+        return response
+
+    def send_recovery_email(
+        self,
+        *,
+        user_id: int | str,
+        email_stage: str,
+        token_duration: str | None = None,
+    ) -> None:
+        payload: dict[str, Any] = {"email_stage": email_stage}
+        if token_duration:
+            payload["token_duration"] = token_duration
+        self.request(
+            "POST",
+            f"core/users/{user_id}/recovery_email/",
+            payload=payload,
+        )
+
+    def find_users_by_username_or_email(
+        self,
+        *,
+        username: str,
+        email: str,
+        page_size: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Search exact username and exact email, deduplicated by user id."""
+        matches: list[dict[str, Any]] = []
+        seen_keys: set[str] = set()
+
+        for params in (
+            {"username": username, "page_size": page_size},
+            {"email": email, "page_size": page_size},
+        ):
+            response = self.list_users(params=params)
+            raw_results = response.get("results")
+            results = raw_results if isinstance(raw_results, list) else []
+            for user in results:
+                if not isinstance(user, dict):
+                    continue
+                key = str(
+                    user.get("pk")
+                    or user.get("uuid")
+                    or user.get("uid")
+                    or f"{user.get('username')}:{user.get('email')}"
+                )
+                if key in seen_keys:
+                    continue
+                seen_keys.add(key)
+                matches.append(user)
+
+        return matches

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -48,6 +48,10 @@ class SharedSettings(BaseSettings):
     docuseal_base_url: str | None = None
     docuseal_api_key: str | None = None
     docuseal_member_agreement_template_id: int | None = None
+    authentik_api_base_url: str | None = None
+    authentik_api_token: str | None = None
+    authentik_api_timeout_seconds: float = 20.0
+    authentik_recovery_email_stage_id: str | None = None
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/tests/unit/test_authentik_client.py
+++ b/tests/unit/test_authentik_client.py
@@ -1,0 +1,117 @@
+"""Unit tests for the shared Authentik client."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from five08.clients.authentik import AuthentikAPIError, AuthentikClient
+
+
+def test_create_user_posts_expected_payload() -> None:
+    """User creation should post a minimal non-superuser payload."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'{"pk": 42}'
+    mock_response.json.return_value = {"pk": 42}
+
+    with patch(
+        "five08.clients.authentik.requests.request",
+        return_value=mock_response,
+    ) as mock_request:
+        result = AuthentikClient(
+            "https://authentik.example.com",
+            "secret",
+        ).create_user(
+            username="jane",
+            name="Jane Doe",
+            email="jane@508.dev",
+        )
+
+    assert result == {"pk": 42}
+    mock_request.assert_called_once_with(
+        "POST",
+        "https://authentik.example.com/api/v3/core/users/",
+        headers={
+            "Accept": "application/json",
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        },
+        params=None,
+        json={
+            "username": "jane",
+            "name": "Jane Doe",
+            "is_active": True,
+            "type": "internal",
+            "email": "jane@508.dev",
+        },
+        timeout=20.0,
+    )
+
+
+def test_send_recovery_email_posts_required_stage() -> None:
+    """Recovery emails should use the Authentik stage UUID payload."""
+    mock_response = Mock()
+    mock_response.status_code = 204
+    mock_response.content = b""
+    mock_response.text = ""
+
+    with patch(
+        "five08.clients.authentik.requests.request",
+        return_value=mock_response,
+    ) as mock_request:
+        AuthentikClient(
+            "https://authentik.example.com/api/v3",
+            "secret",
+        ).send_recovery_email(
+            user_id=42,
+            email_stage="3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        )
+
+    mock_request.assert_called_once_with(
+        "POST",
+        "https://authentik.example.com/api/v3/core/users/42/recovery_email/",
+        headers={
+            "Accept": "application/json",
+            "Authorization": "Bearer secret",
+            "Content-Type": "application/json",
+        },
+        params=None,
+        json={"email_stage": "3fa85f64-5717-4562-b3fc-2c963f66afa6"},
+        timeout=20.0,
+    )
+
+
+def test_find_users_by_username_or_email_deduplicates_matches() -> None:
+    """Username and email lookups should return unique users by id."""
+    client = AuthentikClient("https://authentik.example.com", "secret")
+
+    with patch.object(
+        client,
+        "list_users",
+        side_effect=[
+            {"results": [{"pk": 42, "username": "jane", "email": "jane@508.dev"}]},
+            {"results": [{"pk": 42, "username": "jane", "email": "jane@508.dev"}]},
+        ],
+    ) as mock_list:
+        result = client.find_users_by_username_or_email(
+            username="jane",
+            email="jane@508.dev",
+        )
+
+    assert result == [{"pk": 42, "username": "jane", "email": "jane@508.dev"}]
+    assert mock_list.call_count == 2
+
+
+def test_request_raises_on_non_success_status() -> None:
+    """Non-2xx Authentik responses should raise a shared API error."""
+    mock_response = Mock()
+    mock_response.status_code = 403
+    mock_response.text = '{"detail":"forbidden"}'
+    mock_response.content = b'{"detail":"forbidden"}'
+
+    with patch(
+        "five08.clients.authentik.requests.request",
+        return_value=mock_response,
+    ):
+        with pytest.raises(AuthentikAPIError, match="status code is 403"):
+            AuthentikClient("https://authentik.example.com", "secret").get_user(42)

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -1,0 +1,159 @@
+"""Unit tests for the CRM SSO provisioning command."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from five08.discord_bot.cogs.crm import CRMCog
+
+
+@pytest.fixture
+def mock_interaction() -> AsyncMock:
+    interaction = AsyncMock()
+    interaction.response = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = Mock()
+    role = Mock()
+    role.name = "Admin"
+    interaction.user.roles = [role]
+    return interaction
+
+
+@pytest.fixture
+def cog() -> CRMCog:
+    return CRMCog(Mock())
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_creates_links_and_sends_recovery_email(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "c508Email": "jane@508.dev",
+        "cSsoID": None,
+    }
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = []
+    authentik_client.create_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client.send_recovery_email.return_value = None
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(
+            cog, "_authentik_recovery_email_stage_id", return_value="stage-id"
+        ),
+        patch.object(cog, "_audit_command") as mock_audit,
+        patch.object(
+            cog.espo_api, "request", return_value={"id": "crm-123"}
+        ) as mock_espo,
+    ):
+        await cog.create_sso_user.callback(cog, mock_interaction, search_term="jane")
+
+    mock_interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    authentik_client.create_user.assert_called_once_with(
+        username="jane",
+        name="Jane Doe",
+        email="jane@508.dev",
+    )
+    authentik_client.send_recovery_email.assert_called_once_with(
+        user_id=42,
+        email_stage="stage-id",
+    )
+    mock_espo.assert_called_once_with(
+        "PUT",
+        "Contact/crm-123",
+        {"cSsoID": "42"},
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Created SSO user" in message
+    assert "Recovery email: sent." in message
+    mock_audit.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_links_existing_user_without_recovery_email(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "c508Email": "jane@508.dev",
+        "cSsoID": None,
+    }
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = [
+        {
+            "pk": 42,
+            "username": "jane",
+            "email": "jane@508.dev",
+            "name": "Jane Doe",
+            "is_superuser": False,
+        }
+    ]
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_audit_command"),
+        patch.object(cog.espo_api, "request", return_value={"id": "crm-123"}),
+    ):
+        await cog.create_sso_user.callback(cog, mock_interaction, search_term="jane")
+
+    authentik_client.create_user.assert_not_called()
+    authentik_client.send_recovery_email.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Linked the existing SSO user" in message
+
+
+@pytest.mark.asyncio
+async def test_create_sso_user_rejects_superuser_match(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "c508Email": "jane@508.dev",
+        "cSsoID": "42",
+    }
+    authentik_client = Mock()
+    authentik_client.get_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": True,
+    }
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_audit_command"),
+    ):
+        await cog.create_sso_user.callback(cog, mock_interaction, search_term="jane")
+
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "superuser" in message


### PR DESCRIPTION
## Description
Adds a shared Authentik admin client and a new admin-only `/create-sso-user` CRM command that links `cSsoID`, reuses existing Authentik users when possible, refuses superusers, and sends a recovery email only on fresh user creation. This also adds the required shared Authentik config, command docs, and unit coverage for the shared client and CRM command flow.

## Related Issue
Closes #54

## How Has This Been Tested?
- `uv run pytest tests/unit/test_authentik_client.py tests/unit/test_crm_create_sso_user.py`
- `uv run pytest tests/unit/test_discord_command_metadata.py tests/unit/test_admin_login_cog.py`
- `uv run ruff check packages/shared/src/five08/clients/authentik.py apps/discord_bot/src/five08/discord_bot/cogs/crm.py tests/unit/test_authentik_client.py tests/unit/test_crm_create_sso_user.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only /create-sso-user command to search CRM contacts and create or link SSO accounts via Authentik, with validation and audit logging
  * Integrated Authentik SSO support including user lookup, creation, and optional recovery-email sending for newly provisioned users

* **Documentation**
  * Added Authentik configuration entries to .env.example and documented command usage in the Discord bot README

* **Tests**
  * Added unit tests for the Authentik client and the CRM SSO provisioning command
<!-- end of auto-generated comment: release notes by coderabbit.ai -->