### PR TITLE
chore: add worktree-aware compose ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST_BIND=127.0.0.1
 # Optional: expose postgres on host for local debugging
-POSTGRES_PORT=5432
+POSTGRES_HOST_PORT=5432
 
 # Job retry behavior (optional)
 JOB_MAX_ATTEMPTS=8
@@ -36,12 +36,13 @@ MINIO_ROOT_USER=internal
 MINIO_ROOT_PASSWORD=change-me
 MINIO_INTERNAL_BUCKET=internal-transfers
 MINIO_HOST_BIND=127.0.0.1
-MINIO_API_PORT=9000
-MINIO_CONSOLE_PORT=9001
+MINIO_API_HOST_PORT=9000
+MINIO_CONSOLE_HOST_PORT=9001
 
 # API (optional defaults; API_SHARED_SECRET required to accept ingest calls)
 WEBHOOK_INGEST_HOST=0.0.0.0
 WEBHOOK_INGEST_PORT=8090
+WEBHOOK_INGEST_HOST_PORT=8090
 # Required: ingest requests are rejected when unset
 API_SHARED_SECRET=
 # Authentik admin API (required for /create-sso-user)

--- a/.env.example
+++ b/.env.example
@@ -19,8 +19,9 @@ POSTGRES_USER=postgres
 # Change in production
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST_BIND=127.0.0.1
-# Optional: expose postgres on host for local debugging
-POSTGRES_HOST_PORT=5432
+# Optional: expose postgres on a fixed host port for local debugging.
+# Leave unset to let ./scripts/docker-compose.sh compute a deterministic port.
+# POSTGRES_HOST_PORT=5432
 
 # Job retry behavior (optional)
 JOB_MAX_ATTEMPTS=8
@@ -36,13 +37,18 @@ MINIO_ROOT_USER=internal
 MINIO_ROOT_PASSWORD=change-me
 MINIO_INTERNAL_BUCKET=internal-transfers
 MINIO_HOST_BIND=127.0.0.1
-MINIO_API_HOST_PORT=9000
-MINIO_CONSOLE_HOST_PORT=9001
+# Optional: expose MinIO on fixed host ports for local debugging.
+# Leave unset to let ./scripts/docker-compose.sh compute deterministic ports.
+# MINIO_API_HOST_PORT=9000
+# MINIO_CONSOLE_HOST_PORT=9001
 
 # API (optional defaults; API_SHARED_SECRET required to accept ingest calls)
 WEBHOOK_INGEST_HOST=0.0.0.0
 WEBHOOK_INGEST_PORT=8090
-WEBHOOK_INGEST_HOST_PORT=8090
+WEBHOOK_INGEST_HOST_BIND=127.0.0.1
+# Optional: expose ingest API on a fixed host port for local debugging.
+# Leave unset to let ./scripts/docker-compose.sh compute a deterministic port.
+# WEBHOOK_INGEST_HOST_PORT=8090
 # Required: ingest requests are rejected when unset
 API_SHARED_SECRET=
 # Authentik admin API (required for /create-sso-user)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ uv run --package worker worker-consumer
 Run stack with Compose:
 
 ```bash
-docker compose up --build
+./scripts/docker-compose.sh up --build
 ```
 
 ## Bot Feature Pattern

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -66,8 +66,11 @@ Stop stack:
 Show the deterministic host ports assigned to the current worktree:
 
 ```bash
-./scripts/docker-compose.sh ports
+./scripts/docker-compose.sh print-ports
 ```
+
+Set `*_HOST_PORT` or `COMPOSE_PROJECT_NAME` in `.env` or the invoking shell if you
+need fixed values; otherwise the wrapper computes deterministic per-worktree ones.
 
 ## Testing and Quality
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,13 +54,19 @@ uv run --package five08 crmctl repl
 Start full stack (discord_bot + api + worker + redis + postgres + minio):
 
 ```bash
-docker compose up --build
+./scripts/docker-compose.sh up --build
 ```
 
 Stop stack:
 
 ```bash
-docker compose down
+./scripts/docker-compose.sh down
+```
+
+Show the deterministic host ports assigned to the current worktree:
+
+```bash
+./scripts/docker-compose.sh ports
 ```
 
 ## Testing and Quality

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -37,7 +37,7 @@ Use `.env.example` as the source of defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_PORT` (default: `5432`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432`)
 
 ## MinIO + Internal Transfers
 
@@ -45,8 +45,8 @@ Use `.env.example` as the source of defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_PORT` (default: `9000`)
-- `Optional`: `MINIO_CONSOLE_PORT` (default: `9001`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001`)
 
 ### Notes
 
@@ -56,7 +56,8 @@ Use `.env.example` as the source of defaults.
 ## Backend API Ingest
 
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090`; host-exposed Compose port)
 - `Required`: `API_SHARED_SECRET` (global shared secret for protected endpoints and webhooks)
 
 ## Backend API OIDC Session Auth

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -37,7 +37,7 @@ Use `.env.example` as the source of defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ## MinIO + Internal Transfers
 
@@ -45,8 +45,8 @@ Use `.env.example` as the source of defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### Notes
 
@@ -56,8 +56,9 @@ Use `.env.example` as the source of defaults.
 ## Backend API Ingest
 
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
+- `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
 - `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
-- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090`; host-exposed Compose port)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 - `Required`: `API_SHARED_SECRET` (global shared secret for protected endpoints and webhooks)
 
 ## Backend API OIDC Session Auth

--- a/README.md
+++ b/README.md
@@ -106,8 +106,11 @@ Or run the full stack with Docker Compose:
 Show the deterministic host ports for the current worktree:
 
 ```bash
-./scripts/docker-compose.sh ports
+./scripts/docker-compose.sh print-ports
 ```
+
+Set `*_HOST_PORT` or `COMPOSE_PROJECT_NAME` in `.env` or the invoking shell if you
+want to pin them; otherwise the wrapper computes deterministic per-worktree values.
 
 ## License
 
@@ -142,7 +145,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### MinIO + Internal Transfers
 
@@ -151,8 +154,8 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 - Note: `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are `SharedSettings` alias properties (`minio_access_key`, `minio_secret_key`) and are not env-loaded fields.
 - Note: use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` as the actual env vars.
 
@@ -160,8 +163,9 @@ Use `.env.example` as the source of truth for defaults.
 
 - `Required` for protected endpoints: `API_SHARED_SECRET` (ingest requests are rejected when unset)
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
+- `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
 - `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
-- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090`; host-exposed Compose port)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### Backend API OIDC Session Auth
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,13 @@ uv run --package five08 crmctl batch-update --where timezone__is_null=true --whe
 Or run the full stack with Docker Compose:
 
 ```bash
-docker compose up --build
+./scripts/docker-compose.sh up --build
+```
+
+Show the deterministic host ports for the current worktree:
+
+```bash
+./scripts/docker-compose.sh ports
 ```
 
 ## License
@@ -136,7 +142,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_PORT` (default: `5432`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432`)
 
 ### MinIO + Internal Transfers
 
@@ -145,8 +151,8 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_PORT` (default: `9000`)
-- `Optional`: `MINIO_CONSOLE_PORT` (default: `9001`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001`)
 - Note: `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are `SharedSettings` alias properties (`minio_access_key`, `minio_secret_key`) and are not env-loaded fields.
 - Note: use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` as the actual env vars.
 
@@ -154,7 +160,8 @@ Use `.env.example` as the source of truth for defaults.
 
 - `Required` for protected endpoints: `API_SHARED_SECRET` (ingest requests are rejected when unset)
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090`; host-exposed Compose port)
 
 ### Backend API OIDC Session Auth
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       minio-init:
         condition: service_completed_successfully
     ports:
-      - "${WEBHOOK_INGEST_HOST_PORT:-8090}:${WEBHOOK_INGEST_PORT:-8090}"
+      - "${WEBHOOK_INGEST_HOST_BIND:-127.0.0.1}:${WEBHOOK_INGEST_HOST_PORT:-8090}:${WEBHOOK_INGEST_PORT:-8090}"
 
   worker:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
     restart: unless-stopped
     ports:
-      - "${POSTGRES_HOST_BIND:-127.0.0.1}:${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_HOST_BIND:-127.0.0.1}:${POSTGRES_HOST_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:
@@ -36,8 +36,8 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
       MC_HOST_local: "http://${MINIO_ROOT_USER:-internal}:${MINIO_ROOT_PASSWORD:-change-me}@127.0.0.1:9000"
     ports:
-      - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_API_PORT:-9000}:9000"
-      - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9001}:9001"
+      - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_API_HOST_PORT:-9000}:9000"
+      - "${MINIO_HOST_BIND:-127.0.0.1}:${MINIO_CONSOLE_HOST_PORT:-9001}:9001"
     restart: unless-stopped
     volumes:
       - minio-data:/data
@@ -87,7 +87,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-workflows}}
+      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}
@@ -106,7 +106,7 @@ services:
       minio-init:
         condition: service_completed_successfully
     ports:
-      - "${WEBHOOK_INGEST_PORT:-8090}:${WEBHOOK_INGEST_PORT:-8090}"
+      - "${WEBHOOK_INGEST_HOST_PORT:-8090}:${WEBHOOK_INGEST_PORT:-8090}"
 
   worker:
     build:
@@ -128,7 +128,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-workflows}}
+      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -18,11 +18,47 @@ get_env_file_value() {
   [ -f "$env_file" ] || return 1
 
   awk -F= -v key="$key" '
+    function parse_value(raw,    first, quote, value, i, c, escaped) {
+      sub(/^[[:space:]]*/, "", raw)
+
+      first = substr(raw, 1, 1)
+      if (first == "\"" || first == "'\''") {
+        quote = first
+        value = ""
+        escaped = 0
+
+        for (i = 2; i <= length(raw); i++) {
+          c = substr(raw, i, 1)
+
+          if (quote == "\"" && escaped) {
+            value = value c
+            escaped = 0
+            continue
+          }
+
+          if (quote == "\"" && c == "\\") {
+            escaped = 1
+            continue
+          }
+
+          if (c == quote) {
+            return value
+          }
+
+          value = value c
+        }
+
+        return value
+      }
+
+      sub(/[[:space:]]+#.*$/, "", raw)
+      sub(/[[:space:]]*$/, "", raw)
+      return raw
+    }
+
     /^[[:space:]]*#/ { next }
     $0 ~ "^[[:space:]]*" key "=" {
-      value = substr($0, index($0, "=") + 1)
-      sub(/^[[:space:]]*/, "", value)
-      sub(/[[:space:]]*$/, "", value)
+      value = parse_value(substr($0, index($0, "=") + 1))
       print value
       found = 1
       exit

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+hash_value=$(printf '%s' "$repo_root" | cksum | awk '{print $1}')
+slot=$((hash_value % 2000))
+
+project_name=$(basename "$repo_root" | tr -cs 'A-Za-z0-9' '-' | tr 'A-Z' 'a-z' | sed 's/^-*//; s/-*$//')
+if [ -z "$project_name" ]; then
+  project_name="worktree"
+fi
+
+: "${COMPOSE_PROJECT_NAME:=${project_name}-$(printf '%04d' "$slot")}"
+: "${POSTGRES_HOST_PORT:=$((15432 + slot))}"
+: "${WEBHOOK_INGEST_HOST_PORT:=$((20080 + slot))}"
+: "${MINIO_API_HOST_PORT:=$((24000 + slot))}"
+: "${MINIO_CONSOLE_HOST_PORT:=$((28000 + slot))}"
+
+export COMPOSE_PROJECT_NAME
+export POSTGRES_HOST_PORT
+export WEBHOOK_INGEST_HOST_PORT
+export MINIO_API_HOST_PORT
+export MINIO_CONSOLE_HOST_PORT
+
+if [ "${1:-}" = "ports" ]; then
+  cat <<EOF
+WORKTREE=$repo_root
+COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
+POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
+WEBHOOK_INGEST_HOST_PORT=$WEBHOOK_INGEST_HOST_PORT
+MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT
+MINIO_CONSOLE_HOST_PORT=$MINIO_CONSOLE_HOST_PORT
+EOF
+  exit 0
+fi
+
+cd "$repo_root"
+exec docker compose "$@"

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eu
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+repo_root=$(CDPATH= cd "$script_dir/.." && pwd)
+env_file="$repo_root/.env"
 
 hash_value=$(printf '%s' "$repo_root" | cksum | awk '{print $1}')
 slot=$((hash_value % 2000))
@@ -12,11 +13,47 @@ if [ -z "$project_name" ]; then
   project_name="worktree"
 fi
 
-: "${COMPOSE_PROJECT_NAME:=${project_name}-$(printf '%04d' "$slot")}"
-: "${POSTGRES_HOST_PORT:=$((15432 + slot))}"
-: "${WEBHOOK_INGEST_HOST_PORT:=$((20080 + slot))}"
-: "${MINIO_API_HOST_PORT:=$((24000 + slot))}"
-: "${MINIO_CONSOLE_HOST_PORT:=$((28000 + slot))}"
+get_env_file_value() {
+  key=$1
+  [ -f "$env_file" ] || return 1
+
+  awk -F= -v key="$key" '
+    /^[[:space:]]*#/ { next }
+    $0 ~ "^[[:space:]]*" key "=" {
+      value = substr($0, index($0, "=") + 1)
+      sub(/^[[:space:]]*/, "", value)
+      sub(/[[:space:]]*$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+    END { if (!found) exit 1 }
+  ' "$env_file"
+}
+
+resolve_value() {
+  key=$1
+  default_value=$2
+  eval "shell_value=\${$key-}"
+
+  if [ -n "$shell_value" ]; then
+    printf '%s' "$shell_value"
+    return
+  fi
+
+  if file_value=$(get_env_file_value "$key" 2>/dev/null); then
+    printf '%s' "$file_value"
+    return
+  fi
+
+  printf '%s' "$default_value"
+}
+
+COMPOSE_PROJECT_NAME=$(resolve_value COMPOSE_PROJECT_NAME "${project_name}-$(printf '%04d' "$slot")")
+POSTGRES_HOST_PORT=$(resolve_value POSTGRES_HOST_PORT "$((15432 + slot))")
+WEBHOOK_INGEST_HOST_PORT=$(resolve_value WEBHOOK_INGEST_HOST_PORT "$((20080 + slot))")
+MINIO_API_HOST_PORT=$(resolve_value MINIO_API_HOST_PORT "$((24000 + slot))")
+MINIO_CONSOLE_HOST_PORT=$(resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + slot))")
 
 export COMPOSE_PROJECT_NAME
 export POSTGRES_HOST_PORT
@@ -24,7 +61,7 @@ export WEBHOOK_INGEST_HOST_PORT
 export MINIO_API_HOST_PORT
 export MINIO_CONSOLE_HOST_PORT
 
-if [ "${1:-}" = "ports" ]; then
+if [ "${1:-}" = "print-ports" ]; then
   cat <<EOF
 WORKTREE=$repo_root
 COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME


### PR DESCRIPTION
## Description
- Add `scripts/docker-compose.sh` to derive a stable Compose project name and deterministic host ports from the worktree path, with a `ports` helper to print the assigned values.
- Split Compose host-exposed port variables from internal service listen ports so multiple local stacks can run at once without breaking service-to-service traffic.
- Update `.env.example` and the repo docs to use the wrapper and the new host port variable names.

## Related Issue
- N/A

## How Has This Been Tested?
- `sh -n scripts/docker-compose.sh`
- `./scripts/docker-compose.sh ports`
- `./scripts/docker-compose.sh config --services`
- `./scripts/test.sh` (`917 passed, 18 skipped`)
