### PR TITLE
feat: tighten candidate matching workflow

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -533,6 +533,35 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         return messages
 
     @staticmethod
+    def _sanitize_match_text(value: str) -> str:
+        normalized = re.sub(r"\s+", " ", value).strip()
+        escaped_mentions = discord.utils.escape_mentions(normalized).replace(
+            "@", "@\u200b"
+        )
+        return discord.utils.escape_markdown(escaped_mentions)
+
+    @classmethod
+    def _format_match_inline_code(cls, value: str) -> str:
+        normalized = re.sub(r"\s+", " ", value).strip()
+        escaped_mentions = discord.utils.escape_mentions(normalized).replace(
+            "@", "@\u200b"
+        )
+        return f"`{escaped_mentions.replace('`', 'ˋ')}`"
+
+    @staticmethod
+    def _build_rerank_evidence(candidate: Any) -> list[str]:
+        evidence: list[str] = []
+        if getattr(candidate, "linkedin", None):
+            evidence.append("linkedin profile on file")
+        if getattr(candidate, "github_username", None):
+            evidence.append("github profile on file")
+        if getattr(candidate, "latest_resume_name", None):
+            evidence.append("resume on file")
+        if getattr(candidate, "matched_discord_roles", None):
+            evidence.append("relevant discord role match")
+        return evidence
+
+    @staticmethod
     def _build_match_candidate_lines(
         *,
         candidates: list[Any],
@@ -651,25 +680,42 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             if matched_hard_required_skills:
                 skill_info.append(
                     "hard: "
-                    + ", ".join(f"`{s}`" for s in matched_hard_required_skills[:4])
+                    + ", ".join(
+                        JobsCog._format_match_inline_code(s)
+                        for s in matched_hard_required_skills[:4]
+                    )
                 )
             if matched_soft_required_skills:
                 skill_info.append(
                     "soft: "
-                    + ", ".join(f"`{s}`" for s in matched_soft_required_skills[:4])
+                    + ", ".join(
+                        JobsCog._format_match_inline_code(s)
+                        for s in matched_soft_required_skills[:4]
+                    )
                 )
             elif matched_required_skills and not matched_hard_required_skills:
                 skill_info.append(
-                    "✅ " + ", ".join(f"`{s}`" for s in matched_required_skills[:5])
+                    "✅ "
+                    + ", ".join(
+                        JobsCog._format_match_inline_code(s)
+                        for s in matched_required_skills[:5]
+                    )
                 )
             if matched_preferred_skills:
                 skill_info.append(
                     "preferred: "
-                    + ", ".join(f"`{s}`" for s in matched_preferred_skills[:3])
+                    + ", ".join(
+                        JobsCog._format_match_inline_code(s)
+                        for s in matched_preferred_skills[:3]
+                    )
                 )
             if candidate.matched_discord_roles:
                 skill_info.append(
-                    "🏷️ " + ", ".join(f"`{r}`" for r in candidate.matched_discord_roles)
+                    "🏷️ "
+                    + ", ".join(
+                        JobsCog._format_match_inline_code(r)
+                        for r in candidate.matched_discord_roles
+                    )
                 )
             seniority_label = format_seniority_label(
                 getattr(candidate, "seniority", None),
@@ -680,16 +726,21 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             if location:
                 location_info.append(f"location: **{location}**")
             if candidate.timezone:
-                location_info.append(f"tz: `{candidate.timezone}`")
+                location_info.append(
+                    f"tz: {JobsCog._format_match_inline_code(candidate.timezone)}"
+                )
             if evidence_signals:
-                followup_info.append("evidence: " + " · ".join(evidence_signals[:4]))
+                followup_info.append(
+                    "evidence: "
+                    + " · ".join(
+                        JobsCog._sanitize_match_text(signal)
+                        for signal in evidence_signals[:4]
+                    )
+                )
             llm_summary = getattr(candidate, "llm_summary", None)
             if isinstance(llm_summary, str) and llm_summary.strip():
                 followup_info.append(
-                    "summary: "
-                    + discord.utils.escape_mentions(
-                        re.sub(r"\s+", " ", llm_summary).strip()
-                    )
+                    "summary: " + JobsCog._sanitize_match_text(llm_summary)
                 )
             missing_items = missing_hard_required_skills + [
                 item
@@ -698,13 +749,17 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             ]
             if missing_items:
                 followup_info.append(
-                    "missing: " + " · ".join(f"`{item}`" for item in missing_items[:4])
+                    "missing: "
+                    + " · ".join(
+                        JobsCog._format_match_inline_code(item)
+                        for item in missing_items[:4]
+                    )
                 )
             elif llm_risks:
                 followup_info.append(
                     "risks: "
                     + " · ".join(
-                        discord.utils.escape_mentions(item) for item in llm_risks[:3]
+                        JobsCog._sanitize_match_text(item) for item in llm_risks[:3]
                     )
                 )
             line = " ".join(header_parts)
@@ -720,14 +775,6 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
 
     @staticmethod
     def _candidate_rerank_id(candidate: Any, index: int) -> str:
-        crm_contact_id = getattr(candidate, "crm_contact_id", None)
-        if isinstance(crm_contact_id, str) and crm_contact_id.strip():
-            return f"crm:{crm_contact_id.strip()}"
-
-        discord_user_id = getattr(candidate, "discord_user_id", None)
-        if isinstance(discord_user_id, str) and discord_user_id.strip():
-            return f"discord:{discord_user_id.strip()}"
-
         return f"candidate:{index}"
 
     @classmethod
@@ -737,22 +784,14 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         candidate: Any,
         index: int,
     ) -> dict[str, Any]:
-        location_parts = [
-            part.strip()
-            for part in (
-                getattr(candidate, "address_city", None),
-                getattr(candidate, "address_state", None),
-                getattr(candidate, "address_country", None),
-            )
-            if isinstance(part, str) and part.strip()
-        ]
+        country = getattr(candidate, "address_country", None)
         return {
             "candidate_id": cls._candidate_rerank_id(candidate, index),
-            "name": getattr(candidate, "crm_name", None)
-            or getattr(candidate, "name", None),
             "is_member": bool(getattr(candidate, "is_member", False)),
             "seniority": getattr(candidate, "seniority", None),
-            "location": ", ".join(location_parts) if location_parts else None,
+            "country": country.strip()
+            if isinstance(country, str) and country.strip()
+            else None,
             "timezone": getattr(candidate, "timezone", None),
             "hard_required_matches": list(
                 getattr(candidate, "matched_hard_required_skills", []) or []
@@ -769,10 +808,10 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             "matched_discord_roles": list(
                 getattr(candidate, "matched_discord_roles", []) or []
             ),
-            "evidence": list(getattr(candidate, "evidence_signals", []) or []),
-            "linkedin": getattr(candidate, "linkedin", None),
-            "github_username": getattr(candidate, "github_username", None),
-            "resume_name": getattr(candidate, "latest_resume_name", None),
+            "evidence": cls._build_rerank_evidence(candidate),
+            "has_linkedin": bool(getattr(candidate, "linkedin", None)),
+            "has_github": bool(getattr(candidate, "github_username", None)),
+            "has_resume": bool(getattr(candidate, "latest_resume_name", None)),
             "deterministic_match_score": getattr(candidate, "match_score", None),
         }
 
@@ -820,30 +859,70 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return candidates
 
         result_map = {result.candidate_id: result for result in rerank_results}
-        reranked_shortlist: list[Any] = []
+        result_rank = {
+            result.candidate_id: rank for rank, result in enumerate(rerank_results)
+        }
+        reranked_shortlist: list[tuple[Any, str, int]] = []
         for index, candidate in enumerate(shortlist, start=1):
-            result = result_map.get(self._candidate_rerank_id(candidate, index))
+            candidate_id = self._candidate_rerank_id(candidate, index)
+            result = result_map.get(candidate_id)
             if result is None:
-                reranked_shortlist.append(candidate)
+                reranked_shortlist.append((candidate, candidate_id, index))
                 continue
             reranked_shortlist.append(
-                self._apply_candidate_overrides(
-                    candidate,
-                    llm_fit_score=result.fit_score,
-                    llm_summary=result.summary,
-                    llm_risks=result.risks,
-                    llm_missing_requirements=result.missing_requirements,
+                (
+                    self._apply_candidate_overrides(
+                        candidate,
+                        llm_fit_score=result.fit_score,
+                        llm_summary=result.summary,
+                        llm_risks=result.risks,
+                        llm_missing_requirements=result.missing_requirements,
+                    ),
+                    candidate_id,
+                    index,
                 )
             )
 
         reranked_shortlist.sort(
-            key=lambda candidate: (
-                getattr(candidate, "llm_fit_score", None) is None,
-                -(float(getattr(candidate, "llm_fit_score", 0.0) or 0.0)),
-                -(float(getattr(candidate, "match_score", 0.0) or 0.0)),
+            key=lambda entry: (
+                getattr(entry[0], "llm_fit_score", None) is None,
+                -(float(getattr(entry[0], "llm_fit_score", 0.0) or 0.0)),
+                result_rank.get(entry[1], len(result_rank)),
+                -(float(getattr(entry[0], "match_score", 0.0) or 0.0)),
+                entry[2],
             )
         )
-        return reranked_shortlist + candidates[len(shortlist) :]
+        return [candidate for candidate, _, _ in reranked_shortlist] + candidates[
+            len(shortlist) :
+        ]
+
+    @staticmethod
+    def _has_match_requirements(requirements: JobRequirements) -> bool:
+        return bool(requirements.required_skills or requirements.discord_role_types)
+
+    async def _search_and_rerank_candidates(
+        self,
+        *,
+        posting: str,
+        requirements: JobRequirements,
+        guild_id: str | None,
+        limit: int,
+        min_match_score: float = 0.0,
+    ) -> list[Any]:
+        candidates = await asyncio.to_thread(
+            search_candidates,
+            settings,
+            requirements,
+            guild_id=guild_id,
+            limit=limit,
+            min_match_score=min_match_score,
+        )
+
+        return await self._rerank_candidates(
+            posting=posting,
+            requirements=requirements,
+            candidates=candidates,
+        )
 
     @staticmethod
     def _resume_file_extension(filename: str | None) -> str:
@@ -1332,7 +1411,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
-        if not requirements.required_skills and not requirements.discord_role_types:
+        if not self._has_match_requirements(requirements):
             await self._unmark_thread_auto_matched(thread.id)
             await thread.send(
                 "⚠️ No useful hard/soft skills or role types could be extracted automatically. "
@@ -1341,10 +1420,9 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         try:
-            candidates = await asyncio.to_thread(
-                search_candidates,
-                settings,
-                requirements,
+            candidates = await self._search_and_rerank_candidates(
+                posting=posting,
+                requirements=requirements,
                 guild_id=str(thread.guild.id) if thread.guild else None,
                 limit=10,
             )
@@ -1362,12 +1440,6 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 "Run `/match-candidates` manually in this thread."
             )
             return
-
-        candidates = await self._rerank_candidates(
-            posting=posting,
-            requirements=requirements,
-            candidates=candidates,
-        )
 
         await self._publish_match_results(
             send=thread.send,
@@ -1820,7 +1892,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
-        if not requirements.required_skills and not requirements.discord_role_types:
+        if not self._has_match_requirements(requirements):
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.match_candidates",
@@ -1835,10 +1907,9 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         try:
-            candidates = await asyncio.to_thread(
-                search_candidates,
-                settings,
-                requirements,
+            candidates = await self._search_and_rerank_candidates(
+                posting=posting,
+                requirements=requirements,
                 guild_id=str(interaction.guild.id) if interaction.guild else None,
                 limit=20,
                 min_match_score=8.0,
@@ -1856,12 +1927,6 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 ephemeral=True,
             )
             return
-
-        candidates = await self._rerank_candidates(
-            posting=posting,
-            requirements=requirements,
-            candidates=candidates,
-        )
 
         async def _send_match_result(message: str, **kwargs: Any) -> None:
             if is_private:

--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -9,8 +9,8 @@ import logging
 import re
 import socket
 from collections import OrderedDict
-from dataclasses import dataclass
-from typing import Any, Awaitable, Callable, Literal
+from dataclasses import dataclass, is_dataclass, replace
+from typing import Any, Awaitable, Callable, Literal, cast
 from urllib.parse import urljoin, urlsplit
 
 import aiohttp
@@ -37,6 +37,7 @@ from five08.job_match import (
     DISCORD_ROLES_EXCLUDE_FROM_SYNC,
     JobRequirements,
     extract_job_requirements,
+    rerank_shortlisted_candidates,
 )
 
 logger = logging.getLogger(__name__)
@@ -468,10 +469,25 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 locality_mentions_line = "Locality: " + ", ".join(locality_mentions)
                 locality_mentions_role_ids = role_ids
 
-        if requirements.required_skills:
+        if requirements.hard_required_skills:
+            header_parts.append(
+                "Hard needs: "
+                + ", ".join(f"`{s}`" for s in requirements.hard_required_skills[:5])
+            )
+        elif requirements.required_skills:
             header_parts.append(
                 "Skills: "
                 + ", ".join(f"`{s}`" for s in requirements.required_skills[:8])
+            )
+        if requirements.soft_required_skills:
+            header_parts.append(
+                "Other needs: "
+                + ", ".join(f"`{s}`" for s in requirements.soft_required_skills[:5])
+            )
+        if requirements.required_evidence:
+            header_parts.append(
+                "Evidence: "
+                + ", ".join(f"`{item}`" for item in requirements.required_evidence[:3])
             )
         if requirements.seniority:
             header_parts.append(f"Seniority: `{requirements.seniority}`")
@@ -603,15 +619,53 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 for part in (raw_city, raw_state, raw_country)
                 if part
             )
+            matched_hard_required_skills = list(
+                getattr(candidate, "matched_hard_required_skills", []) or []
+            )
+            matched_soft_required_skills = list(
+                getattr(candidate, "matched_soft_required_skills", []) or []
+            )
+            matched_required_skills = list(
+                getattr(candidate, "matched_required_skills", []) or []
+            )
+            matched_preferred_skills = list(
+                getattr(candidate, "matched_preferred_skills", []) or []
+            )
+            missing_hard_required_skills = list(
+                getattr(candidate, "missing_hard_required_skills", []) or []
+            )
+            evidence_signals = list(getattr(candidate, "evidence_signals", []) or [])
+            llm_risks = list(getattr(candidate, "llm_risks", []) or [])
+            llm_missing_requirements = list(
+                getattr(candidate, "llm_missing_requirements", []) or []
+            )
             skill_info: list[str] = []
             location_info: list[str] = []
+            followup_info: list[str] = []
             match_score = getattr(candidate, "match_score", None)
             if isinstance(match_score, (int, float)):
                 skill_info.append(f"score: {match_score:.1f}")
-            if candidate.matched_required_skills:
+            llm_fit_score = getattr(candidate, "llm_fit_score", None)
+            if isinstance(llm_fit_score, (int, float)):
+                skill_info.append(f"LLM fit: {llm_fit_score:.0f}/100")
+            if matched_hard_required_skills:
                 skill_info.append(
-                    "✅ "
-                    + ", ".join(f"`{s}`" for s in candidate.matched_required_skills[:5])
+                    "hard: "
+                    + ", ".join(f"`{s}`" for s in matched_hard_required_skills[:4])
+                )
+            if matched_soft_required_skills:
+                skill_info.append(
+                    "soft: "
+                    + ", ".join(f"`{s}`" for s in matched_soft_required_skills[:4])
+                )
+            elif matched_required_skills and not matched_hard_required_skills:
+                skill_info.append(
+                    "✅ " + ", ".join(f"`{s}`" for s in matched_required_skills[:5])
+                )
+            if matched_preferred_skills:
+                skill_info.append(
+                    "preferred: "
+                    + ", ".join(f"`{s}`" for s in matched_preferred_skills[:3])
                 )
             if candidate.matched_discord_roles:
                 skill_info.append(
@@ -627,14 +681,169 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 location_info.append(f"location: **{location}**")
             if candidate.timezone:
                 location_info.append(f"tz: `{candidate.timezone}`")
+            if evidence_signals:
+                followup_info.append("evidence: " + " · ".join(evidence_signals[:4]))
+            llm_summary = getattr(candidate, "llm_summary", None)
+            if isinstance(llm_summary, str) and llm_summary.strip():
+                followup_info.append(
+                    "summary: "
+                    + discord.utils.escape_mentions(
+                        re.sub(r"\s+", " ", llm_summary).strip()
+                    )
+                )
+            missing_items = missing_hard_required_skills + [
+                item
+                for item in llm_missing_requirements
+                if item not in missing_hard_required_skills
+            ]
+            if missing_items:
+                followup_info.append(
+                    "missing: " + " · ".join(f"`{item}`" for item in missing_items[:4])
+                )
+            elif llm_risks:
+                followup_info.append(
+                    "risks: "
+                    + " · ".join(
+                        discord.utils.escape_mentions(item) for item in llm_risks[:3]
+                    )
+                )
             line = " ".join(header_parts)
             if skill_info:
                 line += "\n   " + " · ".join(skill_info)
             if location_info:
                 line += "\n   " + " · ".join(location_info)
+            for detail_line in followup_info:
+                line += "\n   " + detail_line
 
             lines.append(line)
         return lines, resume_options
+
+    @staticmethod
+    def _candidate_rerank_id(candidate: Any, index: int) -> str:
+        crm_contact_id = getattr(candidate, "crm_contact_id", None)
+        if isinstance(crm_contact_id, str) and crm_contact_id.strip():
+            return f"crm:{crm_contact_id.strip()}"
+
+        discord_user_id = getattr(candidate, "discord_user_id", None)
+        if isinstance(discord_user_id, str) and discord_user_id.strip():
+            return f"discord:{discord_user_id.strip()}"
+
+        return f"candidate:{index}"
+
+    @classmethod
+    def _build_rerank_candidate_payload(
+        cls,
+        *,
+        candidate: Any,
+        index: int,
+    ) -> dict[str, Any]:
+        location_parts = [
+            part.strip()
+            for part in (
+                getattr(candidate, "address_city", None),
+                getattr(candidate, "address_state", None),
+                getattr(candidate, "address_country", None),
+            )
+            if isinstance(part, str) and part.strip()
+        ]
+        return {
+            "candidate_id": cls._candidate_rerank_id(candidate, index),
+            "name": getattr(candidate, "crm_name", None)
+            or getattr(candidate, "name", None),
+            "is_member": bool(getattr(candidate, "is_member", False)),
+            "seniority": getattr(candidate, "seniority", None),
+            "location": ", ".join(location_parts) if location_parts else None,
+            "timezone": getattr(candidate, "timezone", None),
+            "hard_required_matches": list(
+                getattr(candidate, "matched_hard_required_skills", []) or []
+            ),
+            "soft_required_matches": list(
+                getattr(candidate, "matched_soft_required_skills", []) or []
+            ),
+            "preferred_matches": list(
+                getattr(candidate, "matched_preferred_skills", []) or []
+            ),
+            "missing_hard_requirements": list(
+                getattr(candidate, "missing_hard_required_skills", []) or []
+            ),
+            "matched_discord_roles": list(
+                getattr(candidate, "matched_discord_roles", []) or []
+            ),
+            "evidence": list(getattr(candidate, "evidence_signals", []) or []),
+            "linkedin": getattr(candidate, "linkedin", None),
+            "github_username": getattr(candidate, "github_username", None),
+            "resume_name": getattr(candidate, "latest_resume_name", None),
+            "deterministic_match_score": getattr(candidate, "match_score", None),
+        }
+
+    @staticmethod
+    def _apply_candidate_overrides(candidate: Any, **overrides: Any) -> Any:
+        if is_dataclass(candidate):
+            return replace(cast(Any, candidate), **overrides)
+        for key, value in overrides.items():
+            setattr(candidate, key, value)
+        return candidate
+
+    async def _rerank_candidates(
+        self,
+        *,
+        posting: str,
+        requirements: JobRequirements,
+        candidates: list[Any],
+    ) -> list[Any]:
+        if len(candidates) < 2 or not settings.openai_api_key:
+            return candidates
+
+        shortlist = candidates[:12]
+        payloads = [
+            self._build_rerank_candidate_payload(candidate=candidate, index=index)
+            for index, candidate in enumerate(shortlist, start=1)
+        ]
+
+        try:
+            rerank_results = await asyncio.to_thread(
+                rerank_shortlisted_candidates,
+                posting,
+                requirements=requirements,
+                candidates=payloads,
+                api_key=settings.openai_api_key,
+                base_url=settings.openai_base_url or None,
+                model=settings.openai_model,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Candidate rerank failed; keeping deterministic order: %s", exc
+            )
+            return candidates
+
+        if not rerank_results:
+            return candidates
+
+        result_map = {result.candidate_id: result for result in rerank_results}
+        reranked_shortlist: list[Any] = []
+        for index, candidate in enumerate(shortlist, start=1):
+            result = result_map.get(self._candidate_rerank_id(candidate, index))
+            if result is None:
+                reranked_shortlist.append(candidate)
+                continue
+            reranked_shortlist.append(
+                self._apply_candidate_overrides(
+                    candidate,
+                    llm_fit_score=result.fit_score,
+                    llm_summary=result.summary,
+                    llm_risks=result.risks,
+                    llm_missing_requirements=result.missing_requirements,
+                )
+            )
+
+        reranked_shortlist.sort(
+            key=lambda candidate: (
+                getattr(candidate, "llm_fit_score", None) is None,
+                -(float(getattr(candidate, "llm_fit_score", 0.0) or 0.0)),
+                -(float(getattr(candidate, "match_score", 0.0) or 0.0)),
+            )
+        )
+        return reranked_shortlist + candidates[len(shortlist) :]
 
     @staticmethod
     def _resume_file_extension(filename: str | None) -> str:
@@ -1123,10 +1332,10 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
-        if not requirements.required_skills:
+        if not requirements.required_skills and not requirements.discord_role_types:
             await self._unmark_thread_auto_matched(thread.id)
             await thread.send(
-                "⚠️ No required skills could be extracted automatically. "
+                "⚠️ No useful hard/soft skills or role types could be extracted automatically. "
                 "Run `/match-candidates` manually after updating the posting."
             )
             return
@@ -1153,6 +1362,12 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 "Run `/match-candidates` manually in this thread."
             )
             return
+
+        candidates = await self._rerank_candidates(
+            posting=posting,
+            requirements=requirements,
+            candidates=candidates,
+        )
 
         await self._publish_match_results(
             send=thread.send,
@@ -1605,16 +1820,16 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
-        if not requirements.required_skills:
+        if not requirements.required_skills and not requirements.discord_role_types:
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.match_candidates",
                 result="error",
-                metadata={"stage": "no_required_skills_extracted"},
+                metadata={"stage": "no_requirements_extracted"},
             )
             await interaction.followup.send(
-                "⚠️ No required skills could be extracted from this posting. "
-                "Please include explicit skill requirements and try again.",
+                "⚠️ No useful hard/soft skills or role types could be extracted from this posting. "
+                "Please include explicit requirements and try again.",
                 ephemeral=True,
             )
             return
@@ -1642,6 +1857,12 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
+        candidates = await self._rerank_candidates(
+            posting=posting,
+            requirements=requirements,
+            candidates=candidates,
+        )
+
         async def _send_match_result(message: str, **kwargs: Any) -> None:
             if is_private:
                 kwargs["ephemeral"] = True
@@ -1660,8 +1881,11 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             result="success",
             metadata={
                 "title": requirements.title,
+                "hard_required_skills_count": len(requirements.hard_required_skills),
+                "soft_required_skills_count": len(requirements.soft_required_skills),
                 "required_skills_count": len(requirements.required_skills),
                 "preferred_skills_count": len(requirements.preferred_skills),
+                "required_evidence_count": len(requirements.required_evidence),
                 "discord_role_types": requirements.discord_role_types,
                 "candidates_returned": len(candidates),
                 **posting_metadata,

--- a/packages/shared/src/five08/candidate_search.py
+++ b/packages/shared/src/five08/candidate_search.py
@@ -262,7 +262,7 @@ def search_candidates(
     7. Discord role type matched (1 if any discord role matches the required role types).
     8. Required skill strength score (sum of skill_attrs values).
     9. Preferred skill count matched.
-    9. Seniority score (applied in Python after the query).
+    10. Seniority score (applied in Python after the query).
 
     Candidates must match every hard-required skill when hard requirements exist.
     When there are no hard requirements, candidates are included if they match any
@@ -358,10 +358,14 @@ def search_candidates(
                 -- Weighted score: sum of strength attrs for matched hard-required skills
                 (SELECT COALESCE(
                     SUM(
-                        LEAST(
-                            COALESCE((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 1),
-                            5
-                        )
+                        CASE
+                          WHEN (COALESCE(p.skill_attrs, '{}'::jsonb) ->> s) ~ '^-?[0-9]+$'
+                            THEN LEAST(
+                              GREATEST((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 0),
+                              5
+                            )
+                          ELSE 1
+                        END
                     ),
                     0
                  )::int
@@ -376,10 +380,14 @@ def search_candidates(
                 -- Weighted score: sum of strength attrs for matched soft-required skills
                 (SELECT COALESCE(
                     SUM(
-                        LEAST(
-                            COALESCE((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 1),
-                            5
-                        )
+                        CASE
+                          WHEN (COALESCE(p.skill_attrs, '{}'::jsonb) ->> s) ~ '^-?[0-9]+$'
+                            THEN LEAST(
+                              GREATEST((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 0),
+                              5
+                            )
+                          ELSE 1
+                        END
                     ),
                     0
                  )::int
@@ -580,8 +588,9 @@ def search_candidates(
         ]
         matched_req = [s for s in candidate_skills if s in required_set]
         matched_pref = [s for s in candidate_skills if s in preferred_set]
+        candidate_skills_set = set(candidate_skills)
         missing_hard = [
-            s for s in hard_required_skills if s not in set(candidate_skills)
+            s for s in hard_required_skills if s not in candidate_skills_set
         ]
 
         raw_discord_roles = row.get("discord_roles") or []

--- a/packages/shared/src/five08/candidate_search.py
+++ b/packages/shared/src/five08/candidate_search.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field
+from typing import Any
 
 from psycopg.rows import dict_row
 
@@ -85,6 +86,7 @@ class CandidateMatch:
     email_508: str | None
     email: str | None
     linkedin: str | None
+    github_username: str | None
     latest_resume_id: str | None
     latest_resume_name: str | None
     is_member: bool
@@ -96,8 +98,16 @@ class CandidateMatch:
     discord_user_id: str | None = None
     has_crm_link: bool = True
     matched_required_skills: list[str] = field(default_factory=list)
+    matched_hard_required_skills: list[str] = field(default_factory=list)
+    matched_soft_required_skills: list[str] = field(default_factory=list)
     matched_preferred_skills: list[str] = field(default_factory=list)
     matched_discord_roles: list[str] = field(default_factory=list)
+    missing_hard_required_skills: list[str] = field(default_factory=list)
+    evidence_signals: list[str] = field(default_factory=list)
+    llm_fit_score: float | None = None
+    llm_summary: str | None = None
+    llm_risks: list[str] = field(default_factory=list)
+    llm_missing_requirements: list[str] = field(default_factory=list)
     match_score: float = 0.0
     required_skill_score: int = 0  # sum of strength attrs for matched required skills
     seniority_score: float = 0.0  # 1.0 exact, 0.7 one level up, 0.0 mismatch or unknown
@@ -125,6 +135,69 @@ def _normalize_preferred_timezones(timezones: list[str] | None) -> list[str]:
     return [
         tz.strip() for tz in (timezones or []) if isinstance(tz, str) and tz.strip()
     ]
+
+
+def _skill_strength(skill_attrs: dict[str, Any], skill: str) -> int:
+    raw = skill_attrs.get(skill)
+    if isinstance(raw, bool) or raw is None:
+        return 0
+    if not isinstance(raw, (int, float, str)):
+        return 0
+    try:
+        strength = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, min(5, strength))
+
+
+def _build_candidate_evidence_signals(
+    *,
+    matched_hard: list[str],
+    matched_soft: list[str],
+    matched_preferred: list[str],
+    matched_discord_roles: list[str],
+    skill_attrs: dict[str, Any],
+    linkedin: str | None,
+    github_username: str | None,
+    latest_resume_name: str | None,
+) -> list[str]:
+    signals: list[str] = []
+
+    for skill in matched_hard[:3]:
+        strength = _skill_strength(skill_attrs, skill)
+        if strength > 0:
+            signals.append(f"hard skill `{skill}` (strength {strength})")
+        else:
+            signals.append(f"hard skill `{skill}`")
+
+    for skill in matched_soft[:2]:
+        strength = _skill_strength(skill_attrs, skill)
+        if strength > 0:
+            signals.append(f"soft requirement `{skill}` (strength {strength})")
+        else:
+            signals.append(f"soft requirement `{skill}`")
+
+    for skill in matched_preferred[:2]:
+        signals.append(f"preferred skill `{skill}`")
+
+    for role in matched_discord_roles[:2]:
+        signals.append(f"discord role `{role}`")
+
+    if linkedin:
+        signals.append("LinkedIn on file")
+    if github_username:
+        signals.append(f"GitHub `{github_username}`")
+    if latest_resume_name:
+        signals.append(f"resume `{latest_resume_name}`")
+
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for signal in signals:
+        if signal in seen:
+            continue
+        seen.add(signal)
+        deduped.append(signal)
+    return deduped[:6]
 
 
 def _build_location_hints(
@@ -182,21 +255,27 @@ def search_candidates(
     Ranking priority:
     1. Members before prospects.
     2. Location signal when posting has location constraints (explicit mismatch demoted).
-    3. Match score (weighted score from skills + CRM/location signals).
+    3. Match score (weighted score from hard/soft skill coverage + CRM/location signals).
     4. Timezone match (soft signal; 1 when candidate timezone is in preferred_timezones).
-    5. Required skill count matched.
-    6. Discord role type matched (1 if any discord role matches the required role types).
-    7. Required skill strength score (sum of skill_attrs values).
-    8. Preferred skill count matched.
+    5. Hard-required skill count matched.
+    6. Soft-required skill count matched.
+    7. Discord role type matched (1 if any discord role matches the required role types).
+    8. Required skill strength score (sum of skill_attrs values).
+    9. Preferred skill count matched.
     9. Seniority score (applied in Python after the query).
 
-    Candidates are included if they match ANY required skill OR any discord role type.
+    Candidates must match every hard-required skill when hard requirements exist.
+    When there are no hard requirements, candidates are included if they match any
+    soft-required skill or any discord role type. Discord role types remain a ranking
+    signal even when hard/soft skill requirements are present.
     A minimum final match score can be requested via min_match_score.
     When guild_id is provided, discord member snapshots are scoped to that guild.
     When requirements.location_type == "us_only", a hard US-only filter is applied
     in SQL so non-US candidates are excluded rather than merely down-ranked by the
     location signal.
     """
+    hard_required_skills = requirements.hard_required_skills
+    soft_required_skills = requirements.soft_required_skills
     required_skills = requirements.required_skills
     preferred_skills = requirements.preferred_skills
     role_types = requirements.discord_role_types
@@ -222,7 +301,8 @@ def search_candidates(
     # Python only adds seniority alignment and the final tie-break sort afterwards.
     query = """
         WITH
-          req AS (SELECT %s::text[] AS skills),
+          req_hard AS (SELECT %s::text[] AS skills),
+          req_soft AS (SELECT %s::text[] AS skills),
           pref AS (SELECT %s::text[] AS skills),
           rtypes AS (SELECT %s::text[] AS types),
           dm_agg AS (
@@ -255,6 +335,7 @@ def search_candidates(
                 p.email_508,
                 p.email,
                 p.linkedin,
+                p.github_username,
                 p.latest_resume_id,
                 p.latest_resume_name,
                 COALESCE(p.is_member, false) AS is_member,
@@ -269,12 +350,12 @@ def search_candidates(
                 COALESCE(dm.member_discord_username, p.discord_username) AS discord_username,
                 COALESCE(p.discord_user_id, dm.discord_user_id) AS discord_user_id,
                 (p.crm_contact_id IS NOT NULL) AS has_crm_link,
-                -- How many required skills this candidate has
+                -- How many hard-required skills this candidate has
                 (SELECT count(*)::int
                  FROM unnest(COALESCE(p.skills, '{}'::text[])) s
-                 WHERE s IN (SELECT unnest(skills) FROM req)
-                ) AS required_matched,
-                -- Weighted score: sum of strength attrs for matched required skills (default 1)
+                 WHERE s IN (SELECT unnest(skills) FROM req_hard)
+                ) AS hard_required_matched,
+                -- Weighted score: sum of strength attrs for matched hard-required skills
                 (SELECT COALESCE(
                     SUM(
                         LEAST(
@@ -285,8 +366,26 @@ def search_candidates(
                     0
                  )::int
                  FROM unnest(COALESCE(p.skills, '{}'::text[])) s
-                 WHERE s IN (SELECT unnest(skills) FROM req)
-                ) AS required_skill_score,
+                 WHERE s IN (SELECT unnest(skills) FROM req_hard)
+                ) AS hard_required_skill_score,
+                -- How many soft-required skills this candidate has
+                (SELECT count(*)::int
+                 FROM unnest(COALESCE(p.skills, '{}'::text[])) s
+                 WHERE s IN (SELECT unnest(skills) FROM req_soft)
+                ) AS soft_required_matched,
+                -- Weighted score: sum of strength attrs for matched soft-required skills
+                (SELECT COALESCE(
+                    SUM(
+                        LEAST(
+                            COALESCE((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 1),
+                            5
+                        )
+                    ),
+                    0
+                 )::int
+                 FROM unnest(COALESCE(p.skills, '{}'::text[])) s
+                 WHERE s IN (SELECT unnest(skills) FROM req_soft)
+                ) AS soft_required_skill_score,
                 -- How many preferred skills this candidate has
                 (SELECT count(*)::int
                  FROM unnest(COALESCE(p.skills, '{}'::text[])) s
@@ -336,15 +435,42 @@ def search_candidates(
             CROSS JOIN rtypes
             CROSS JOIN loc
             WHERE (p.sync_status = 'active' OR p.sync_status IS NULL)
-              -- Must match at least one required skill OR one discord role type
+              -- When hard requirements exist, candidates must match all of them.
+              -- If there are no hard requirements, allow candidates in through
+              -- soft-required skills or role-type matches.
               AND (
-                COALESCE(p.skills, '{}'::text[]) && (SELECT skills FROM req)
-                OR EXISTS (
-                  SELECT 1
-                  FROM jsonb_array_elements_text(
-                      COALESCE(dm.roles, p.discord_roles, '[]'::jsonb)
-                  ) r
-                  WHERE r = ANY(rtypes.types)
+                (
+                  cardinality((SELECT skills FROM req_hard)) > 0
+                  AND COALESCE(p.skills, '{}'::text[])
+                    @> (SELECT skills FROM req_hard)
+                )
+                OR (
+                  cardinality((SELECT skills FROM req_hard)) = 0
+                  AND (
+                    (
+                      cardinality((SELECT skills FROM req_soft)) > 0
+                      AND (
+                        COALESCE(p.skills, '{}'::text[]) && (SELECT skills FROM req_soft)
+                        OR EXISTS (
+                          SELECT 1
+                          FROM jsonb_array_elements_text(
+                              COALESCE(dm.roles, p.discord_roles, '[]'::jsonb)
+                          ) r
+                          WHERE r = ANY(rtypes.types)
+                        )
+                      )
+                    )
+                    OR (
+                      cardinality((SELECT skills FROM req_soft)) = 0
+                      AND EXISTS (
+                        SELECT 1
+                        FROM jsonb_array_elements_text(
+                            COALESCE(dm.roles, p.discord_roles, '[]'::jsonb)
+                        ) r
+                        WHERE r = ANY(rtypes.types)
+                      )
+                    )
+                  )
                 )
               )
               -- Hard location filter when us_only
@@ -361,6 +487,7 @@ def search_candidates(
             email_508,
             email,
             linkedin,
+            github_username,
             latest_resume_id,
             latest_resume_name,
             is_member,
@@ -374,15 +501,21 @@ def search_candidates(
             discord_roles,
             discord_user_id,
             has_crm_link,
-            required_matched,
-            required_skill_score,
+            hard_required_matched,
+            hard_required_skill_score,
+            soft_required_matched,
+            soft_required_skill_score,
+            (hard_required_matched + soft_required_matched) AS required_matched,
+            (hard_required_skill_score + soft_required_skill_score) AS required_skill_score,
             preferred_matched,
             timezone_matched,
             discord_role_matched,
             location_signal,
             (
-                required_matched * 10
-                + required_skill_score * 2
+                hard_required_matched * 16
+                + hard_required_skill_score * 3
+                + soft_required_matched * 8
+                + soft_required_skill_score * 2
                 + preferred_matched * 2
                 + timezone_matched * 2
                 + (discord_role_matched * 2)
@@ -396,10 +529,11 @@ def search_candidates(
             has_crm_link DESC,
             location_signal DESC,
             match_score DESC,
+            hard_required_matched DESC,
+            soft_required_matched DESC,
             timezone_matched DESC,
-            required_matched DESC,
-            discord_role_matched DESC,
             required_skill_score DESC,
+            discord_role_matched DESC,
             preferred_matched DESC
         LIMIT %s
     """
@@ -411,7 +545,8 @@ def search_candidates(
             cursor.execute(
                 query,
                 (
-                    required_skills,
+                    hard_required_skills,
+                    soft_required_skills,
                     preferred_skills,
                     role_types,
                     guild_id,
@@ -432,24 +567,42 @@ def search_candidates(
     for row in rows:
         candidate_skills: list[str] = row.get("skills") or []
         required_set = set(required_skills)
+        hard_required_set = set(hard_required_skills)
+        soft_required_set = set(soft_required_skills)
         preferred_set = set(preferred_skills)
         role_types_set = set(role_types)
 
+        matched_hard = [s for s in candidate_skills if s in hard_required_set]
+        matched_soft = [
+            s
+            for s in candidate_skills
+            if s in soft_required_set and s not in hard_required_set
+        ]
         matched_req = [s for s in candidate_skills if s in required_set]
         matched_pref = [s for s in candidate_skills if s in preferred_set]
+        missing_hard = [
+            s for s in hard_required_skills if s not in set(candidate_skills)
+        ]
 
         raw_discord_roles = row.get("discord_roles") or []
         matched_discord = [
             r for r in raw_discord_roles if isinstance(r, str) and r in role_types_set
         ]
+        skill_attrs = row.get("skill_attrs") or {}
 
         sen_score = _seniority_score(row.get("seniority"), requirements.seniority)
         raw_match_score = row.get("match_score")
         if raw_match_score is None:
             # Keep the final Python pass resilient if the selected SQL columns ever
             # drift; this mirrors the SQL scoring formula rather than failing closed.
-            required_matched = row.get("required_matched") or 0
-            required_skill_score = row.get("required_skill_score") or 0
+            hard_required_matched = row.get("hard_required_matched")
+            if hard_required_matched is None:
+                hard_required_matched = row.get("required_matched") or 0
+            hard_required_skill_score = row.get("hard_required_skill_score")
+            if hard_required_skill_score is None:
+                hard_required_skill_score = row.get("required_skill_score") or 0
+            soft_required_matched = row.get("soft_required_matched") or 0
+            soft_required_skill_score = row.get("soft_required_skill_score") or 0
             preferred_matched = row.get("preferred_matched") or 0
             timezone_matched = row.get("timezone_matched") or 0
             discord_role_matched = row.get("discord_role_matched") or 0
@@ -457,8 +610,10 @@ def search_candidates(
             is_member = bool(row.get("is_member"))
             has_crm_link = bool(row.get("has_crm_link", True))
             raw_match_score = (
-                required_matched * 10
-                + required_skill_score * 2
+                hard_required_matched * 16
+                + hard_required_skill_score * 3
+                + soft_required_matched * 8
+                + soft_required_skill_score * 2
                 + preferred_matched * 2
                 + timezone_matched * 2
                 + (discord_role_matched * 2)
@@ -478,6 +633,7 @@ def search_candidates(
                 email_508=row.get("email_508"),
                 email=row.get("email"),
                 linkedin=row.get("linkedin"),
+                github_username=row.get("github_username"),
                 latest_resume_id=row.get("latest_resume_id"),
                 latest_resume_name=row.get("latest_resume_name"),
                 is_member=bool(row.get("is_member")),
@@ -489,8 +645,21 @@ def search_candidates(
                 discord_user_id=row.get("discord_user_id"),
                 has_crm_link=bool(row.get("has_crm_link", True)),
                 matched_required_skills=matched_req,
+                matched_hard_required_skills=matched_hard,
+                matched_soft_required_skills=matched_soft,
                 matched_preferred_skills=matched_pref,
                 matched_discord_roles=matched_discord,
+                missing_hard_required_skills=missing_hard,
+                evidence_signals=_build_candidate_evidence_signals(
+                    matched_hard=matched_hard,
+                    matched_soft=matched_soft,
+                    matched_preferred=matched_pref,
+                    matched_discord_roles=matched_discord,
+                    skill_attrs=skill_attrs,
+                    linkedin=row.get("linkedin"),
+                    github_username=row.get("github_username"),
+                    latest_resume_name=row.get("latest_resume_name"),
+                ),
                 match_score=match_score,
                 required_skill_score=row.get("required_skill_score") or 0,
                 seniority_score=sen_score,
@@ -508,9 +677,11 @@ def search_candidates(
             not c.has_crm_link,
             -c.location_signal,
             -c.match_score,
+            -len(c.matched_hard_required_skills),
+            -len(c.matched_soft_required_skills),
             -len(c.matched_required_skills),
-            -len(c.matched_discord_roles),
             -c.required_skill_score,
+            -len(c.matched_discord_roles),
             -len(c.matched_preferred_skills),
             -c.seniority_score,
         )

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -418,16 +418,18 @@ class JobRequirements:
             hard_required_skills = legacy_required_skills[:1]
             soft_required_skills = legacy_required_skills[1:]
 
-        required_skills = hard_required_skills + [
+        hard_required_skill_keys = {item.casefold() for item in hard_required_skills}
+        soft_required_skills = [
             skill
             for skill in soft_required_skills
-            if skill.casefold()
-            not in {item.casefold() for item in hard_required_skills}
+            if skill.casefold() not in hard_required_skill_keys
         ]
+        required_skills = hard_required_skills + soft_required_skills
+        required_skill_keys = {item.casefold() for item in required_skills}
         preferred_skills = [
             skill
             for skill in normalize_skill_list(list(self.preferred_skills))
-            if skill.casefold() not in {item.casefold() for item in required_skills}
+            if skill.casefold() not in required_skill_keys
         ]
 
         object.__setattr__(
@@ -647,7 +649,11 @@ def rerank_shortlisted_candidates(
     try:
         data = _parse_llm_response(raw_content)
     except (json.JSONDecodeError, ValueError) as exc:
-        logger.error("Failed to parse LLM rerank response: %s", raw_content)
+        logger.error(
+            "Failed to parse LLM rerank response length=%d error=%s",
+            len(raw_content),
+            exc,
+        )
         raise RuntimeError(f"LLM rerank returned unparseable response: {exc}") from exc
 
     ranked_payload = data.get("ranked_candidates")

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -1,4 +1,4 @@
-"""Job posting analysis and candidate requirement extraction."""
+"""Job posting analysis, candidate requirement extraction, and shortlist reranking."""
 
 from __future__ import annotations
 
@@ -392,7 +392,10 @@ class JobRequirements:
     """Normalized requirements extracted from a job posting."""
 
     required_skills: list[str] = field(default_factory=list)
+    hard_required_skills: list[str] = field(default_factory=list)
+    soft_required_skills: list[str] = field(default_factory=list)
     preferred_skills: list[str] = field(default_factory=list)
+    required_evidence: list[str] = field(default_factory=list)
     # Subset of DISCORD_SKILL_ROLE_NAMES that apply to this role.
     # Used to match candidates via their discord_roles column.
     discord_role_types: list[str] = field(default_factory=list)
@@ -403,11 +406,73 @@ class JobRequirements:
     title: str | None = None
 
     def __post_init__(self) -> None:
+        hard_required_skills = normalize_skill_list(list(self.hard_required_skills))
+        soft_required_skills = normalize_skill_list(list(self.soft_required_skills))
+        legacy_required_skills = normalize_skill_list(list(self.required_skills))
+
+        if (
+            not hard_required_skills
+            and not soft_required_skills
+            and legacy_required_skills
+        ):
+            hard_required_skills = legacy_required_skills[:1]
+            soft_required_skills = legacy_required_skills[1:]
+
+        required_skills = hard_required_skills + [
+            skill
+            for skill in soft_required_skills
+            if skill.casefold()
+            not in {item.casefold() for item in hard_required_skills}
+        ]
+        preferred_skills = [
+            skill
+            for skill in normalize_skill_list(list(self.preferred_skills))
+            if skill.casefold() not in {item.casefold() for item in required_skills}
+        ]
+
         object.__setattr__(
             self,
             "discord_role_types",
             _normalize_discord_role_types(self.discord_role_types),
         )
+        object.__setattr__(self, "hard_required_skills", hard_required_skills)
+        object.__setattr__(self, "soft_required_skills", soft_required_skills)
+        object.__setattr__(self, "required_skills", required_skills)
+        object.__setattr__(self, "preferred_skills", preferred_skills)
+        object.__setattr__(
+            self,
+            "required_evidence",
+            _normalize_evidence_list(self.required_evidence),
+        )
+
+
+@dataclass(frozen=True)
+class CandidateRerankResult:
+    """Structured LLM assessment for one shortlisted candidate."""
+
+    candidate_id: str
+    fit_score: float
+    summary: str | None = None
+    strengths: list[str] = field(default_factory=list)
+    risks: list[str] = field(default_factory=list)
+    missing_requirements: list[str] = field(default_factory=list)
+
+
+def _normalize_evidence_list(values: list[str]) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        if not isinstance(raw, str):
+            continue
+        cleaned = re.sub(r"\s+", " ", raw.strip()).strip(" .,_-:/")
+        if not cleaned:
+            continue
+        key = cleaned.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(cleaned.lower())
+    return normalized
 
 
 def _regex_hints(text: str) -> dict[str, Any]:
@@ -444,13 +509,21 @@ def _build_prompt(posting_text: str, hints: dict[str, Any]) -> str:
         f"{hint_block}"
         "Analyze the following job posting and return a JSON object with these fields:\n"
         '- "title": string or null — the job title\n'
-        '- "required_skills": array of strings — up to 5 most critical TECHNICAL skills, '
-        'using concise canonical names (1-3 words, e.g. "effect ts", "typescript", '
-        '"react", "postgresql", "solidity"). Order by importance. '
+        '- "hard_required_skills": array of strings — hard must-have TECHNICAL skills. '
+        'Use concise canonical names (1-3 words, e.g. "webflow", "typescript", '
+        '"postgresql"). Only include skills that should block a candidate if missing. '
+        "If the posting clearly hinges on one platform or tool, put that anchor skill "
+        'first (e.g. "webflow" before adjacent skills like "figma").\n'
+        '- "soft_required_skills": array of strings — technical skills that matter a lot '
+        "but should not automatically disqualify a candidate if missing.\n"
+        '- "preferred_skills": array of strings — secondary technical skills, same format.\n'
+        '- "required_evidence": array of strings — non-skill proof items the hiring team '
+        'explicitly asks for, like "live webflow projects", "portfolio", or '
+        '"hubspot integration examples".\n'
+        '- "required_skills": array of strings — legacy compatibility field. Return the '
+        "combined hard + soft technical requirements in priority order.\n"
         "EXCLUDE soft skills, work styles, or behavioral traits such as "
         '"self-directed", "independent", "communication skills", "public github profile".\n'
-        '- "preferred_skills": array of strings — secondary technical skills, same format, '
-        "no soft skills\n"
         f'- "discord_role_types": array — classify using ONLY values from: [{role_names_str}]. '
         "Pick all that apply to this role.\n"
         '- "seniority": one of "junior", "midlevel", "senior", "staff", or null\n'
@@ -477,6 +550,139 @@ def _coerce_str_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [s for s in value if isinstance(s, str) and s.strip()]
+
+
+def _coerce_fit_score(value: Any) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(100.0, score))
+
+
+def _build_rerank_prompt(
+    posting_text: str,
+    requirements: JobRequirements,
+    candidates: list[dict[str, Any]],
+) -> str:
+    requirements_payload = {
+        "title": requirements.title,
+        "hard_required_skills": requirements.hard_required_skills,
+        "soft_required_skills": requirements.soft_required_skills,
+        "preferred_skills": requirements.preferred_skills,
+        "required_evidence": requirements.required_evidence,
+        "discord_role_types": requirements.discord_role_types,
+        "seniority": requirements.seniority,
+        "location_type": requirements.location_type,
+        "preferred_timezones": requirements.preferred_timezones,
+        "raw_location_text": requirements.raw_location_text,
+    }
+    return (
+        "You are reranking a shortlist of candidates after deterministic filtering.\n"
+        "Only use the provided candidate data. Do not invent portfolio links, project "
+        "history, or evidence that is not present.\n"
+        "Return a JSON object with a single key `ranked_candidates`, whose value is an "
+        "array of objects with:\n"
+        "- `candidate_id`: string copied exactly from the input\n"
+        "- `fit_score`: number from 0 to 100\n"
+        "- `summary`: one short sentence about the fit\n"
+        "- `strengths`: array of short strings\n"
+        "- `risks`: array of short strings\n"
+        "- `missing_requirements`: array of short strings, especially for missing evidence or unclear proof\n\n"
+        "Job requirements:\n"
+        f"{json.dumps(requirements_payload, ensure_ascii=True, indent=2)}\n\n"
+        "Job posting:\n"
+        f"{posting_text[:12000]}\n\n"
+        "Candidates:\n"
+        f"{json.dumps(candidates, ensure_ascii=True, indent=2)}"
+    )
+
+
+def rerank_shortlisted_candidates(
+    posting_text: str,
+    *,
+    requirements: JobRequirements,
+    candidates: list[dict[str, Any]],
+    api_key: str | None,
+    base_url: str | None = None,
+    model: str = "gpt-5-mini",
+) -> list[CandidateRerankResult]:
+    """Run an LLM rerank pass over an already filtered shortlist."""
+    if not api_key or len(candidates) < 2:
+        return []
+
+    try:
+        from openai import OpenAI as _OpenAI
+    except ImportError as exc:
+        raise RuntimeError("openai package is not installed") from exc
+
+    client = _OpenAI(api_key=api_key, base_url=base_url or None)
+    prompt = _build_rerank_prompt(posting_text, requirements, candidates)
+
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            temperature=0.1,
+            response_format={"type": "json_object"},
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a senior recruiting coordinator. Rerank a shortlist "
+                        "using only the provided evidence. Return only valid JSON."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=2500,
+        )
+    except Exception as exc:
+        logger.error("OpenAI candidate rerank call failed: %s", exc)
+        raise RuntimeError(f"OpenAI rerank failed: {exc}") from exc
+
+    if not response.choices or not response.choices[0].message.content:
+        raise RuntimeError("OpenAI rerank returned empty or missing response content.")
+
+    raw_content = response.choices[0].message.content.strip()
+    try:
+        data = _parse_llm_response(raw_content)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.error("Failed to parse LLM rerank response: %s", raw_content)
+        raise RuntimeError(f"LLM rerank returned unparseable response: {exc}") from exc
+
+    ranked_payload = data.get("ranked_candidates")
+    if not isinstance(ranked_payload, list):
+        raise RuntimeError("LLM rerank response missing ranked_candidates array.")
+
+    results: list[CandidateRerankResult] = []
+    seen_ids: set[str] = set()
+    for item in ranked_payload:
+        if not isinstance(item, dict):
+            continue
+        candidate_id = item.get("candidate_id")
+        if not isinstance(candidate_id, str):
+            continue
+        candidate_id = candidate_id.strip()
+        if not candidate_id or candidate_id in seen_ids:
+            continue
+        seen_ids.add(candidate_id)
+        summary = item.get("summary")
+        results.append(
+            CandidateRerankResult(
+                candidate_id=candidate_id,
+                fit_score=_coerce_fit_score(item.get("fit_score")),
+                summary=summary.strip()
+                if isinstance(summary, str) and summary.strip()
+                else None,
+                strengths=_coerce_str_list(item.get("strengths"))[:4],
+                risks=_coerce_str_list(item.get("risks"))[:4],
+                missing_requirements=_coerce_str_list(item.get("missing_requirements"))[
+                    :5
+                ],
+            )
+        )
+
+    return results
 
 
 def extract_job_requirements(
@@ -547,11 +753,20 @@ def extract_job_requirements(
         logger.error("Failed to parse LLM job extraction response: %s", raw_content)
         raise RuntimeError(f"LLM returned unparseable response: {exc}") from exc
 
+    hard_required_skills = normalize_skill_list(
+        _coerce_str_list(data.get("hard_required_skills"))
+    )
+    soft_required_skills = normalize_skill_list(
+        _coerce_str_list(data.get("soft_required_skills"))
+    )
     required_skills = normalize_skill_list(
         _coerce_str_list(data.get("required_skills"))
     )
     preferred_skills = normalize_skill_list(
         _coerce_str_list(data.get("preferred_skills"))
+    )
+    required_evidence = _normalize_evidence_list(
+        _coerce_str_list(data.get("required_evidence"))
     )
 
     # Let JobRequirements.__post_init__ apply canonicalization + dedupe consistently.
@@ -587,7 +802,10 @@ def extract_job_requirements(
 
     return JobRequirements(
         required_skills=required_skills,
+        hard_required_skills=hard_required_skills,
+        soft_required_skills=soft_required_skills,
         preferred_skills=preferred_skills,
+        required_evidence=required_evidence,
         discord_role_types=discord_role_types,
         seniority=seniority,
         location_type=location_type,

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -417,6 +417,17 @@ class JobRequirements:
         ):
             hard_required_skills = legacy_required_skills[:1]
             soft_required_skills = legacy_required_skills[1:]
+        elif (
+            hard_required_skills and not soft_required_skills and legacy_required_skills
+        ):
+            hard_required_skill_keys = {
+                item.casefold() for item in hard_required_skills
+            }
+            soft_required_skills = [
+                skill
+                for skill in legacy_required_skills
+                if skill.casefold() not in hard_required_skill_keys
+            ]
 
         hard_required_skill_keys = {item.casefold() for item in hard_required_skills}
         soft_required_skills = [

--- a/packages/shared/src/five08/skills.py
+++ b/packages/shared/src/five08/skills.py
@@ -35,6 +35,7 @@ SKILL_ALIASES: dict[str, str] = {
     "crm": "customer relationship management",
     "ga4": "google analytics",
     "google analytics 4": "google analytics",
+    "webflow cms": "webflow",
 }
 
 DISALLOWED_RESUME_SKILLS: frozenset[str] = frozenset(

--- a/tests/integration/test_candidate_search_e2e.py
+++ b/tests/integration/test_candidate_search_e2e.py
@@ -275,6 +275,40 @@ class TestSearchCandidatesE2E:
         assert results[0].crm_contact_id == "c1"
         assert "python" in results[0].matched_required_skills
 
+    def test_requires_anchor_skill_when_multiple_required_skills_present(
+        self, pg_db: SharedSettings
+    ) -> None:
+        _insert(crm_contact_id="webflow_dev", skills=["webflow", "figma"])
+        _insert(
+            crm_contact_id="figma_only",
+            skills=["figma", "hubspot"],
+            discord_roles=["Frontend"],
+        )
+
+        results = search_candidates(
+            pg_db,
+            _reqs(
+                required_skills=["webflow", "figma", "hubspot"],
+                discord_role_types=["Frontend"],
+            ),
+        )
+
+        assert [result.crm_contact_id for result in results] == ["webflow_dev"]
+
+    def test_requires_all_hard_skills(self, pg_db: SharedSettings) -> None:
+        _insert(crm_contact_id="full_match", skills=["webflow", "hubspot", "figma"])
+        _insert(crm_contact_id="missing_hard", skills=["webflow", "figma"])
+
+        results = search_candidates(
+            pg_db,
+            _reqs(
+                hard_required_skills=["webflow", "hubspot"],
+                soft_required_skills=["figma"],
+            ),
+        )
+
+        assert [result.crm_contact_id for result in results] == ["full_match"]
+
     def test_excludes_candidate_without_required_skill(
         self, pg_db: SharedSettings
     ) -> None:

--- a/tests/unit/test_candidate_search.py
+++ b/tests/unit/test_candidate_search.py
@@ -202,6 +202,25 @@ def test_search_candidates_binds_anchor_required_skill() -> None:
     assert execute_params[1] == ["figma", "hubspot"]
 
 
+def test_search_candidates_guards_non_numeric_skill_attr_casts() -> None:
+    row = _make_row(skills=["webflow", "figma"], skill_attrs={"webflow": "expert"})
+    conn = _patch_db([row])
+    reqs = _make_requirements(
+        hard_required_skills=["webflow"],
+        soft_required_skills=["figma"],
+    )
+    settings = MagicMock()
+
+    with patch("five08.candidate_search.get_postgres_connection", return_value=conn):
+        search_candidates(settings, reqs)
+
+    executed_query = conn.cursor.return_value.execute.call_args[0][0]
+    assert executed_query.count("~ '^-?[0-9]+$'") >= 2
+    assert "GREATEST((COALESCE(p.skill_attrs, '{}'::jsonb) ->> s)::int, 0)" in (
+        executed_query
+    )
+
+
 # ---------------------------------------------------------------------------
 # search_candidates — DB rows → CandidateMatch mapping and secondary sort
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_candidate_search.py
+++ b/tests/unit/test_candidate_search.py
@@ -181,8 +181,25 @@ def test_search_candidates_binds_trimmed_exact_timezones() -> None:
         search_candidates(settings, reqs)
 
     execute_params = conn.cursor.return_value.execute.call_args[0][1]
-    # Fixed SQL param order: exact_timezones is the 6th bind parameter.
-    assert execute_params[5] == ["America/New_York"]
+    # Fixed SQL param order: exact_timezones is the 7th bind parameter.
+    assert execute_params[6] == ["America/New_York"]
+
+
+def test_search_candidates_binds_anchor_required_skill() -> None:
+    row = _make_row(skills=["webflow"])
+    conn = _patch_db([row])
+    reqs = _make_requirements(
+        hard_required_skills=["webflow"],
+        soft_required_skills=["figma", "hubspot"],
+    )
+    settings = MagicMock()
+
+    with patch("five08.candidate_search.get_postgres_connection", return_value=conn):
+        search_candidates(settings, reqs)
+
+    execute_params = conn.cursor.return_value.execute.call_args[0][1]
+    assert execute_params[0] == ["webflow"]
+    assert execute_params[1] == ["figma", "hubspot"]
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +215,7 @@ def _make_row(**overrides: object) -> dict:
         "email_508": "alice@508.dev",
         "email": "alice@example.com",
         "linkedin": None,
+        "github_username": None,
         "latest_resume_id": None,
         "latest_resume_name": None,
         "is_member": True,
@@ -218,6 +236,32 @@ def _make_row(**overrides: object) -> dict:
     }
     base.update(overrides)
     return base
+
+
+def test_search_candidates_populates_hard_soft_matches_and_evidence() -> None:
+    row = _make_row(
+        skills=["webflow", "figma", "hubspot"],
+        skill_attrs={"webflow": "5", "figma": "3"},
+        linkedin="https://linkedin.example/jamie",
+        github_username="jamie-dev",
+        latest_resume_name="jamie.pdf",
+    )
+    conn = _patch_db([row])
+    reqs = _make_requirements(
+        hard_required_skills=["webflow"],
+        soft_required_skills=["figma"],
+        preferred_skills=["hubspot"],
+    )
+    settings = MagicMock()
+
+    with patch("five08.candidate_search.get_postgres_connection", return_value=conn):
+        results = search_candidates(settings, reqs)
+
+    assert results[0].matched_hard_required_skills == ["webflow"]
+    assert results[0].matched_soft_required_skills == ["figma"]
+    assert results[0].matched_preferred_skills == ["hubspot"]
+    assert "hard skill `webflow` (strength 5)" in results[0].evidence_signals
+    assert "GitHub `jamie-dev`" in results[0].evidence_signals
 
 
 def _make_requirements(**overrides: object) -> JobRequirements:

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -131,7 +131,7 @@ class TestCRMCog:
 
         assert header_lines[0] == "## Job Match Results"
         assert "Full Stack Engineer" in header_lines[1]
-        assert "Skills: `python`" in header_lines[1]
+        assert "Hard needs: `python`" in header_lines[1]
         assert header_lines[-1] == "Found **3** candidate(s)."
         assert role_line == "Discord roles: `Full Stack`"
         assert role_ids == []
@@ -2016,15 +2016,16 @@ class TestCRMCog:
         thread_instance.starter_message = starter_msg
         mock_interaction.channel = thread_instance
 
-        requirements = Mock()
-        requirements.title = "Frontend Engineer"
-        requirements.discord_role_types = [" Frontend ", "Senior"]
-        requirements.raw_location_text = "USA"
-        requirements.preferred_timezones = []
-        requirements.location_type = "us_only"
-        requirements.required_skills = ["python"]
-        requirements.preferred_skills = []
-        requirements.seniority = "Senior"
+        requirements = JobRequirements(
+            required_skills=["python"],
+            preferred_skills=[],
+            discord_role_types=[" Frontend ", "Senior"],
+            seniority="senior",
+            location_type="us_only",
+            preferred_timezones=[],
+            raw_location_text="USA",
+            title="Frontend Engineer",
+        )
 
         candidate = Mock()
         candidate.is_member = True
@@ -2039,7 +2040,17 @@ class TestCRMCog:
         candidate.latest_resume_name = None
         candidate.match_score = 9.2
         candidate.matched_required_skills = ["python"]
+        candidate.matched_hard_required_skills = ["python"]
+        candidate.matched_soft_required_skills = []
         candidate.matched_discord_roles = ["Frontend"]
+        candidate.matched_preferred_skills = []
+        candidate.missing_hard_required_skills = []
+        candidate.evidence_signals = ["hard skill `python`"]
+        candidate.llm_fit_score = None
+        candidate.llm_summary = None
+        candidate.llm_risks = []
+        candidate.llm_missing_requirements = []
+        candidate.github_username = None
         candidate.seniority = "Senior"
         candidate.timezone = "America/New_York"
 
@@ -2150,15 +2161,16 @@ class TestCRMCog:
         thread_instance.starter_message = starter_msg
         mock_interaction.channel = thread_instance
 
-        requirements = Mock()
-        requirements.title = "Frontend Engineer"
-        requirements.discord_role_types = [" Frontend ", "Senior"]
-        requirements.raw_location_text = "USA"
-        requirements.preferred_timezones = []
-        requirements.location_type = "us_only"
-        requirements.required_skills = ["python"]
-        requirements.preferred_skills = []
-        requirements.seniority = "Senior"
+        requirements = JobRequirements(
+            required_skills=["python"],
+            preferred_skills=[],
+            discord_role_types=[" Frontend ", "Senior"],
+            seniority="senior",
+            location_type="us_only",
+            preferred_timezones=[],
+            raw_location_text="USA",
+            title="Frontend Engineer",
+        )
 
         candidate = Mock()
         candidate.is_member = True
@@ -2173,7 +2185,17 @@ class TestCRMCog:
         candidate.latest_resume_name = None
         candidate.match_score = 9.2
         candidate.matched_required_skills = ["python"]
+        candidate.matched_hard_required_skills = ["python"]
+        candidate.matched_soft_required_skills = []
         candidate.matched_discord_roles = ["Frontend"]
+        candidate.matched_preferred_skills = []
+        candidate.missing_hard_required_skills = []
+        candidate.evidence_signals = ["hard skill `python`"]
+        candidate.llm_fit_score = None
+        candidate.llm_summary = None
+        candidate.llm_risks = []
+        candidate.llm_missing_requirements = []
+        candidate.github_username = None
         candidate.seniority = "Senior"
         candidate.timezone = "America/New_York"
 

--- a/tests/unit/test_job_match.py
+++ b/tests/unit/test_job_match.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from five08.job_match import (
+    CandidateRerankResult,
     DISCORD_LOCALITY_ROLE_NAMES,
     DISCORD_ROLES_EXCLUDE_FROM_SYNC,
     DISCORD_ROLES_NEVER_SUGGEST,
@@ -17,6 +18,8 @@ from five08.job_match import (
     _parse_llm_response,
     _regex_hints,
     extract_job_requirements,
+    rerank_shortlisted_candidates,
+    JobRequirements,
     suggest_locality_discord_roles,
     suggest_technical_discord_roles,
 )
@@ -142,8 +145,11 @@ def test_extract_raises_and_logs_webhook_when_api_key_missing() -> None:
 
 def test_extract_normalizes_required_skills() -> None:
     payload = {
-        "required_skills": ["Python", "REACT", "  django  "],
-        "preferred_skills": [],
+        "hard_required_skills": ["Python"],
+        "soft_required_skills": ["REACT", "  django  "],
+        "preferred_skills": ["GraphQL"],
+        "required_evidence": ["Portfolio"],
+        "required_skills": ["Python", "REACT", "django"],
         "seniority": "senior",
         "location_type": "remote_any",
         "preferred_timezones": [],
@@ -162,10 +168,37 @@ def test_extract_normalizes_required_skills() -> None:
             api_key="test-key",
         )
 
-    # Skills should be normalized/lowercased
-    assert "python" in result.required_skills
+    assert result.hard_required_skills == ["python"]
+    assert result.soft_required_skills == ["react", "django"]
+    assert result.preferred_skills == ["graphql"]
+    assert result.required_evidence == ["portfolio"]
+    assert result.required_skills == ["python", "react", "django"]
     assert result.seniority == "senior"
     assert result.title == "Backend Engineer"
+
+
+def test_extract_backfills_hard_and_soft_from_legacy_required_skills() -> None:
+    payload = {
+        "required_skills": ["Webflow", "Figma", "HubSpot"],
+        "preferred_skills": [],
+        "required_evidence": [],
+        "seniority": None,
+        "location_type": "remote_any",
+        "preferred_timezones": [],
+        "raw_location_text": None,
+        "title": None,
+    }
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response(
+            payload
+        )
+
+        result = extract_job_requirements("Webflow role", api_key="test-key")
+
+    assert result.hard_required_skills == ["webflow"]
+    assert result.soft_required_skills == ["figma", "hubspot"]
 
 
 def test_extract_us_only_regex_overrides_remote_any() -> None:
@@ -254,6 +287,54 @@ def test_build_prompt_includes_us_only_hint() -> None:
 def test_build_prompt_includes_seniority_hint() -> None:
     prompt = _build_prompt("text", {"seniority_hint": "senior"})
     assert "senior" in prompt
+
+
+def test_build_prompt_includes_anchor_skill_instruction() -> None:
+    prompt = _build_prompt("text", {})
+    assert "anchor skill first" in prompt
+    assert '"webflow" before adjacent skills like "figma"' in prompt
+
+
+def test_rerank_shortlisted_candidates_parses_structured_response() -> None:
+    payload = {
+        "ranked_candidates": [
+            {
+                "candidate_id": "crm:1",
+                "fit_score": 91,
+                "summary": "Strong Webflow fit.",
+                "strengths": ["webflow", "resume"],
+                "risks": ["portfolio evidence thin"],
+                "missing_requirements": ["live webflow projects"],
+            }
+        ]
+    }
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response(
+            payload
+        )
+
+        results = rerank_shortlisted_candidates(
+            "Webflow job",
+            requirements=JobRequirements(required_skills=["webflow"]),
+            candidates=[
+                {"candidate_id": "crm:1", "name": "Jamie"},
+                {"candidate_id": "crm:2", "name": "Taylor"},
+            ],
+            api_key="test-key",
+        )
+
+    assert results == [
+        CandidateRerankResult(
+            candidate_id="crm:1",
+            fit_score=91.0,
+            summary="Strong Webflow fit.",
+            strengths=["webflow", "resume"],
+            risks=["portfolio evidence thin"],
+            missing_requirements=["live webflow projects"],
+        )
+    ]
 
 
 def test_build_prompt_no_hints_has_no_note_lines() -> None:

--- a/tests/unit/test_job_match.py
+++ b/tests/unit/test_job_match.py
@@ -201,6 +201,19 @@ def test_extract_backfills_hard_and_soft_from_legacy_required_skills() -> None:
     assert result.soft_required_skills == ["figma", "hubspot"]
 
 
+def test_job_requirements_dedupes_soft_and_preferred_against_hard() -> None:
+    requirements = JobRequirements(
+        hard_required_skills=["Webflow"],
+        soft_required_skills=["webflow", "Figma"],
+        preferred_skills=["FIGMA", "HubSpot", "webflow"],
+    )
+
+    assert requirements.hard_required_skills == ["webflow"]
+    assert requirements.soft_required_skills == ["figma"]
+    assert requirements.required_skills == ["webflow", "figma"]
+    assert requirements.preferred_skills == ["hubspot"]
+
+
 def test_extract_us_only_regex_overrides_remote_any() -> None:
     """Regex US-only detection must override the LLM returning remote_any."""
     payload = {
@@ -299,7 +312,7 @@ def test_rerank_shortlisted_candidates_parses_structured_response() -> None:
     payload = {
         "ranked_candidates": [
             {
-                "candidate_id": "crm:1",
+                "candidate_id": "candidate:1",
                 "fit_score": 91,
                 "summary": "Strong Webflow fit.",
                 "strengths": ["webflow", "resume"],
@@ -319,15 +332,15 @@ def test_rerank_shortlisted_candidates_parses_structured_response() -> None:
             "Webflow job",
             requirements=JobRequirements(required_skills=["webflow"]),
             candidates=[
-                {"candidate_id": "crm:1", "name": "Jamie"},
-                {"candidate_id": "crm:2", "name": "Taylor"},
+                {"candidate_id": "candidate:1"},
+                {"candidate_id": "candidate:2"},
             ],
             api_key="test-key",
         )
 
     assert results == [
         CandidateRerankResult(
-            candidate_id="crm:1",
+            candidate_id="candidate:1",
             fit_score=91.0,
             summary="Strong Webflow fit.",
             strengths=["webflow", "resume"],
@@ -335,6 +348,38 @@ def test_rerank_shortlisted_candidates_parses_structured_response() -> None:
             missing_requirements=["live webflow projects"],
         )
     ]
+
+
+def test_rerank_shortlisted_candidates_parse_error_does_not_log_raw_content() -> None:
+    choice = MagicMock()
+    choice.message.content = "not json"
+    choice.finish_reason = "stop"
+    response = MagicMock()
+    response.choices = [choice]
+
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = response
+
+        with patch("five08.job_match.logger.error") as mock_logger_error:
+            with pytest.raises(RuntimeError, match="unparseable"):
+                rerank_shortlisted_candidates(
+                    "python role",
+                    requirements=JobRequirements(required_skills=["python"]),
+                    candidates=[
+                        {"candidate_id": "candidate:1"},
+                        {"candidate_id": "candidate:2"},
+                    ],
+                    api_key="test-key",
+                )
+
+    assert mock_logger_error.call_args is not None
+    assert (
+        mock_logger_error.call_args[0][0]
+        == "Failed to parse LLM rerank response length=%d error=%s"
+    )
+    assert "not json" not in repr(mock_logger_error.call_args)
 
 
 def test_build_prompt_no_hints_has_no_note_lines() -> None:

--- a/tests/unit/test_job_match.py
+++ b/tests/unit/test_job_match.py
@@ -201,6 +201,32 @@ def test_extract_backfills_hard_and_soft_from_legacy_required_skills() -> None:
     assert result.soft_required_skills == ["figma", "hubspot"]
 
 
+def test_extract_backfills_soft_from_legacy_required_skills_when_hard_present() -> None:
+    payload = {
+        "hard_required_skills": ["Webflow"],
+        "required_skills": ["Webflow", "Figma", "HubSpot"],
+        "preferred_skills": [],
+        "required_evidence": [],
+        "seniority": None,
+        "location_type": "remote_any",
+        "preferred_timezones": [],
+        "raw_location_text": None,
+        "title": None,
+    }
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.return_value = _make_openai_response(
+            payload
+        )
+
+        result = extract_job_requirements("Webflow role", api_key="test-key")
+
+    assert result.hard_required_skills == ["webflow"]
+    assert result.soft_required_skills == ["figma", "hubspot"]
+    assert result.required_skills == ["webflow", "figma", "hubspot"]
+
+
 def test_job_requirements_dedupes_soft_and_preferred_against_hard() -> None:
     requirements = JobRequirements(
         hard_required_skills=["Webflow"],

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -20,8 +20,16 @@ def _make_candidate(**overrides: object) -> SimpleNamespace:
         "latest_resume_id": None,
         "latest_resume_name": None,
         "matched_required_skills": [],
+        "matched_hard_required_skills": [],
+        "matched_soft_required_skills": [],
         "matched_discord_roles": [],
         "matched_preferred_skills": [],
+        "missing_hard_required_skills": [],
+        "evidence_signals": [],
+        "llm_fit_score": None,
+        "llm_summary": None,
+        "llm_risks": [],
+        "llm_missing_requirements": [],
         "match_score": 0.0,
         "seniority": None,
         "address_city": None,
@@ -29,6 +37,7 @@ def _make_candidate(**overrides: object) -> SimpleNamespace:
         "address_country": None,
         "timezone": None,
         "linkedin": None,
+        "github_username": None,
     }
     base.update(overrides)
     return SimpleNamespace(**base)
@@ -154,3 +163,29 @@ def test_build_match_candidate_lines_keeps_name_discord_and_linkedin_on_first_li
     assert "score: 31.0" in second_line
     assert "seniority: **Mid-level**" in second_line
     assert "location: **Seattle, Washington, US** · tz: `UTC-08:00`" in third_line
+
+
+def test_build_match_candidate_lines_includes_evidence_and_llm_notes() -> None:
+    candidate = _make_candidate(
+        crm_name="Jamie",
+        matched_hard_required_skills=["webflow"],
+        matched_soft_required_skills=["figma"],
+        evidence_signals=["hard skill `webflow` (strength 5)", "resume `jamie.pdf`"],
+        llm_fit_score=92.0,
+        llm_summary="Strong Webflow fit but portfolio proof is still thin.",
+        llm_missing_requirements=["live webflow projects"],
+    )
+
+    lines, _ = JobsCog._build_match_candidate_lines(
+        candidates=[candidate],
+        crm_base="https://crm.example",
+    )
+
+    assert "LLM fit: 92/100" in lines[0]
+    assert "hard: `webflow`" in lines[0]
+    assert "soft: `figma`" in lines[0]
+    assert (
+        "evidence: hard skill `webflow` (strength 5) · resume `jamie.pdf`" in lines[0]
+    )
+    assert "summary: Strong Webflow fit but portfolio proof is still thin." in lines[0]
+    assert "missing: `live webflow projects`" in lines[0]

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import Mock
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from five08.discord_bot.cogs.jobs import JobsCog
+from five08.job_match import CandidateRerankResult, JobRequirements
 
 
 def _make_candidate(**overrides: object) -> SimpleNamespace:
@@ -185,7 +188,94 @@ def test_build_match_candidate_lines_includes_evidence_and_llm_notes() -> None:
     assert "hard: `webflow`" in lines[0]
     assert "soft: `figma`" in lines[0]
     assert (
-        "evidence: hard skill `webflow` (strength 5) · resume `jamie.pdf`" in lines[0]
+        r"evidence: hard skill \`webflow\` (strength 5) · resume \`jamie.pdf\`"
+        in lines[0]
     )
     assert "summary: Strong Webflow fit but portfolio proof is still thin." in lines[0]
     assert "missing: `live webflow projects`" in lines[0]
+
+
+def test_build_match_candidate_lines_escapes_untrusted_evidence_and_missing_items() -> (
+    None
+):
+    candidate = _make_candidate(
+        crm_name="Jamie",
+        evidence_signals=["resume `jamie.pdf` <@123>"],
+        llm_missing_requirements=["needs `webflow` <@456>"],
+    )
+
+    lines, _ = JobsCog._build_match_candidate_lines(
+        candidates=[candidate],
+        crm_base="https://crm.example",
+    )
+
+    assert r"evidence: resume \`jamie.pdf\` <@​123>" in lines[0]
+    assert "missing: `needs ˋwebflowˋ <@\u200b456>`" in lines[0]
+
+
+def test_build_rerank_candidate_payload_uses_opaque_id_and_omits_pii() -> None:
+    candidate = _make_candidate(
+        crm_contact_id="crm-123",
+        discord_user_id="discord-456",
+        crm_name="Jamie",
+        name="Jamie Display",
+        linkedin="https://linkedin.example/jamie",
+        github_username="jamie-dev",
+        latest_resume_name="jamie.pdf",
+        matched_hard_required_skills=["webflow"],
+        matched_soft_required_skills=["figma"],
+        matched_preferred_skills=["hubspot"],
+        matched_discord_roles=["Frontend"],
+        missing_hard_required_skills=["webflow cms"],
+        match_score=42.0,
+        seniority="midlevel",
+        address_city="Seattle",
+        address_state="Washington",
+        address_country="US",
+        timezone="UTC-08:00",
+    )
+
+    payload = JobsCog._build_rerank_candidate_payload(candidate=candidate, index=3)
+
+    assert payload["candidate_id"] == "candidate:3"
+    assert payload["country"] == "US"
+    assert payload["has_linkedin"] is True
+    assert payload["has_github"] is True
+    assert payload["has_resume"] is True
+    assert "name" not in payload
+    assert "linkedin" not in payload
+    assert "github_username" not in payload
+    assert "resume_name" not in payload
+    assert payload["evidence"] == [
+        "linkedin profile on file",
+        "github profile on file",
+        "resume on file",
+        "relevant discord role match",
+    ]
+
+
+def test_rerank_candidates_preserves_llm_order_for_tied_scores() -> None:
+    cog = JobsCog(Mock())
+    candidates = [
+        _make_candidate(crm_name="Alpha", match_score=80.0),
+        _make_candidate(crm_name="Beta", match_score=95.0),
+    ]
+    rerank_results = [
+        CandidateRerankResult(candidate_id="candidate:2", fit_score=90.0),
+        CandidateRerankResult(candidate_id="candidate:1", fit_score=90.0),
+    ]
+
+    with (
+        patch("five08.discord_bot.cogs.jobs.rerank_shortlisted_candidates") as rerank,
+        patch("five08.discord_bot.cogs.jobs.settings.openai_api_key", "test-key"),
+    ):
+        rerank.return_value = rerank_results
+        reranked = asyncio.run(
+            cog._rerank_candidates(
+                posting="Webflow job",
+                requirements=JobRequirements(required_skills=["webflow"]),
+                candidates=candidates,
+            )
+        )
+
+    assert [candidate.crm_name for candidate in reranked[:2]] == ["Beta", "Alpha"]

--- a/tests/unit/test_shared_skills.py
+++ b/tests/unit/test_shared_skills.py
@@ -15,13 +15,16 @@ def test_normalize_skill_prefers_discord_friendly_canonical_forms() -> None:
     assert normalize_skill("GTM") == "go to market"
     assert normalize_skill("CRM") == "customer relationship management"
     assert normalize_skill("SEO") == "search engine optimization"
+    assert normalize_skill("Webflow CMS") == "webflow"
 
 
 def test_normalize_skill_list_dedupes_after_aliasing() -> None:
     """List normalization should dedupe across equivalent aliases."""
-    normalized = normalize_skill_list(["node.js", "node", "A/B Testing", "ab testing"])
+    normalized = normalize_skill_list(
+        ["node.js", "node", "A/B Testing", "ab testing", "webflow cms", "webflow"]
+    )
 
-    assert normalized == ["node", "ab testing"]
+    assert normalized == ["node", "ab testing", "webflow"]
 
 
 def test_normalize_skill_payload_merges_inline_and_structured_strengths() -> None:


### PR DESCRIPTION
## Description
Split job extraction into hard/soft/evidence requirements, enforce hard gating in candidate search, and add evidence-aware scoring plus shortlist LLM reranking.
Update Discord match output to show hard needs, evidence, matched and missing requirements, and rerank summaries.

## Related Issue
N/A

## How Has This Been Tested?
- ============================= test session starts ==============================
platform darwin -- Python 3.12.0, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/michaelwu/conductor/workspaces/508-workflows/manado-v1
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 350 items

tests/unit/test_job_match.py ........................................... [ 12%]
....................                                                     [ 18%]
tests/unit/test_candidate_search.py .............................        [ 26%]
tests/unit/test_jobs.py ......                                           [ 28%]
tests/unit/test_crm.py ................................................. [ 42%]
........................................................................ [ 62%]
........................................................................ [ 83%]
...........................................................              [100%]

=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/discord/player.py:30
  /Users/michaelwu/conductor/workspaces/508-workflows/manado-v1/.venv/lib/python3.12/site-packages/discord/player.py:30: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

tests/unit/test_crm.py::TestCRMCog::test_upload_resume_inferred_multiple_matches_records_error
tests/unit/test_crm.py::TestCRMCog::test_upload_resume_inferred_multiple_matches_records_error
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

tests/unit/test_crm.py::TestCRMCog::test_upload_resume_inferred_multiple_matches_records_error
tests/unit/test_crm.py::TestCRMCog::test_upload_resume_inferred_multiple_matches_records_error
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/unit/test_crm.py::TestCRMCog::test_upload_resume_inferred_multiple_matches_records_error
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type swigvarlink has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================= 350 passed, 6 warnings in 0.91s ========================
- Success: no issues found in 75 source files
- ============================= test session starts ==============================
platform darwin -- Python 3.12.0, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/michaelwu/conductor/workspaces/508-workflows/manado-v1
configfile: pyproject.toml
plugins: mock-3.15.1, anyio-4.11.0, asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 20 items / 18 deselected / 2 selected

tests/integration/test_candidate_search_e2e.py ss                        [100%]

=============================== warnings summary ===============================
.venv/lib/python3.12/site-packages/discord/player.py:30
  /Users/michaelwu/conductor/workspaces/508-workflows/manado-v1/.venv/lib/python3.12/site-packages/discord/player.py:30: DeprecationWarning: 'audioop' is deprecated and slated for removal in Python 3.13
    import audioop

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 2 skipped, 18 deselected, 1 warning in 0.09s ================= (skipped locally because Postgres is unavailable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered candidate reranking to improve match quality for shortlisted candidates.
  * Enhanced job requirement rendering with separate hard/soft skill sections and evidence requirements.
  * Introduced LLM fit scoring and AI-generated candidate summaries and risk assessments.

* **Bug Fixes**
  * Improved candidate filtering logic to properly enforce hard skill requirements.

* **Chores**
  * Expanded skill alias support for better skill normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->