### PR TITLE
fix: make resume download responses ephemeral

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -221,7 +221,8 @@ class ResumeDownloadButton(discord.ui.Button[discord.ui.View]):
                     resource_id=self.resume_id,
                 )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while downloading the resume."
+                "❌ An unexpected error occurred while downloading the resume.",
+                ephemeral=True,
             )
 
 
@@ -4624,13 +4625,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             discord_file = discord.File(file_buffer, filename=filename)
 
             await interaction.followup.send(
-                f"📄 Resume for **{contact_name}**:", file=discord_file
+                f"📄 Resume for **{contact_name}**:", file=discord_file, ephemeral=True
             )
             return True
 
         except EspoAPIError as e:
             logger.error(f"Failed to download resume {resume_id}: {e}")
-            await interaction.followup.send(f"❌ Failed to download resume: {str(e)}")
+            await interaction.followup.send(f"❌ Failed to download resume: {str(e)}", ephemeral=True)
             return False
 
     def _check_member_role(self, interaction: discord.Interaction) -> bool:

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4631,7 +4631,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         except EspoAPIError as e:
             logger.error(f"Failed to download resume {resume_id}: {e}")
-            await interaction.followup.send(f"❌ Failed to download resume: {str(e)}", ephemeral=True)
+            await interaction.followup.send(
+                f"❌ Failed to download resume: {str(e)}", ephemeral=True
+            )
             return False
 
     def _check_member_role(self, interaction: discord.Interaction) -> bool:

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -1919,7 +1919,7 @@ class TestCRMCog:
         )
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ Failed to download resume: API Error"
+            "❌ Failed to download resume: API Error", ephemeral=True
         )
 
     def test_role_id_cache_initializes_empty(self, jobs_cog):


### PR DESCRIPTION
## Title
Fix: Make resume download responses ephemeral 

## Issue
When using the /search-member command and clicking the "Resume" button, the response is sent to everyone in the channel instead of being visible only to the user who triggered the command. This behavior is inconsistent with the expected use case — the response should be ephemeral (visible only to the caller).

## Description                                                                                              
  Resume responses sent via the Resume button (from /search-members)                                                      
  were visible to all channel members. This fix ensures all responses
  from the resume download flow are ephemeral — only visible to the                                                       
  user who triggered the interaction.   
  
  ### Fixed three missing `ephemeral=True`:                                                                                   
  - Successful resume file send in `_download_and_send_resume`                                                            
  - API error message in `_download_and_send_resume`                                                                    
  - Unexpected error handler in `ResumeDownloadButton.callback` 

## How Has This Been Tested?
Updated existing unit test `test_download_and_send_resume_api_error`                                                    
to assert ephemeral=True is passed. All 907 unit tests pass.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Resume download error notifications are now sent privately to the requesting user instead of publicly.
  * Successfully downloaded resumes are now delivered privately to the requesting user instead of publicly.
  * CRM API failure messages shown during resume download are now private to the requester.

* **Tests**
  * Unit tests updated to expect private (ephemeral) follow-up messages for the resume-download error path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->