### PR TITLE
fix: parse LinkedIn profile sources

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -1817,7 +1817,7 @@ class ResumeConfirmInferredWebsitesButton(
             link_member=link_member,
             action=view.preview_action,
             status_message=(
-                "🔄 Re-running profile extraction with confirmed website and GitHub content..."
+                "🔄 Re-running profile extraction with confirmed profile-source content..."
             ),
             confirmed_personal_websites=view.website_reparse_candidates,
             confirmed_github_usernames=view.github_reparse_candidates,
@@ -4024,7 +4024,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 name="Source Reparse",
                 value=truncate_field_value(
                     "New external sources were found. Use **Reparse With New Sources** "
-                    "before confirming if you want website or GitHub content included."
+                    "before confirming if you want profile-source content included."
                 ),
                 inline=False,
             )
@@ -4300,7 +4300,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         normalized_filename = str(filename or "")
         status_text = (
             status_message
-            or "📥 Profile input received. Extracting profile fields with any fetchable website or GitHub sources now..."
+            or "📥 Profile input received. Extracting profile fields with any fetchable profile sources now..."
         )
         if link_discord_payload is None and link_member is not None:
             link_discord_payload = {
@@ -7123,9 +7123,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             has_resume = self._contact_has_resume(contact)
             has_profile_sources = self._contact_has_external_profile_sources(contact)
             resume_status = resume_name or ("on file" if has_resume else "missing")
-            source_status = (
-                "website or GitHub on file" if has_profile_sources else "none"
-            )
+            source_status = "profile sources on file" if has_profile_sources else "none"
             contact_info = (
                 f"📧 {email}\n🏢 508 Email: {email_508}\n"
                 f"📄 Resume: {resume_status}\n"
@@ -7138,7 +7136,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             name="💡 Tip",
             value=(
                 "Select the contact button to continue. Contacts without a resume "
-                "and without CRM website or GitHub sources will hand off to `/upload-resume`."
+                "and without CRM profile sources will hand off to `/upload-resume`."
             ),
             inline=False,
         )
@@ -8466,7 +8464,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         has_resume = bool(attachment_id)
         display_filename = filename or (
-            "latest resume" if has_resume else "CRM website/GitHub sources"
+            "latest resume" if has_resume else "CRM profile sources"
         )
         view = ResumeReprocessConfirmationView(
             crm_cog=self,
@@ -8479,9 +8477,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         )
         confirmation_message = (
             f"⚠️ Reprocess profile for `{contact_name}` from resume `{display_filename}` "
-            "and include any fetchable website or GitHub profile sources?"
+            "and include any fetchable profile sources?"
             if has_resume
-            else f"⚠️ Reprocess profile for `{contact_name}` from CRM website or GitHub sources?"
+            else f"⚠️ Reprocess profile for `{contact_name}` from CRM profile sources?"
         )
         await interaction.followup.send(
             confirmation_message,
@@ -8527,7 +8525,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         has_resume = bool(attachment_id)
         display_filename = filename or (
-            "latest resume" if has_resume else "CRM website/GitHub sources"
+            "latest resume" if has_resume else "CRM profile sources"
         )
         await self._run_resume_extract_and_preview(
             interaction=interaction,
@@ -10066,7 +10064,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
     @app_commands.command(
         name="reprocess-profile",
-        description="Reprocess a profile from the latest resume or CRM website/GitHub",
+        description="Reprocess a profile from the latest resume or CRM profile sources",
     )
     @app_commands.describe(search_term="Email, 508 username, 508 email, or contact ID.")
     async def reprocess_profile(

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -115,7 +115,7 @@ PROFILE_SOURCE_JS_RENDER_MARKERS = (
     "please turn on javascript",
 )
 _HTML_BLOCK_RE = re.compile(
-    r"(?is)<(script|style|noscript|svg|nav|header|footer)[^>]*>.*?</\1>"
+    r"(?is)<(script|style|noscript|svg|nav|header|footer|template)[^>]*>.*?</\1>"
 )
 _HTML_TAG_RE = re.compile(r"(?s)<[^>]+>")
 _HTML_BREAK_RE = re.compile(r"(?i)<br\s*/?>")
@@ -133,13 +133,13 @@ _HTML_META_CONTENT_ATTR_RE = re.compile(
     flags=re.IGNORECASE,
 )
 _LINKEDIN_PROFILE_PAGEKEY_RE = re.compile(
-    r'(?is)<meta[^>]+name=["\']pagekey["\'][^>]+content=["\']public_profile_v3[^"\']*["\']'
+    r'(?is)<meta\b(?=[^>]*\bname=["\']pagekey["\'])(?=[^>]*\bcontent=["\']public_profile_v3[^"\']*["\'])[^>]*>'
 )
 _LINKEDIN_PROFILE_CANONICAL_URL_RE = re.compile(
     r"(?is)(?:"
-    r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
-    r'|<meta[^>]+property=["\']og:url["\'][^>]+content=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
-    r'|<meta[^>]+property=["\']al:(?:android|ios):url["\'][^>]+content=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
+    r'<link\b(?=[^>]*\brel=["\']canonical["\'])(?=[^>]*\bhref=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\'])[^>]*>'
+    r'|<meta\b(?=[^>]*\bproperty=["\']og:url["\'])(?=[^>]*\bcontent=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\'])[^>]*>'
+    r'|<meta\b(?=[^>]*\bproperty=["\']al:(?:android|ios):url["\'])(?=[^>]*\bcontent=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\'])[^>]*>'
     r")"
 )
 _LINKEDIN_BAY_AREA_RE = re.compile(r"(?i)^(?:greater\s+)?[A-Za-z .'-]+ area$")
@@ -162,6 +162,33 @@ _LINKEDIN_SECTION_HEADINGS = (
     "Patents",
     "Honors & Awards",
     "Languages",
+)
+_LINKEDIN_SECTION_HEADINGS_BY_CASEFOLD = {
+    heading.casefold(): heading for heading in _LINKEDIN_SECTION_HEADINGS
+}
+_LINKEDIN_LOCATION_NEGATIVE_TERMS = (
+    "founder",
+    "co-founder",
+    "engineer",
+    "developer",
+    "designer",
+    "manager",
+    "director",
+    "consultant",
+    "software",
+    "product",
+    "marketing",
+    "science",
+    "scientist",
+    "master",
+    "bachelor",
+    "degree",
+    "university",
+    "college",
+    "investor",
+    "blogger",
+    "writer",
+    "researcher",
 )
 
 
@@ -1549,7 +1576,9 @@ class ResumeProfileProcessor:
                             )
                         except ValueError as browser_exc:
                             last_fetch_error = browser_exc
-                            if not self._is_retryable_profile_fetch_error(str(exc)):
+                            if not self._is_retryable_profile_fetch_error(
+                                str(browser_exc)
+                            ):
                                 raise browser_exc
                         else:
                             return ProfileSourceFetchDiagnostics(
@@ -2350,8 +2379,15 @@ class ResumeProfileProcessor:
         normalized = _HTML_TAG_RE.sub(" ", normalized)
         normalized = unescape(normalized)
         normalized = re.sub(r"[ \t\r\f\v]+", " ", normalized)
-        normalized = re.sub(r"\n{2,}", "\n", normalized)
-        normalized = normalized.strip()
+        normalized_lines = [
+            line
+            for line in (
+                re.sub(r"\s+", " ", raw_line).strip()
+                for raw_line in normalized.splitlines()
+            )
+            if line and not self._is_low_value_html_text_line(line)
+        ]
+        normalized = "\n".join(normalized_lines).strip()
 
         text_parts: list[str] = []
         if title_match:
@@ -2400,6 +2436,9 @@ class ResumeProfileProcessor:
 
         sections = self._extract_linkedin_sections(filtered_lines)
         websites = self._format_linkedin_websites(sections.pop("Websites", []))
+        has_structured_content = bool(websites) or any(sections.values())
+        if not has_structured_content:
+            return None
 
         parts: list[str] = []
         if name:
@@ -2459,9 +2498,12 @@ class ResumeProfileProcessor:
         normalized = unescape(normalized)
         normalized = normalized.replace("\xa0", " ")
         return [
-            re.sub(r"\s+", " ", line).strip()
-            for line in normalized.splitlines()
-            if re.sub(r"\s+", " ", line).strip()
+            line
+            for line in (
+                re.sub(r"\s+", " ", raw_line).strip()
+                for raw_line in normalized.splitlines()
+            )
+            if line and not self._is_low_value_html_text_line(line)
         ]
 
     @staticmethod
@@ -2523,11 +2565,43 @@ class ResumeProfileProcessor:
         }
         return lowered in exact_noise_tokens
 
+    @staticmethod
+    def _is_low_value_html_text_line(line: str) -> bool:
+        candidate = line.strip()
+        if not candidate:
+            return False
+        if (
+            candidate.count("%") >= 3
+            and " " not in candidate
+            and re.search(r"%[0-9A-Fa-f]{2}", candidate)
+        ):
+            return True
+        if any(
+            marker in candidate
+            for marker in (
+                "__NEXT_DATA__",
+                "__NUXT__",
+                "window.__",
+                "webpackChunk",
+            )
+        ):
+            return True
+        if (
+            (
+                (candidate.startswith("{") and candidate.endswith("}"))
+                or (candidate.startswith("[") and candidate.endswith("]"))
+            )
+            and ('"' in candidate or ":" in candidate)
+            and candidate.count(" ") <= 2
+        ):
+            return True
+        return False
+
     def _extract_linkedin_sections(self, lines: list[str]) -> dict[str, list[str]]:
         indexed_headings = [
-            (index, line)
+            (index, heading)
             for index, line in enumerate(lines)
-            if line in _LINKEDIN_SECTION_HEADINGS
+            if (heading := _LINKEDIN_SECTION_HEADINGS_BY_CASEFOLD.get(line.casefold()))
         ]
         sections: dict[str, list[str]] = {}
         for position, (start_index, heading) in enumerate(indexed_headings):
@@ -2596,11 +2670,9 @@ class ResumeProfileProcessor:
         header_lines = lines[: min(first_section_index, 6)]
         for line in header_lines:
             candidate = line.strip()
-            if not candidate or any(char.isdigit() for char in candidate):
-                continue
-            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", candidate):
-                return candidate
-            if _LINKEDIN_BAY_AREA_RE.fullmatch(candidate):
+            if ResumeProfileProcessor._looks_like_linkedin_location_candidate(
+                candidate
+            ):
                 return candidate
         return None
 
@@ -2612,13 +2684,30 @@ class ResumeProfileProcessor:
             flags=re.IGNORECASE,
         ):
             candidate = re.sub(r"\s+", " ", unescape(match.group(1))).strip()
-            if not candidate:
-                continue
-            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", candidate):
-                return candidate
-            if _LINKEDIN_BAY_AREA_RE.fullmatch(candidate):
+            if ResumeProfileProcessor._looks_like_linkedin_location_candidate(
+                candidate
+            ):
                 return candidate
         return None
+
+    @staticmethod
+    def _looks_like_linkedin_location_candidate(candidate: str) -> bool:
+        line = candidate.strip()
+        if not line or any(char.isdigit() for char in line):
+            return False
+        if _LINKEDIN_BAY_AREA_RE.fullmatch(line):
+            return True
+        if "," not in line:
+            return False
+        lowered = line.casefold()
+        if any(term in lowered for term in _LINKEDIN_LOCATION_NEGATIVE_TERMS):
+            return False
+        parts = [part.strip() for part in line.split(",") if part.strip()]
+        if len(parts) < 2 or len(parts) > 3:
+            return False
+        if any(len(part.split()) > 4 for part in parts):
+            return False
+        return all(re.fullmatch(r"[A-Za-z .'-]+", part) for part in parts)
 
     def _validate_public_profile_url(self, candidate_url: str) -> str | None:
         resolution = self._resolve_public_profile_request_target(candidate_url)

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -80,16 +80,16 @@ PROFILE_SOURCE_ALLOWED_CONTENT_TYPES = (
     "text/markdown",
 )
 PROFILE_SOURCE_BLOCKED_STATUS_CODES = frozenset({401, 403, 429, 503})
-PROFILE_SOURCE_BLOCKED_MARKERS = (
-    "access denied",
-    "attention required",
-    "captcha",
-    "cf-chl",
-    "challenge-platform",
-    "checking your browser",
-    "enable javascript and cookies",
-    "unusual traffic",
-    "verify you are human",
+PROFILE_SOURCE_BLOCKED_PATTERNS = (
+    re.compile(r"access denied", re.IGNORECASE),
+    re.compile(r"attention required", re.IGNORECASE),
+    re.compile(r"\bcaptcha\b", re.IGNORECASE),
+    re.compile(r"_cf_chl_opt", re.IGNORECASE),
+    re.compile(r"/cdn-cgi/challenge-platform", re.IGNORECASE),
+    re.compile(r"checking your browser", re.IGNORECASE),
+    re.compile(r"enable javascript and cookies(?: to continue)?", re.IGNORECASE),
+    re.compile(r"unusual traffic", re.IGNORECASE),
+    re.compile(r"verify you are human", re.IGNORECASE),
 )
 PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_CHARS = 250
 PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_WORDS = 40
@@ -1942,7 +1942,10 @@ class ResumeProfileProcessor:
                 except Exception:
                     logger.debug("Failed to close CloakBrowser for %s", navigation_url)
 
-        return self._extract_rendered_profile_source_text(rendered_html)
+        return self._extract_rendered_profile_source_text(
+            rendered_html,
+            navigation_url=navigation_url,
+        )
 
     def _extract_profile_source_text(self, *, body: bytes, content_type: str) -> str:
         normalized_type = content_type.split(";", 1)[0].strip().lower()
@@ -2074,9 +2077,16 @@ class ResumeProfileProcessor:
             return "Profile URL must use http or https"
         return self._validate_public_profile_url(candidate_url)
 
-    def _extract_rendered_profile_source_text(self, rendered_html: str) -> str:
+    def _extract_rendered_profile_source_text(
+        self,
+        rendered_html: str,
+        *,
+        navigation_url: str | None = None,
+    ) -> str:
         rendered_body = rendered_html.encode("utf-8")
-        if len(rendered_body) > PROFILE_SOURCE_MAX_BYTES:
+        if len(rendered_body) > self._profile_source_max_bytes_for_url(
+            navigation_url or ""
+        ):
             raise ValueError("Rendered profile page exceeds size limit")
         return self._extract_profile_source_text(
             body=rendered_body,
@@ -2158,8 +2168,9 @@ class ResumeProfileProcessor:
 
     @staticmethod
     def _profile_source_html_looks_blocked(rendered_html: str) -> bool:
-        normalized = rendered_html.casefold()
-        return any(marker in normalized for marker in PROFILE_SOURCE_BLOCKED_MARKERS)
+        return any(
+            pattern.search(rendered_html) for pattern in PROFILE_SOURCE_BLOCKED_PATTERNS
+        )
 
     @staticmethod
     def _profile_source_response_looks_blocked(
@@ -2335,41 +2346,45 @@ class ResumeProfileProcessor:
             return True
         if line.endswith(" Graphic"):
             return True
-        return any(
-            marker in lowered
-            for marker in (
-                "skip to main content",
-                "join now",
-                "sign in",
-                "join with email",
-                "already on linkedin",
-                "user agreement",
-                "privacy policy",
-                "cookie policy",
-                "view mutual connections",
-                "see your mutual connections",
-                "view michael’s full profile",
-                "view michael's full profile",
-                "report this",
-                "close menu",
-                "copy",
-                "facebook",
-                "top content",
-                "people",
-                "learning",
-                "jobs",
-                "games",
-                "contact info",
-                "email or phone",
-                "password",
-                "forgot password",
-                "show all activity",
-                "other similar profiles",
-                "message",
-                "view profile",
-                "public_profile__posts",
-            )
-        )
+        if re.fullmatch(r"sign in to view .+ full profile", lowered):
+            return True
+        exact_noise_tokens = {
+            "skip to main content",
+            "join now",
+            "sign in",
+            "join with email",
+            "already on linkedin? sign in",
+            "user agreement",
+            "privacy policy",
+            "cookie policy",
+            "view mutual connections",
+            "see your mutual connections",
+            "report this post",
+            "report this profile",
+            "report this",
+            "close menu",
+            "copy",
+            "copy link",
+            "facebook",
+            "x",
+            "top content",
+            "people",
+            "learning",
+            "jobs",
+            "games",
+            "contact info",
+            "email or phone",
+            "password",
+            "forgot password?",
+            "forgot password",
+            "show all activity",
+            "other similar profiles",
+            "message",
+            "send message",
+            "view profile",
+            "public_profile__posts",
+        }
+        return lowered in exact_noise_tokens
 
     def _extract_linkedin_sections(self, lines: list[str]) -> dict[str, list[str]]:
         headings = (

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -59,6 +59,7 @@ LINKEDIN_FIELD = "cLinkedIn"
 PROFILE_SOURCE_FETCH_TIMEOUT_SECONDS = 10.0
 PROFILE_SOURCE_BROWSER_TIMEOUT_SECONDS = 20.0
 PROFILE_SOURCE_BROWSER_TIMEOUT_MS = int(PROFILE_SOURCE_BROWSER_TIMEOUT_SECONDS * 1000)
+PROFILE_SOURCE_BROWSER_POST_NAV_WAIT_MS = 5000
 PROFILE_SOURCE_MAX_REDIRECTS = 3
 PROFILE_SOURCE_MAX_BYTES = 512 * 1024
 PROFILE_SOURCE_LINKEDIN_MAX_BYTES = 2 * 1024 * 1024
@@ -1400,6 +1401,10 @@ class ResumeProfileProcessor:
             contact.get(LINKEDIN_FIELD)
         )
         if linkedin_profile_url:
+            linkedin_source_key = normalized_website_identity_key(linkedin_profile_url)
+            if linkedin_source_key in added_website_source_keys:
+                linkedin_profile_url = None
+        if linkedin_profile_url:
             candidates.append(
                 _ExternalProfileSourceCandidate(
                     label="LinkedIn Profile",
@@ -1975,6 +1980,8 @@ class ResumeProfileProcessor:
         if validation_error:
             raise ValueError(validation_error)
 
+        session = self._create_profile_source_http_session()
+        response_cache: dict[str, ProfileSourceHttpResponse] = {}
         context = None
         try:
             context = launch_context(
@@ -1987,14 +1994,18 @@ class ResumeProfileProcessor:
             page = context.new_page()
             page.route(
                 "**/*",
-                lambda route: self._handle_browser_profile_request_route_direct(route),
+                lambda route: self._handle_browser_profile_request_route(
+                    route,
+                    response_cache,
+                    session=session,
+                ),
             )
             page.goto(
                 navigation_url,
                 wait_until="domcontentloaded",
                 timeout=PROFILE_SOURCE_BROWSER_TIMEOUT_MS,
             )
-            page.wait_for_timeout(5000)
+            page.wait_for_timeout(PROFILE_SOURCE_BROWSER_POST_NAV_WAIT_MS)
             final_page_url = str(getattr(page, "url", "")).strip()
             validation_error = self._validate_browser_profile_navigation_url(
                 final_page_url
@@ -2015,20 +2026,7 @@ class ResumeProfileProcessor:
                     context.close()
                 except Exception:
                     logger.debug("Failed to close CloakBrowser for %s", navigation_url)
-
-    def _handle_browser_profile_request_route_direct(self, route: Any) -> None:
-        request = route.request
-        request_url = str(getattr(request, "url", "")).strip()
-        validation_error = self._validate_browser_profile_request_url(request_url)
-        if validation_error:
-            logger.info(
-                "Blocked non-public direct browser profile request url=%s error=%s",
-                request_url,
-                validation_error,
-            )
-            route.abort()
-            return
-        route.continue_()
+            session.close()
 
     def _fetch_external_profile_source_text_with_browser_once(
         self,
@@ -2087,7 +2085,7 @@ class ResumeProfileProcessor:
 
         return self._extract_browser_rendered_profile_source_text(
             rendered_html,
-            navigation_url=navigation_url,
+            navigation_url=final_page_url,
         )
 
     def _extract_profile_source_text(self, *, body: bytes, content_type: str) -> str:

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -132,6 +132,17 @@ _HTML_META_CONTENT_ATTR_RE = re.compile(
     r'content\s*=\s*["\']([^"\']*)["\']',
     flags=re.IGNORECASE,
 )
+_LINKEDIN_PROFILE_PAGEKEY_RE = re.compile(
+    r'(?is)<meta[^>]+name=["\']pagekey["\'][^>]+content=["\']public_profile_v3[^"\']*["\']'
+)
+_LINKEDIN_PROFILE_CANONICAL_URL_RE = re.compile(
+    r"(?is)(?:"
+    r'<link[^>]+rel=["\']canonical["\'][^>]+href=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
+    r'|<meta[^>]+property=["\']og:url["\'][^>]+content=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
+    r'|<meta[^>]+property=["\']al:(?:android|ios):url["\'][^>]+content=["\']https?://(?:[\w.-]+\.)?linkedin\.com/in/[^"\']+["\']'
+    r")"
+)
+_LINKEDIN_BAY_AREA_RE = re.compile(r"(?i)^(?:greater\s+)?[A-Za-z .'-]+ area$")
 _GITHUB_USERNAME_RE = re.compile(
     r"^(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})/?(?:[?#].*)?$",
     flags=re.IGNORECASE,
@@ -142,6 +153,15 @@ _LINKEDIN_PROFILE_RE = re.compile(
 )
 _DOMAIN_LINE_RE = re.compile(
     r"(?i)^(?:https?://)?(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}(?:[/?#].*)?$"
+)
+_LINKEDIN_SECTION_HEADINGS = (
+    "Websites",
+    "Experience",
+    "Education",
+    "Publications",
+    "Patents",
+    "Honors & Awards",
+    "Languages",
 )
 
 
@@ -2356,9 +2376,9 @@ class ResumeProfileProcessor:
                 name = name.strip() or None
                 headline = headline_part.strip() or None
 
-        location = self._extract_linkedin_location(filtered_lines)
+        location = self._extract_linkedin_location_from_html(value)
         if not location:
-            location = self._extract_linkedin_location_from_html(value)
+            location = self._extract_linkedin_location(filtered_lines)
 
         sections = self._extract_linkedin_sections(filtered_lines)
         websites = self._format_linkedin_websites(sections.pop("Websites", []))
@@ -2398,16 +2418,17 @@ class ResumeProfileProcessor:
     @staticmethod
     def _is_linkedin_public_profile_html(value: str) -> bool:
         lowered = value.casefold()
-        has_profile_marker = (
-            "linkedin.com/in/" in lowered or "public_profile_v3" in lowered
-        )
-        if not has_profile_marker:
+        if "| linkedin</title>" not in lowered:
             return False
-        return (
-            "linkedin:pagetag" in lowered
-            or "| linkedin</title>" in lowered
-            or "public_profile_v3" in lowered
-        )
+        has_profile_pagekey = _LINKEDIN_PROFILE_PAGEKEY_RE.search(value) is not None
+        has_profile_url = _LINKEDIN_PROFILE_CANONICAL_URL_RE.search(value) is not None
+        if not has_profile_pagekey or not has_profile_url:
+            return False
+        title_match = _HTML_TITLE_RE.search(value)
+        if not title_match:
+            return False
+        title = re.sub(r"\s+", " ", unescape(title_match.group(1))).strip()
+        return " - " in title
 
     def _extract_html_text_lines(self, value: str) -> list[str]:
         main_match = re.search(r"(?is)<main[^>]*>(.*?)</main>", value)
@@ -2485,17 +2506,10 @@ class ResumeProfileProcessor:
         return lowered in exact_noise_tokens
 
     def _extract_linkedin_sections(self, lines: list[str]) -> dict[str, list[str]]:
-        headings = (
-            "Websites",
-            "Experience",
-            "Education",
-            "Publications",
-            "Patents",
-            "Honors & Awards",
-            "Languages",
-        )
         indexed_headings = [
-            (index, line) for index, line in enumerate(lines) if line in headings
+            (index, line)
+            for index, line in enumerate(lines)
+            if line in _LINKEDIN_SECTION_HEADINGS
         ]
         sections: dict[str, list[str]] = {}
         for position, (start_index, heading) in enumerate(indexed_headings):
@@ -2540,7 +2554,9 @@ class ResumeProfileProcessor:
                 break
             if index + 1 < len(lines) and _DOMAIN_LINE_RE.fullmatch(lines[index + 1]):
                 if current.casefold() not in allowed_labels:
-                    break
+                    formatted.append(lines[index + 1])
+                    index += 2
+                    continue
                 formatted.append(f"{current}: {lines[index + 1]}")
                 index += 2
                 continue
@@ -2551,9 +2567,23 @@ class ResumeProfileProcessor:
 
     @staticmethod
     def _extract_linkedin_location(lines: list[str]) -> str | None:
-        for line in lines:
-            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", line):
-                return line
+        first_section_index = next(
+            (
+                index
+                for index, line in enumerate(lines)
+                if line in _LINKEDIN_SECTION_HEADINGS
+            ),
+            len(lines),
+        )
+        header_lines = lines[: min(first_section_index, 6)]
+        for line in header_lines:
+            candidate = line.strip()
+            if not candidate or any(char.isdigit() for char in candidate):
+                continue
+            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", candidate):
+                return candidate
+            if _LINKEDIN_BAY_AREA_RE.fullmatch(candidate):
+                return candidate
         return None
 
     @staticmethod
@@ -2564,7 +2594,11 @@ class ResumeProfileProcessor:
             flags=re.IGNORECASE,
         ):
             candidate = re.sub(r"\s+", " ", unescape(match.group(1))).strip()
-            if candidate:
+            if not candidate:
+                continue
+            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", candidate):
+                return candidate
+            if _LINKEDIN_BAY_AREA_RE.fullmatch(candidate):
                 return candidate
         return None
 

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -1502,6 +1502,7 @@ class ResumeProfileProcessor:
         try:
             response: ProfileSourceHttpResponse | None = None
             last_fetch_error: ValueError | None = None
+            browser_attempted = False
             for candidate_url in self._iter_profile_source_fetch_urls(
                 url,
                 allow_javascript_fallback=allow_javascript_fallback,
@@ -1514,6 +1515,34 @@ class ResumeProfileProcessor:
                     break
                 except ValueError as exc:
                     last_fetch_error = exc
+                    if (
+                        allow_javascript_fallback
+                        and self._should_reset_profile_source_session(str(exc))
+                    ):
+                        browser_attempted = True
+                        try:
+                            (
+                                browser_final_url,
+                                direct_browser_text,
+                            ) = self._fetch_external_profile_source_text_with_browser_direct(
+                                candidate_url
+                            )
+                        except ValueError as browser_exc:
+                            last_fetch_error = browser_exc
+                            if not self._is_retryable_profile_fetch_error(str(exc)):
+                                raise browser_exc
+                        else:
+                            return ProfileSourceFetchDiagnostics(
+                                url=url,
+                                final_url=browser_final_url,
+                                content_type="text/html",
+                                selected_text=direct_browser_text,
+                                curl_text=None,
+                                browser_attempted=True,
+                                browser_used=True,
+                                browser_text=direct_browser_text,
+                                error=None,
+                            )
                     if not self._is_retryable_profile_fetch_error(str(exc)):
                         raise
 
@@ -1529,7 +1558,6 @@ class ResumeProfileProcessor:
             except ValueError as exc:
                 extraction_error = exc
 
-            browser_attempted = False
             browser_used = False
             browser_text: str | None = None
             if (
@@ -1885,6 +1913,56 @@ class ResumeProfileProcessor:
         finally:
             fresh_session.close()
 
+    def _fetch_external_profile_source_text_with_browser_direct(
+        self,
+        navigation_url: str,
+    ) -> tuple[str, str]:
+        try:
+            from cloakbrowser import launch_context  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise ValueError("JavaScript browser fallback is unavailable") from exc
+
+        validation_error = self._validate_browser_profile_navigation_url(navigation_url)
+        if validation_error:
+            raise ValueError(validation_error)
+
+        context = None
+        try:
+            context = launch_context(
+                user_agent=PROFILE_SOURCE_USER_AGENT,
+                viewport=PROFILE_SOURCE_BROWSER_VIEWPORT,
+                is_mobile=True,
+                has_touch=True,
+                device_scale_factor=PROFILE_SOURCE_BROWSER_DEVICE_SCALE_FACTOR,
+            )
+            page = context.new_page()
+            page.goto(
+                navigation_url,
+                wait_until="domcontentloaded",
+                timeout=PROFILE_SOURCE_BROWSER_TIMEOUT_MS,
+            )
+            page.wait_for_timeout(5000)
+            final_page_url = str(getattr(page, "url", "")).strip()
+            validation_error = self._validate_browser_profile_navigation_url(
+                final_page_url
+            )
+            if validation_error:
+                raise ValueError(validation_error)
+            rendered_html = page.content()
+            rendered_text = self._extract_browser_rendered_profile_source_text(
+                rendered_html,
+                navigation_url=final_page_url,
+            )
+            return final_page_url, rendered_text
+        except Exception as exc:
+            raise ValueError(f"JavaScript profile fetch failed: {exc}") from exc
+        finally:
+            if context is not None:
+                try:
+                    context.close()
+                except Exception:
+                    logger.debug("Failed to close CloakBrowser for %s", navigation_url)
+
     def _fetch_external_profile_source_text_with_browser_once(
         self,
         initial_response: ProfileSourceHttpResponse,
@@ -1931,8 +2009,6 @@ class ResumeProfileProcessor:
             if validation_error:
                 raise ValueError(validation_error)
             rendered_html = page.content()
-            if self._profile_source_html_looks_blocked(rendered_html):
-                raise ValueError("JavaScript profile fetch hit a scraping block")
         except Exception as exc:
             raise ValueError(f"JavaScript profile fetch failed: {exc}") from exc
         finally:
@@ -1942,7 +2018,7 @@ class ResumeProfileProcessor:
                 except Exception:
                     logger.debug("Failed to close CloakBrowser for %s", navigation_url)
 
-        return self._extract_rendered_profile_source_text(
+        return self._extract_browser_rendered_profile_source_text(
             rendered_html,
             navigation_url=navigation_url,
         )
@@ -2092,6 +2168,28 @@ class ResumeProfileProcessor:
             body=rendered_body,
             content_type="text/html",
         )
+
+    def _extract_browser_rendered_profile_source_text(
+        self,
+        rendered_html: str,
+        *,
+        navigation_url: str | None = None,
+    ) -> str:
+        rendered_text = self._extract_rendered_profile_source_text(
+            rendered_html,
+            navigation_url=navigation_url,
+        )
+        if not self._profile_source_html_looks_blocked(rendered_html):
+            return rendered_text
+
+        stripped_text = rendered_text.strip()
+        word_count = len(re.findall(r"\w+", stripped_text))
+        if self._profile_source_html_looks_blocked(stripped_text) or (
+            len(stripped_text) <= PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_CHARS
+            and word_count <= PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_WORDS
+        ):
+            raise ValueError("JavaScript profile fetch hit a scraping block")
+        return rendered_text
 
     @staticmethod
     def _browser_route_response_headers(

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -1956,6 +1956,10 @@ class ResumeProfileProcessor:
                 device_scale_factor=PROFILE_SOURCE_BROWSER_DEVICE_SCALE_FACTOR,
             )
             page = context.new_page()
+            page.route(
+                "**/*",
+                lambda route: self._handle_browser_profile_request_route_direct(route),
+            )
             page.goto(
                 navigation_url,
                 wait_until="domcontentloaded",
@@ -1982,6 +1986,20 @@ class ResumeProfileProcessor:
                     context.close()
                 except Exception:
                     logger.debug("Failed to close CloakBrowser for %s", navigation_url)
+
+    def _handle_browser_profile_request_route_direct(self, route: Any) -> None:
+        request = route.request
+        request_url = str(getattr(request, "url", "")).strip()
+        validation_error = self._validate_browser_profile_request_url(request_url)
+        if validation_error:
+            logger.info(
+                "Blocked non-public direct browser profile request url=%s error=%s",
+                request_url,
+                validation_error,
+            )
+            route.abort()
+            return
+        route.continue_()
 
     def _fetch_external_profile_source_text_with_browser_once(
         self,

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -61,6 +61,7 @@ PROFILE_SOURCE_BROWSER_TIMEOUT_SECONDS = 20.0
 PROFILE_SOURCE_BROWSER_TIMEOUT_MS = int(PROFILE_SOURCE_BROWSER_TIMEOUT_SECONDS * 1000)
 PROFILE_SOURCE_MAX_REDIRECTS = 3
 PROFILE_SOURCE_MAX_BYTES = 512 * 1024
+PROFILE_SOURCE_LINKEDIN_MAX_BYTES = 2 * 1024 * 1024
 PROFILE_SOURCE_BROWSER_RESOURCE_MAX_BYTES = 10 * 1024 * 1024
 PROFILE_SOURCE_MAX_TEXT_CHARS = 12000
 PROFILE_SOURCE_MAX_WEBSITES = 2
@@ -134,6 +135,13 @@ _HTML_META_CONTENT_ATTR_RE = re.compile(
 _GITHUB_USERNAME_RE = re.compile(
     r"^(?:https?://)?(?:www\.)?github\.com/([A-Za-z0-9-]{1,39})/?(?:[?#].*)?$",
     flags=re.IGNORECASE,
+)
+_LINKEDIN_PROFILE_RE = re.compile(
+    r"^(?:https?://)?(?:[\w.-]+\.)?linkedin\.com/in/([A-Za-z0-9_%-]+)/?(?:[?#].*)?$",
+    flags=re.IGNORECASE,
+)
+_DOMAIN_LINE_RE = re.compile(
+    r"(?i)^(?:https?://)?(?:www\.)?(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,}(?:[/?#].*)?$"
 )
 
 
@@ -1341,6 +1349,19 @@ class ResumeProfileProcessor:
                 )
             )
 
+        linkedin_profile_url = self._normalize_linkedin_profile_url(
+            contact.get(LINKEDIN_FIELD)
+        )
+        if linkedin_profile_url:
+            candidates.append(
+                _ExternalProfileSourceCandidate(
+                    label="LinkedIn Profile",
+                    url=linkedin_profile_url,
+                    origin="crm",
+                    source_key=f"linkedin:{linkedin_profile_url.casefold()}",
+                )
+            )
+
         explicit_github_keys: set[str] = set()
         for username in explicit_github_usernames or []:
             normalized_username = self._normalize_github_username(username)
@@ -1381,6 +1402,8 @@ class ResumeProfileProcessor:
         explicit_github_usernames: list[str] | None = None,
     ) -> bool:
         if self._coerce_website_links(explicit_personal_websites):
+            return True
+        if self._normalize_linkedin_profile_url(contact.get(LINKEDIN_FIELD)):
             return True
         if any(
             self._normalize_github_username(username)
@@ -1428,6 +1451,8 @@ class ResumeProfileProcessor:
             label_base = (
                 "github_profile"
                 if candidate.label.casefold() == "github profile"
+                else "linkedin_profile"
+                if candidate.label.casefold() == "linkedin profile"
                 else "personal_website"
             )
             next_index = source_label_counts.get(label_base, 0) + 1
@@ -1650,7 +1675,7 @@ class ResumeProfileProcessor:
                 "Accept": ", ".join(PROFILE_SOURCE_ALLOWED_CONTENT_TYPES),
             },
             body=None,
-            max_bytes=PROFILE_SOURCE_MAX_BYTES,
+            max_bytes=self._profile_source_max_bytes_for_url(url),
             require_success=True,
             size_limit_error="Profile page exceeds size limit",
             detect_blocked=True,
@@ -1809,6 +1834,12 @@ class ResumeProfileProcessor:
             if len(payload) > max_bytes:
                 raise ValueError(size_limit_error)
         return bytes(payload)
+
+    def _profile_source_max_bytes_for_url(self, url: str) -> int:
+        host = (urlsplit(url).hostname or "").strip().casefold()
+        if host == "linkedin.com" or host.endswith(".linkedin.com"):
+            return PROFILE_SOURCE_LINKEDIN_MAX_BYTES
+        return PROFILE_SOURCE_MAX_BYTES
 
     def _fetch_external_profile_source_text_with_browser(
         self,
@@ -2157,6 +2188,10 @@ class ResumeProfileProcessor:
         )
 
     def _extract_text_from_html(self, value: str) -> str:
+        linkedin_text = self._extract_text_from_linkedin_html(value)
+        if linkedin_text:
+            return linkedin_text
+
         main_match = re.search(r"(?is)<main[^>]*>(.*?)</main>", value)
         html_value = main_match.group(1) if main_match else value
         title_match = _HTML_TITLE_RE.search(value)
@@ -2187,6 +2222,238 @@ class ResumeProfileProcessor:
         if normalized:
             text_parts.append(normalized)
         return "\n".join(text_parts).strip()
+
+    def _extract_text_from_linkedin_html(self, value: str) -> str | None:
+        if not self._is_linkedin_public_profile_html(value):
+            return None
+
+        lines = self._extract_html_text_lines(value)
+        if not lines:
+            return None
+        filtered_lines = self._dedupe_lines(
+            line for line in lines if not self._is_linkedin_noise_line(line)
+        )
+        if not filtered_lines:
+            return None
+
+        title_match = _HTML_TITLE_RE.search(value)
+        name: str | None = None
+        headline: str | None = None
+        if title_match:
+            title = re.sub(r"\s+", " ", unescape(title_match.group(1))).strip()
+            if title:
+                title_root = title.removesuffix(" | LinkedIn").strip()
+                name, _, headline_part = title_root.partition(" - ")
+                name = name.strip() or None
+                headline = headline_part.strip() or None
+
+        location = self._extract_linkedin_location(filtered_lines)
+        if not location:
+            location = self._extract_linkedin_location_from_html(value)
+
+        sections = self._extract_linkedin_sections(filtered_lines)
+        websites = self._format_linkedin_websites(sections.pop("Websites", []))
+
+        parts: list[str] = []
+        if name:
+            parts.append(f"Name: {name}")
+        if headline:
+            parts.append(f"Headline: {headline}")
+        if location:
+            parts.append(f"Location: {location}")
+
+        if websites:
+            if parts:
+                parts.append("")
+            parts.append("Websites:")
+            parts.extend(f"- {item}" for item in websites)
+
+        for heading in (
+            "Experience",
+            "Education",
+            "Publications",
+            "Patents",
+            "Honors & Awards",
+            "Languages",
+        ):
+            section_lines = sections.get(heading, [])
+            if not section_lines:
+                continue
+            if parts:
+                parts.append("")
+            parts.append(f"{heading}:")
+            parts.extend(section_lines)
+
+        return "\n".join(parts).strip() or None
+
+    @staticmethod
+    def _is_linkedin_public_profile_html(value: str) -> bool:
+        lowered = value.casefold()
+        has_profile_marker = (
+            "linkedin.com/in/" in lowered or "public_profile_v3" in lowered
+        )
+        if not has_profile_marker:
+            return False
+        return (
+            "linkedin:pagetag" in lowered
+            or "| linkedin</title>" in lowered
+            or "public_profile_v3" in lowered
+        )
+
+    def _extract_html_text_lines(self, value: str) -> list[str]:
+        main_match = re.search(r"(?is)<main[^>]*>(.*?)</main>", value)
+        html_value = main_match.group(1) if main_match else value
+        normalized = re.sub(r"(?is)<!--.*?-->", " ", html_value)
+        normalized = _HTML_BLOCK_RE.sub(" ", normalized)
+        normalized = _HTML_BREAK_RE.sub("\n", normalized)
+        normalized = _HTML_BLOCK_CLOSE_RE.sub("\n", normalized)
+        normalized = _HTML_TAG_RE.sub("\n", normalized)
+        normalized = unescape(normalized)
+        normalized = normalized.replace("\xa0", " ")
+        return [
+            re.sub(r"\s+", " ", line).strip()
+            for line in normalized.splitlines()
+            if re.sub(r"\s+", " ", line).strip()
+        ]
+
+    @staticmethod
+    def _dedupe_lines(lines: Any) -> list[str]:
+        deduped: list[str] = []
+        previous: str | None = None
+        for raw_line in lines:
+            line = str(raw_line).strip()
+            if not line or line == previous:
+                continue
+            deduped.append(line)
+            previous = line
+        return deduped
+
+    @staticmethod
+    def _is_linkedin_noise_line(line: str) -> bool:
+        lowered = line.casefold()
+        if re.search(r"\*]:|\[&|group-hover:|text-color-|font-|leading-\[", line):
+            return True
+        if line.endswith(" Graphic"):
+            return True
+        return any(
+            marker in lowered
+            for marker in (
+                "skip to main content",
+                "join now",
+                "sign in",
+                "join with email",
+                "already on linkedin",
+                "user agreement",
+                "privacy policy",
+                "cookie policy",
+                "view mutual connections",
+                "see your mutual connections",
+                "view michael’s full profile",
+                "view michael's full profile",
+                "report this",
+                "close menu",
+                "copy",
+                "facebook",
+                "top content",
+                "people",
+                "learning",
+                "jobs",
+                "games",
+                "contact info",
+                "email or phone",
+                "password",
+                "forgot password",
+                "show all activity",
+                "other similar profiles",
+                "message",
+                "view profile",
+                "public_profile__posts",
+            )
+        )
+
+    def _extract_linkedin_sections(self, lines: list[str]) -> dict[str, list[str]]:
+        headings = (
+            "Websites",
+            "Experience",
+            "Education",
+            "Publications",
+            "Patents",
+            "Honors & Awards",
+            "Languages",
+        )
+        indexed_headings = [
+            (index, line) for index, line in enumerate(lines) if line in headings
+        ]
+        sections: dict[str, list[str]] = {}
+        for position, (start_index, heading) in enumerate(indexed_headings):
+            end_index = (
+                indexed_headings[position + 1][0]
+                if position + 1 < len(indexed_headings)
+                else len(lines)
+            )
+            section_lines = self._dedupe_lines(
+                line
+                for line in lines[start_index + 1 : end_index]
+                if not self._is_linkedin_noise_line(line)
+            )
+            if not section_lines:
+                continue
+            if heading == "Websites":
+                trimmed_lines: list[str] = []
+                for line in section_lines:
+                    if "similar profiles" in line.casefold():
+                        break
+                    trimmed_lines.append(line)
+                section_lines = trimmed_lines
+            sections[heading] = section_lines
+        return sections
+
+    @staticmethod
+    def _format_linkedin_websites(lines: list[str]) -> list[str]:
+        allowed_labels = {
+            "blog",
+            "company website",
+            "other",
+            "personal website",
+            "portfolio",
+            "rss feed",
+            "website",
+        }
+        formatted: list[str] = []
+        index = 0
+        while index < len(lines):
+            current = lines[index]
+            if current.casefold().startswith("other similar profiles"):
+                break
+            if index + 1 < len(lines) and _DOMAIN_LINE_RE.fullmatch(lines[index + 1]):
+                if current.casefold() not in allowed_labels:
+                    break
+                formatted.append(f"{current}: {lines[index + 1]}")
+                index += 2
+                continue
+            if _DOMAIN_LINE_RE.fullmatch(current):
+                formatted.append(current)
+            index += 1
+        return formatted
+
+    @staticmethod
+    def _extract_linkedin_location(lines: list[str]) -> str | None:
+        for line in lines:
+            if re.fullmatch(r"[A-Za-z .'-]+,\s*[A-Za-z .'-]+", line):
+                return line
+        return None
+
+    @staticmethod
+    def _extract_linkedin_location_from_html(html: str) -> str | None:
+        for match in re.finditer(
+            r'"addressLocality"\s*:\s*"([^"]+)"',
+            html,
+            flags=re.IGNORECASE,
+        ):
+            candidate = re.sub(r"\s+", " ", unescape(match.group(1))).strip()
+            if candidate:
+                return candidate
+        return None
 
     def _validate_public_profile_url(self, candidate_url: str) -> str | None:
         resolution = self._resolve_public_profile_request_target(candidate_url)
@@ -2287,6 +2554,32 @@ class ResumeProfileProcessor:
         if not re.fullmatch(r"[A-Za-z0-9-]{1,39}", candidate):
             return None
         return candidate
+
+    @staticmethod
+    def _normalize_linkedin_profile_url(value: Any) -> str | None:
+        if not isinstance(value, str):
+            return None
+        candidate = value.strip()
+        if not candidate:
+            return None
+        if candidate.casefold().startswith("www."):
+            candidate = f"https://{candidate}"
+        elif not candidate.casefold().startswith(("http://", "https://")):
+            candidate = f"https://{candidate}"
+        try:
+            parsed = urlsplit(candidate)
+        except Exception:
+            return None
+        if "@" in parsed.netloc:
+            return None
+        host = (parsed.hostname or "").strip().casefold()
+        if host != "linkedin.com" and not host.endswith(".linkedin.com"):
+            return None
+        normalized_path = re.sub(r"/{2,}", "/", parsed.path or "").rstrip("/")
+        match = _LINKEDIN_PROFILE_RE.fullmatch(f"https://linkedin.com{normalized_path}")
+        if not match:
+            return None
+        return f"https://linkedin.com/in/{match.group(1)}"
 
     @staticmethod
     def _reset_unused_source_enrichments(

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -1664,7 +1664,7 @@ class TestCRMCog:
         assert "developer profile" in evidence_field.value
 
     def test_resume_preview_embed_includes_external_sources(self, crm_cog):
-        """Preview embeds should show external website/GitHub enrichment attempts."""
+        """Preview embeds should show external profile-source enrichment attempts."""
         embed, _ = crm_cog._build_resume_preview_embed(
             contact_id="contact-1",
             contact_name="Test User",
@@ -6064,10 +6064,7 @@ class TestCRMCog:
         followup_kwargs = mock_interaction.followup.send.call_args.kwargs
         assert "view" in followup_kwargs
         assert isinstance(followup_kwargs["view"], ResumeReprocessConfirmationView)
-        assert (
-            "include any fetchable website or GitHub profile sources"
-            in confirmation_message
-        )
+        assert "include any fetchable profile sources" in confirmation_message
         view = followup_kwargs["view"]
         assert view.contact_id == "contact123"
         assert view.contact_name == "Candidate User"
@@ -6079,7 +6076,7 @@ class TestCRMCog:
     async def test_reprocess_profile_without_resume_uses_crm_sources(
         self, crm_cog, mock_interaction
     ):
-        """Contacts without a resume can still reprocess from CRM website/GitHub sources."""
+        """Contacts without a resume can still reprocess from CRM profile sources."""
         mock_interaction.user.id = 101
 
         with (
@@ -6114,10 +6111,10 @@ class TestCRMCog:
 
         confirmation_message = mock_interaction.followup.send.call_args.args[0]
         followup_kwargs = mock_interaction.followup.send.call_args.kwargs
-        assert "CRM website or GitHub sources" in confirmation_message
+        assert "CRM profile sources" in confirmation_message
         view = followup_kwargs["view"]
         assert view.attachment_id == ""
-        assert view.filename == "CRM website/GitHub sources"
+        assert view.filename == "CRM profile sources"
         assert view.has_resume is False
 
     @pytest.mark.asyncio
@@ -6498,7 +6495,7 @@ class TestCRMCog:
         }
         assert (
             kwargs["status_message"]
-            == "🔄 Re-running profile extraction with confirmed website and GitHub content..."
+            == "🔄 Re-running profile extraction with confirmed profile-source content..."
         )
         assert all(
             child.disabled

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -261,7 +261,9 @@ def test_extract_profile_proposal_merges_and_serializes_social_links() -> None:
     ]
 
 
-def test_extract_profile_proposal_fetches_crm_website_and_github_sources() -> None:
+def test_extract_profile_proposal_fetches_crm_website_linkedin_and_github_sources() -> (
+    None
+):
     """Existing CRM website, LinkedIn, and GitHub profile text should be passed into extraction."""
     processor = ResumeProfileProcessor()
     processor.crm = Mock()
@@ -1125,6 +1127,41 @@ def test_request_profile_http_response_allows_blocked_browser_subrequests() -> N
     response.close.assert_called_once()
 
 
+def test_profile_source_html_looks_blocked_ignores_recaptcha_feature_flags() -> None:
+    """Normal pages should not be flagged by recaptcha-related config keys."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._profile_source_html_looks_blocked(
+            '<meta data-recaptcha-v3-integration-lix-value="control">'
+        )
+        is False
+    )
+    assert (
+        processor._profile_source_html_looks_blocked(
+            '<script>window.features = ["octocaptcha_origin_optimization"]</script>'
+        )
+        is False
+    )
+
+
+def test_profile_source_html_looks_blocked_detects_cloudflare_challenge() -> None:
+    """Cloudflare challenge pages should still be recognized as blocked."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._profile_source_html_looks_blocked(
+            """
+            <html><body>
+            <script>window._cf_chl_opt = {};</script>
+            <span>Enable JavaScript and cookies to continue</span>
+            </body></html>
+            """
+        )
+        is True
+    )
+
+
 def test_extract_rendered_profile_source_text_enforces_size_limit() -> None:
     """Rendered browser HTML should honor the same size cap as curl fetches."""
     processor = ResumeProfileProcessor()
@@ -1134,6 +1171,34 @@ def test_extract_rendered_profile_source_text_enforces_size_limit() -> None:
 
     with pytest.raises(ValueError, match="Rendered profile page exceeds size limit"):
         processor._extract_rendered_profile_source_text(oversized_html)
+
+
+def test_extract_rendered_profile_source_text_allows_larger_linkedin_pages() -> None:
+    """Rendered LinkedIn pages should use the larger LinkedIn size limit."""
+    processor = ResumeProfileProcessor()
+    oversized_html = (
+        "<html><body>" + ("a" * PROFILE_SOURCE_MAX_BYTES) + "</body></html>"
+    )
+
+    rendered = processor._extract_rendered_profile_source_text(
+        oversized_html,
+        navigation_url="https://www.linkedin.com/in/wumichaelm/",
+    )
+
+    assert rendered
+
+
+def test_is_linkedin_noise_line_uses_exact_ui_labels() -> None:
+    """Noise filtering should not drop legitimate profile content by substring."""
+    processor = ResumeProfileProcessor()
+
+    assert processor._is_linkedin_noise_line("Copy") is True
+    assert processor._is_linkedin_noise_line("Facebook") is True
+    assert processor._is_linkedin_noise_line("Copywriter") is False
+    assert processor._is_linkedin_noise_line("Facebook") is True
+    assert processor._is_linkedin_noise_line("Facebook / Meta") is False
+    assert processor._is_linkedin_noise_line("People Operations Lead") is False
+    assert processor._is_linkedin_noise_line("Jobs to Be Done Researcher") is False
 
 
 def test_extract_profile_proposal_reruns_with_confirmed_personal_website() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -826,6 +826,51 @@ def test_inspect_profile_source_fetch_uses_direct_browser_on_initial_block() -> 
     )
 
 
+def test_inspect_profile_source_fetch_raises_non_retryable_direct_browser_error() -> (
+    None
+):
+    """Non-retryable direct browser failures should stop candidate iteration immediately."""
+    processor = ResumeProfileProcessor()
+    processor._fetch_external_profile_source_response = Mock(
+        side_effect=[
+            ValueError("Profile fetch hit a scraping block; reset session"),
+            ProfileSourceHttpResponse(
+                final_url="https://candidate-two.example.com",
+                status_code=200,
+                headers={"content-type": "text/html"},
+                body=b"<html><body>candidate two</body></html>",
+            ),
+        ]
+    )
+    processor._fetch_external_profile_source_text_with_browser_direct = Mock(
+        side_effect=ValueError(
+            "JavaScript profile fetch failed: Profile URL is invalid"
+        )
+    )
+    processor._iter_profile_source_fetch_urls = Mock(
+        return_value=iter(
+            [
+                "https://candidate-one.example.com",
+                "https://candidate-two.example.com",
+            ]
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="JavaScript profile fetch failed: Profile URL is invalid",
+    ):
+        processor.inspect_profile_source_fetch(
+            "https://example.com/",
+            allow_javascript_fallback=True,
+        )
+
+    processor._fetch_external_profile_source_response.assert_called_once_with(
+        "https://candidate-one.example.com",
+        session=ANY,
+    )
+
+
 def test_fetch_external_profile_source_text_with_browser_direct_validates_routed_requests() -> (
     None
 ):
@@ -1513,6 +1558,34 @@ def test_extract_text_from_html_reads_meta_description_regardless_of_order() -> 
     assert "Body copy" in rendered
 
 
+def test_extract_text_from_html_filters_template_and_jsonish_noise() -> None:
+    """Generic HTML extraction should drop template and hydration-style junk lines."""
+    processor = ResumeProfileProcessor()
+
+    rendered = processor._extract_text_from_html(
+        """
+        <html>
+          <head><title>Profile</title></head>
+          <body>
+            <main>
+              <div>Michael Wu</div>
+              <div>Software Engineer</div>
+              <div>%7B%22foo%22%3A%22bar%22%7D</div>
+              <div>{"props":{"page":"profile"}}</div>
+              <template>{"hydration":true}</template>
+            </main>
+          </body>
+        </html>
+        """
+    )
+
+    assert "Michael Wu" in rendered
+    assert "Software Engineer" in rendered
+    assert "%7B%22foo%22%3A%22bar%22%7D" not in rendered
+    assert '{"props":{"page":"profile"}}' not in rendered
+    assert '{"hydration":true}' not in rendered
+
+
 def test_profile_source_max_bytes_for_linkedin_pages_is_larger() -> None:
     """LinkedIn public profiles should be allowed a larger response budget."""
     processor = ResumeProfileProcessor()
@@ -1618,6 +1691,60 @@ def test_is_linkedin_public_profile_html_requires_profile_canonical_url() -> Non
     )
 
 
+def test_is_linkedin_public_profile_html_handles_swapped_attribute_order() -> None:
+    """LinkedIn profile detection should not depend on HTML attribute order."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._is_linkedin_public_profile_html(
+            """
+            <html>
+              <head>
+                <meta content="public_profile_v3_desktop" name="pageKey">
+                <link href="https://www.linkedin.com/in/wumichaelm/" rel="canonical">
+                <title>Michael Wu - Software Engineer | LinkedIn</title>
+              </head>
+            </html>
+            """
+        )
+        is True
+    )
+
+
+def test_extract_text_from_html_falls_back_when_linkedin_sections_are_localized() -> (
+    None
+):
+    """Localized LinkedIn headings should keep generic body text instead of header-only compaction."""
+    processor = ResumeProfileProcessor()
+
+    rendered = processor._extract_text_from_html(
+        """
+        <html>
+          <head>
+            <meta name="pageKey" content="public_profile_v3_desktop">
+            <link rel="canonical" href="https://www.linkedin.com/in/wumichaelm/">
+            <title>Michael Wu - Software Engineer | LinkedIn</title>
+          </head>
+          <body>
+            <main>
+              <div>Michael Wu</div>
+              <div>Software Engineer</div>
+              <div>Tokyo, Japan</div>
+              <section>
+                <h2>経験</h2>
+                <div>Stripe</div>
+                <div>Implemented cost pipelines for card transactions in Japan.</div>
+              </section>
+            </main>
+          </body>
+        </html>
+        """
+    )
+
+    assert "Implemented cost pipelines for card transactions in Japan." in rendered
+    assert "Name: Michael Wu" not in rendered
+
+
 def test_format_linkedin_websites_keeps_parsing_after_unknown_label() -> None:
     """Unexpected LinkedIn website labels should not suppress later website entries."""
     processor = ResumeProfileProcessor()
@@ -1662,6 +1789,29 @@ def test_extract_linkedin_location_uses_header_lines_only() -> None:
             ]
         )
         == "San Francisco Bay Area"
+    )
+    assert (
+        processor._extract_linkedin_location(
+            [
+                "Michael Wu",
+                "Founder, Acme",
+                "Tokyo, Japan",
+                "500+ connections",
+                "Experience",
+            ]
+        )
+        == "Tokyo, Japan"
+    )
+    assert (
+        processor._extract_linkedin_location(
+            [
+                "Michael Wu",
+                "Founder, Acme",
+                "500+ connections",
+                "Experience",
+            ]
+        )
+        is None
     )
 
 

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -14,6 +14,7 @@ from curl_cffi import CurlOpt
 
 from five08.clients.espo import EspoAPIError
 from five08.resume_profile_processor import (
+    PROFILE_SOURCE_BROWSER_POST_NAV_WAIT_MS,
     PROFILE_SOURCE_BROWSER_RESOURCE_MAX_BYTES,
     PROFILE_SOURCE_MAX_BYTES,
     ProfileSourceHttpResponse,
@@ -725,6 +726,24 @@ def test_build_initial_external_source_candidates_preserves_www_host_from_crm() 
     assert candidates[0].source_key == "website:example.com/about"
 
 
+def test_build_initial_external_source_candidates_skips_duplicate_linkedin_website() -> (
+    None
+):
+    """LinkedIn URLs present in website links should not be added twice."""
+    processor = ResumeProfileProcessor()
+
+    candidates = processor._build_initial_external_source_candidates(
+        contact={
+            "cWebsiteLink": ["https://www.linkedin.com/in/octocat/"],
+            "cLinkedIn": "https://linkedin.com/in/octocat",
+        },
+    )
+
+    assert [(candidate.label, candidate.url) for candidate in candidates] == [
+        ("Personal Website", "https://www.linkedin.com/in/octocat"),
+    ]
+
+
 def test_fetch_external_profile_sources_retries_alternate_candidate_after_failure() -> (
     None
 ):
@@ -874,12 +893,14 @@ def test_inspect_profile_source_fetch_raises_non_retryable_direct_browser_error(
 def test_fetch_external_profile_source_text_with_browser_direct_validates_routed_requests() -> (
     None
 ):
-    """Direct browser fallback should still abort non-public requests via route validation."""
+    """Direct browser fallback should proxy requests through the pinned fetch path."""
     processor = ResumeProfileProcessor()
     page = Mock()
     page.url = "https://beacons.ai/michaelmwu"
     page.content.return_value = "<html><body>Michael Wu</body></html>"
     route_handler: Any = None
+    session = Mock()
+    session.close = Mock()
 
     def capture_route(pattern: str, handler: object) -> None:
         nonlocal route_handler
@@ -914,9 +935,24 @@ def test_fetch_external_profile_source_text_with_browser_direct_validates_routed
         ),
         patch.object(
             processor,
+            "_create_profile_source_http_session",
+            return_value=session,
+        ),
+        patch.object(
+            processor,
             "_validate_browser_profile_request_url",
             side_effect=validate,
         ) as validate_url,
+        patch.object(
+            processor,
+            "_fetch_browser_profile_request_response",
+            return_value=ProfileSourceHttpResponse(
+                final_url="https://beacons.ai/assets/app.js",
+                status_code=200,
+                headers={"content-type": "application/javascript"},
+                body=b"console.log('ok')",
+            ),
+        ) as fetch_route_response,
         patch.object(
             processor,
             "_extract_browser_rendered_profile_source_text",
@@ -928,6 +964,9 @@ def test_fetch_external_profile_source_text_with_browser_direct_validates_routed
                 "https://michaelmwu.com/"
             )
         )
+        page.wait_for_timeout.assert_called_once_with(
+            PROFILE_SOURCE_BROWSER_POST_NAV_WAIT_MS
+        )
 
         assert route_handler is not None
 
@@ -938,13 +977,25 @@ def test_fetch_external_profile_source_text_with_browser_direct_validates_routed
         blocked_route.continue_.assert_not_called()
 
         allowed_route = Mock()
-        allowed_route.request = SimpleNamespace(url="https://beacons.ai/assets/app.js")
+        allowed_route.request = SimpleNamespace(
+            url="https://beacons.ai/assets/app.js",
+            method="GET",
+        )
         route_handler(allowed_route)
-        allowed_route.continue_.assert_called_once_with()
+        allowed_route.fulfill.assert_called_once_with(
+            status=200,
+            headers={"content-type": "application/javascript"},
+            body=b"console.log('ok')",
+        )
         allowed_route.abort.assert_not_called()
 
     assert final_url == "https://beacons.ai/michaelmwu"
     assert text == "Michael Wu"
+    fetch_route_response.assert_called_once_with(
+        allowed_route.request,
+        session=session,
+    )
+    session.close.assert_called_once_with()
     assert validate_url.call_args_list == [
         call("http://127.0.0.1/internal"),
         call("https://beacons.ai/assets/app.js"),
@@ -1341,6 +1392,49 @@ def test_extract_rendered_profile_source_text_allows_larger_linkedin_pages() -> 
     )
 
     assert rendered
+
+
+def test_fetch_external_profile_source_text_with_browser_once_uses_final_url_for_size_limit() -> (
+    None
+):
+    """Browser fallback should apply rendered size limits using the redirected destination URL."""
+    processor = ResumeProfileProcessor()
+    session = Mock()
+    context = Mock()
+    page = Mock()
+    page.url = "https://www.linkedin.com/in/wumichaelm/"
+    page.content.return_value = "<html><body>LinkedIn content</body></html>"
+    context.new_page.return_value = page
+    initial_response = ProfileSourceHttpResponse(
+        final_url="https://example.com/about",
+        status_code=200,
+        headers={"content-type": "text/html"},
+        body=b"<html><body>Initial</body></html>",
+    )
+
+    with (
+        patch.object(processor, "_seed_browser_profile_session"),
+        patch.object(
+            processor,
+            "_validate_browser_profile_navigation_url",
+            return_value=None,
+        ),
+        patch.object(
+            processor,
+            "_extract_browser_rendered_profile_source_text",
+            return_value="Rendered text",
+        ) as extract_rendered,
+    ):
+        rendered = processor._fetch_external_profile_source_text_with_browser_once(
+            initial_response,
+            session=session,
+            launch_context=Mock(return_value=context),
+        )
+
+    assert rendered == "Rendered text"
+    assert extract_rendered.call_args.kwargs["navigation_url"] == (
+        "https://www.linkedin.com/in/wumichaelm/"
+    )
 
 
 def test_is_linkedin_noise_line_uses_exact_ui_labels() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -2,7 +2,9 @@
 
 import ipaddress
 import json
+import sys
 from datetime import datetime
+from typing import Any
 from types import SimpleNamespace
 
 import pytest
@@ -822,6 +824,86 @@ def test_inspect_profile_source_fetch_uses_direct_browser_on_initial_block() -> 
     processor._fetch_external_profile_source_text_with_browser_direct.assert_called_once_with(
         "https://michaelmwu.com/"
     )
+
+
+def test_fetch_external_profile_source_text_with_browser_direct_validates_routed_requests() -> (
+    None
+):
+    """Direct browser fallback should still abort non-public requests via route validation."""
+    processor = ResumeProfileProcessor()
+    page = Mock()
+    page.url = "https://beacons.ai/michaelmwu"
+    page.content.return_value = "<html><body>Michael Wu</body></html>"
+    route_handler: Any = None
+
+    def capture_route(pattern: str, handler: object) -> None:
+        nonlocal route_handler
+        assert pattern == "**/*"
+        route_handler = handler
+
+    page.route.side_effect = capture_route
+    context = Mock()
+    context.new_page.return_value = page
+
+    def validate(url: str) -> str | None:
+        allowed_urls = {
+            "https://michaelmwu.com/",
+            "https://beacons.ai/michaelmwu",
+            "https://beacons.ai/assets/app.js",
+        }
+        return None if url in allowed_urls else "blocked"
+
+    with (
+        patch.dict(
+            sys.modules,
+            {
+                "cloakbrowser": SimpleNamespace(
+                    launch_context=Mock(return_value=context)
+                )
+            },
+        ),
+        patch.object(
+            processor,
+            "_validate_browser_profile_navigation_url",
+            return_value=None,
+        ),
+        patch.object(
+            processor,
+            "_validate_browser_profile_request_url",
+            side_effect=validate,
+        ) as validate_url,
+        patch.object(
+            processor,
+            "_extract_browser_rendered_profile_source_text",
+            return_value="Michael Wu",
+        ),
+    ):
+        final_url, text = (
+            processor._fetch_external_profile_source_text_with_browser_direct(
+                "https://michaelmwu.com/"
+            )
+        )
+
+        assert route_handler is not None
+
+        blocked_route = Mock()
+        blocked_route.request = SimpleNamespace(url="http://127.0.0.1/internal")
+        route_handler(blocked_route)
+        blocked_route.abort.assert_called_once_with()
+        blocked_route.continue_.assert_not_called()
+
+        allowed_route = Mock()
+        allowed_route.request = SimpleNamespace(url="https://beacons.ai/assets/app.js")
+        route_handler(allowed_route)
+        allowed_route.continue_.assert_called_once_with()
+        allowed_route.abort.assert_not_called()
+
+    assert final_url == "https://beacons.ai/michaelmwu"
+    assert text == "Michael Wu"
+    assert validate_url.call_args_list == [
+        call("http://127.0.0.1/internal"),
+        call("https://beacons.ai/assets/app.js"),
+    ]
 
 
 def test_fetch_external_profile_source_text_skips_browser_for_github_sources() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -796,6 +796,34 @@ def test_fetch_external_profile_source_text_uses_browser_for_sparse_personal_sit
     assert browser_call.args[0].final_url == "https://example.com/about"
 
 
+def test_inspect_profile_source_fetch_uses_direct_browser_on_initial_block() -> None:
+    """Blocked personal websites should still get a direct browser fallback attempt."""
+    processor = ResumeProfileProcessor()
+    processor._fetch_external_profile_source_response = Mock(
+        side_effect=ValueError("Profile fetch hit a scraping block; reset session")
+    )
+    processor._fetch_external_profile_source_text_with_browser_direct = Mock(
+        return_value=(
+            "https://beacons.ai/michaelmwu",
+            "Michael Wu\nMichael in Asia\nDEM Flyers",
+        )
+    )
+
+    diagnostics = processor.inspect_profile_source_fetch(
+        "https://michaelmwu.com/",
+        allow_javascript_fallback=True,
+    )
+
+    assert diagnostics.final_url == "https://beacons.ai/michaelmwu"
+    assert diagnostics.selected_text == "Michael Wu\nMichael in Asia\nDEM Flyers"
+    assert diagnostics.browser_attempted is True
+    assert diagnostics.browser_used is True
+    assert diagnostics.curl_text is None
+    processor._fetch_external_profile_source_text_with_browser_direct.assert_called_once_with(
+        "https://michaelmwu.com/"
+    )
+
+
 def test_fetch_external_profile_source_text_skips_browser_for_github_sources() -> None:
     """Non-website profile sources should stay on the curl path even if sparse."""
     processor = ResumeProfileProcessor()

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -262,7 +262,7 @@ def test_extract_profile_proposal_merges_and_serializes_social_links() -> None:
 
 
 def test_extract_profile_proposal_fetches_crm_website_and_github_sources() -> None:
-    """Existing CRM website and GitHub profile text should be passed into extraction."""
+    """Existing CRM website, LinkedIn, and GitHub profile text should be passed into extraction."""
     processor = ResumeProfileProcessor()
     processor.crm = Mock()
     processor.extractor = Mock()
@@ -272,6 +272,7 @@ def test_extract_profile_proposal_fetches_crm_website_and_github_sources() -> No
     processor._fetch_external_profile_source_text = Mock(
         side_effect=lambda url, **_: {
             "https://portfolio.example.com": "Portfolio content",
+            "https://linkedin.com/in/octocat": "LinkedIn profile content",
             "https://github.com/octocat": "GitHub profile content",
         }[url]
     )
@@ -282,6 +283,7 @@ def test_extract_profile_proposal_fetches_crm_website_and_github_sources() -> No
     processor.crm.get_contact.return_value = {
         "emailAddress": "member@example.com",
         "cWebsiteLink": ["https://portfolio.example.com"],
+        "cLinkedIn": "https://www.linkedin.com/in/octocat/",
         "cGitHubUsername": "octocat",
     }
     processor.crm.download_attachment.return_value = b"resume-bytes"
@@ -325,9 +327,23 @@ def test_extract_profile_proposal_fetches_crm_website_and_github_sources() -> No
             "Content:\n"
             "GitHub profile content"
         ),
+        "linkedin_profile": (
+            "Source: LinkedIn Profile\n"
+            "URL: https://linkedin.com/in/octocat\n"
+            "Content:\n"
+            "LinkedIn profile content"
+        ),
     }
-    assert [item.status for item in result.source_enrichments] == ["used", "used"]
-    assert [item.origin for item in result.source_enrichments] == ["crm", "crm"]
+    assert [item.status for item in result.source_enrichments] == [
+        "used",
+        "used",
+        "used",
+    ]
+    assert [item.origin for item in result.source_enrichments] == [
+        "crm",
+        "crm",
+        "crm",
+    ]
 
 
 def test_extract_profile_proposal_reruns_with_inferred_github_only() -> None:
@@ -1321,6 +1337,88 @@ def test_extract_text_from_html_reads_meta_description_regardless_of_order() -> 
     assert "Title: Portfolio" in rendered
     assert "Description: Builder of useful things" in rendered
     assert "Body copy" in rendered
+
+
+def test_profile_source_max_bytes_for_linkedin_pages_is_larger() -> None:
+    """LinkedIn public profiles should be allowed a larger response budget."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._profile_source_max_bytes_for_url(
+            "https://www.linkedin.com/in/wumichaelm/"
+        )
+        > PROFILE_SOURCE_MAX_BYTES
+    )
+    assert (
+        processor._profile_source_max_bytes_for_url("https://example.com/about")
+        == PROFILE_SOURCE_MAX_BYTES
+    )
+
+
+def test_extract_text_from_html_compacts_linkedin_public_profile_sections() -> None:
+    """LinkedIn public profile HTML should be reduced to the useful header and sections."""
+    processor = ResumeProfileProcessor()
+
+    rendered = processor._extract_text_from_html(
+        """
+        <html>
+          <head>
+            <meta name="pageKey" content="public_profile_v3_desktop">
+            <title>Michael Wu - Software Engineer, Fractional CTO, Founder, Investor, World Traveler based in Taipei / Tokyo | LinkedIn</title>
+          </head>
+          <body>
+            <main>
+              <div>Michael Wu</div>
+              <div>Software Engineer, Fractional CTO, Founder, Investor, World Traveler based in Taipei / Tokyo</div>
+              <div>Tokyo, Japan</div>
+              <section>
+                <h2>Websites</h2>
+                <div>Blog</div>
+                <div>michaelinasia.com</div>
+                <div>Blog</div>
+                <div>demflyers.com</div>
+              </section>
+              <section>
+                <h2>Experience</h2>
+                <div>Senior Software Engineer</div>
+                <div>Stripe</div>
+                <div>Feb 2020 - Dec 2022 2 years 11 months</div>
+                <div>Tokyo, Japan</div>
+                <div>Implemented cost pipelines for card transactions in Japan.</div>
+              </section>
+              <section>
+                <h2>Education</h2>
+                <div>Stanford University</div>
+                <div>Master of Science (MS) Electrical Engineering</div>
+              </section>
+              <section>
+                <h2>Languages</h2>
+                <div>Japanese</div>
+                <div>Limited working proficiency</div>
+              </section>
+            </main>
+          </body>
+        </html>
+        """
+    )
+
+    assert "Name: Michael Wu" in rendered
+    assert (
+        "Headline: Software Engineer, Fractional CTO, Founder, Investor, "
+        "World Traveler based in Taipei / Tokyo" in rendered
+    )
+    assert "Location: Tokyo, Japan" in rendered
+    assert "Websites:" in rendered
+    assert "- Blog: michaelinasia.com" in rendered
+    assert "- Blog: demflyers.com" in rendered
+    assert "Experience:" in rendered
+    assert "Senior Software Engineer" in rendered
+    assert "Stripe" in rendered
+    assert "Implemented cost pipelines for card transactions in Japan." in rendered
+    assert "Education:" in rendered
+    assert "Stanford University" in rendered
+    assert "Languages:" in rendered
+    assert "Japanese" in rendered
 
 
 def test_fetch_external_profile_source_text_pins_resolved_public_ips() -> None:

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -1223,7 +1223,6 @@ def test_is_linkedin_noise_line_uses_exact_ui_labels() -> None:
     assert processor._is_linkedin_noise_line("Copy") is True
     assert processor._is_linkedin_noise_line("Facebook") is True
     assert processor._is_linkedin_noise_line("Copywriter") is False
-    assert processor._is_linkedin_noise_line("Facebook") is True
     assert processor._is_linkedin_noise_line("Facebook / Meta") is False
     assert processor._is_linkedin_noise_line("People Operations Lead") is False
     assert processor._is_linkedin_noise_line("Jobs to Be Done Researcher") is False
@@ -1457,6 +1456,7 @@ def test_extract_text_from_html_compacts_linkedin_public_profile_sections() -> N
         <html>
           <head>
             <meta name="pageKey" content="public_profile_v3_desktop">
+            <link rel="canonical" href="https://www.linkedin.com/in/wumichaelm/">
             <title>Michael Wu - Software Engineer, Fractional CTO, Founder, Investor, World Traveler based in Taipei / Tokyo | LinkedIn</title>
           </head>
           <body>
@@ -1512,6 +1512,75 @@ def test_extract_text_from_html_compacts_linkedin_public_profile_sections() -> N
     assert "Stanford University" in rendered
     assert "Languages:" in rendered
     assert "Japanese" in rendered
+
+
+def test_is_linkedin_public_profile_html_requires_profile_canonical_url() -> None:
+    """LinkedIn profile compaction should ignore pages that merely link to a profile."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._is_linkedin_public_profile_html(
+            """
+            <html>
+              <head>
+                <meta name="pageKey" content="public_profile_v3_desktop">
+                <title>Acme Corp - Hiring | LinkedIn</title>
+              </head>
+              <body>
+                <a href="https://www.linkedin.com/in/example-person/">Employee profile</a>
+              </body>
+            </html>
+            """
+        )
+        is False
+    )
+
+
+def test_format_linkedin_websites_keeps_parsing_after_unknown_label() -> None:
+    """Unexpected LinkedIn website labels should not suppress later website entries."""
+    processor = ResumeProfileProcessor()
+
+    assert processor._format_linkedin_websites(
+        [
+            "Newsletter",
+            "michaelinasia.com",
+            "Blog",
+            "demflyers.com",
+        ]
+    ) == [
+        "michaelinasia.com",
+        "Blog: demflyers.com",
+    ]
+
+
+def test_extract_linkedin_location_uses_header_lines_only() -> None:
+    """Location parsing should stay within the profile header and support Bay Area labels."""
+    processor = ResumeProfileProcessor()
+
+    assert (
+        processor._extract_linkedin_location(
+            [
+                "Michael Wu",
+                "Software Engineer",
+                "500+ connections",
+                "Experience",
+                "Master of Science, Computer Science",
+            ]
+        )
+        is None
+    )
+    assert (
+        processor._extract_linkedin_location(
+            [
+                "Michael Wu",
+                "Software Engineer",
+                "San Francisco Bay Area",
+                "500+ connections",
+                "Experience",
+            ]
+        )
+        == "San Francisco Bay Area"
+    )
 
 
 def test_fetch_external_profile_source_text_pins_resolved_public_ips() -> None:


### PR DESCRIPTION
## Description
The resume profile processor now fetches `cLinkedIn` as an external profile source and allows larger LinkedIn public-profile responses through the fetch guard.
It compacts LinkedIn public-profile HTML into a cleaner source blob with header, websites, experience, education, publications, patents, honors, and languages sections so personal sites like `michaelinasia.com` and `demflyers.com` can be suggested reliably.
The change also adds unit coverage for LinkedIn source ingestion, the larger LinkedIn size limit, and the sectioned HTML extraction path.

## Related Issue
N/A

## How Has This Been Tested?
`uv run pytest tests/unit/test_resume_profile_processor.py -q`