### PR TITLE
chore: switch local dev apps to host runtime

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ MINIO_HOST_BIND=127.0.0.1
 
 # API (optional defaults; API_SHARED_SECRET required to accept ingest calls)
 WEBHOOK_INGEST_HOST=0.0.0.0
+# Host-run API processes use this port directly. docker-compose.yml pins the
+# API container to 8090 internally and varies only the published host port.
 WEBHOOK_INGEST_PORT=8090
 WEBHOOK_INGEST_HOST_BIND=127.0.0.1
 # Optional: expose ingest API on a fixed host port for local debugging.

--- a/.env.example
+++ b/.env.example
@@ -5,15 +5,15 @@ SENTRY_DSN=
 SENTRY_SEND_DEFAULT_PII=false
 SENTRY_DEBUG=false
 
-# Queue transport (optional defaults)
-REDIS_URL=redis://redis:6379/0
+# Queue transport (optional defaults for host-run app services)
+REDIS_URL=redis://127.0.0.1:6379/0
 REDIS_QUEUE_NAME=jobs.default
 REDIS_KEY_PREFIX=jobs
 REDIS_SOCKET_CONNECT_TIMEOUT=5.0
 REDIS_SOCKET_TIMEOUT=5.0
 
-# Postgres (required in production; optional defaults for local compose)
-POSTGRES_URL=postgresql://postgres:postgres@postgres:5432/workflows
+# Postgres (required in production; optional defaults for host-run app services)
+POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/workflows
 POSTGRES_DB=workflows
 POSTGRES_USER=postgres
 # Change in production
@@ -29,8 +29,8 @@ JOB_RETRY_MAX_SECONDS=300
 JOB_TIMEOUT_SECONDS=600
 JOB_RESULT_TTL_SECONDS=3600
 
-# Internal transfer storage (optional defaults for local compose)
-MINIO_ENDPOINT=http://minio:9000
+# Internal transfer storage (optional defaults for host-run app services)
+MINIO_ENDPOINT=http://127.0.0.1:9000
 MINIO_ROOT_USER=internal
 # Change in production
 MINIO_ROOT_PASSWORD=change-me
@@ -84,8 +84,8 @@ DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=true
 
 # Worker / consumer (optional defaults)
 WORKER_NAME=worker
-WORKER_API_BASE_URL=http://api:8090
-DISCORD_BOT_INTERNAL_BASE_URL=http://discord_bot:3000
+WORKER_API_BASE_URL=http://127.0.0.1:8090
+DISCORD_BOT_INTERNAL_BASE_URL=http://127.0.0.1:3000
 WORKER_QUEUE_NAMES=jobs.default
 WORKER_BURST=false
 MAX_ATTACHMENTS_PER_CONTACT=3
@@ -112,7 +112,7 @@ DOCUSEAL_API_KEY=
 # Discord bot (required for bot runtime)
 DISCORD_BOT_TOKEN=your_bot_token_here
 HEALTHCHECK_PORT=3000
-BACKEND_API_BASE_URL=http://api:8090
+BACKEND_API_BASE_URL=http://127.0.0.1:8090
 AUDIT_API_BASE_URL=
 AUDIT_API_TIMEOUT_SECONDS=2.0
 # Worker mailbox resume intake (required if email intake is enabled)

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ REDIS_QUEUE_NAME=jobs.default
 REDIS_KEY_PREFIX=jobs
 REDIS_SOCKET_CONNECT_TIMEOUT=5.0
 REDIS_SOCKET_TIMEOUT=5.0
+REDIS_HOST_BIND=127.0.0.1
+# Optional: expose Redis on a fixed host port for local debugging.
+# `./scripts/dev.sh` computes a deterministic per-worktree port when unset.
+# `./scripts/docker-compose.sh` computes a deterministic per-worktree port when unset.
+# REDIS_HOST_PORT=6379
 
 # Postgres (required in production; optional defaults for host-run app services)
 POSTGRES_URL=postgresql://postgres:postgres@127.0.0.1:5432/workflows
@@ -20,7 +25,8 @@ POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_HOST_BIND=127.0.0.1
 # Optional: expose postgres on a fixed host port for local debugging.
-# Leave unset to let ./scripts/docker-compose.sh compute a deterministic port.
+# `./scripts/dev.sh` computes a deterministic per-worktree port when unset.
+# `./scripts/docker-compose.sh` computes a deterministic per-worktree port when unset.
 # POSTGRES_HOST_PORT=5432
 
 # Job retry behavior (optional)
@@ -38,7 +44,8 @@ MINIO_ROOT_PASSWORD=change-me
 MINIO_INTERNAL_BUCKET=internal-transfers
 MINIO_HOST_BIND=127.0.0.1
 # Optional: expose MinIO on fixed host ports for local debugging.
-# Leave unset to let ./scripts/docker-compose.sh compute deterministic ports.
+# `./scripts/dev.sh` computes deterministic per-worktree ports when unset.
+# `./scripts/docker-compose.sh` computes deterministic per-worktree ports when unset.
 # MINIO_API_HOST_PORT=9000
 # MINIO_CONSOLE_HOST_PORT=9001
 
@@ -49,6 +56,8 @@ WEBHOOK_INGEST_HOST_BIND=127.0.0.1
 # Optional: expose ingest API on a fixed host port for local debugging.
 # Leave unset to let ./scripts/docker-compose.sh compute a deterministic port.
 # WEBHOOK_INGEST_HOST_PORT=8090
+# Host-run API processes launched through `./scripts/dev.sh api` override
+# `WEBHOOK_INGEST_PORT` with a deterministic per-worktree port automatically.
 # Required: ingest requests are rejected when unset
 API_SHARED_SECRET=
 # Authentik admin API (required for /create-sso-user)
@@ -119,6 +128,8 @@ DOCUSEAL_API_KEY=
 # Discord bot (required for bot runtime)
 DISCORD_BOT_TOKEN=your_bot_token_here
 HEALTHCHECK_PORT=3000
+# Host-run bot processes launched through `./scripts/dev.sh discord-bot` override
+# `HEALTHCHECK_PORT` with a deterministic per-worktree port automatically.
 BACKEND_API_BASE_URL=http://127.0.0.1:8090
 AUDIT_API_BASE_URL=
 AUDIT_API_TIMEOUT_SECONDS=2.0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,7 +60,7 @@ uv run --package api backend-api
 uv run --package worker worker-consumer
 ```
 
-Run stack with Compose:
+Run the local dev stack:
 
 ```bash
 ./scripts/dev.sh infra

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ This repo contains multiple services:
 - `apps/discord_bot`: Discord gateway and bot commands/cogs
 - `apps/api`: webhook ingest API and dashboard auth routes
 - `apps/worker`: queue consumer and processing jobs
-- `docker-compose.yml`: stack orchestration with Redis, Postgres, and MinIO
+- `docker-compose.yml`: full container stack for Coolify/local parity; day-to-day dev should prefer host-run app services with Docker-managed infra
 
 4. Human audit logging
 - Human-triggered CRM actions from Discord should write to the worker audit ingest endpoint.
@@ -61,6 +61,15 @@ uv run --package worker worker-consumer
 ```
 
 Run stack with Compose:
+
+```bash
+./scripts/dev-up.sh
+uv run --package discord_bot discord-bot
+uv run --package api backend-api
+uv run --package worker worker-consumer
+```
+
+Full container parity remains available with:
 
 ```bash
 docker compose up --build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,15 @@ uv run --package worker worker-consumer
 Run stack with Compose:
 
 ```bash
-./scripts/dev-up.sh
-uv run --package discord_bot discord-bot
-uv run --package api backend-api
-uv run --package worker worker-consumer
+./scripts/dev.sh infra
+./scripts/dev.sh discord-bot
+./scripts/dev.sh api
+./scripts/dev.sh worker
+./scripts/dev.sh all
 ```
 
-Full container parity remains available with:
+`./scripts/dev.sh` is the primary local-dev entrypoint. Full container parity
+remains available with:
 
 ```bash
 ./scripts/docker-compose.sh up --build

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,9 @@ Show, export, or stop the local dev environment:
 ./scripts/dev.sh down
 ```
 
+`./scripts/dev.sh env` emits shell-safe exports for the current worktree and
+avoids printing the resolved Postgres password directly.
+
 4. Run services on the host:
 
 ```bash

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -36,7 +36,27 @@ The backend API process runs Alembic migrations on startup (`apps/worker/src/fiv
 3. Start local infrastructure:
 
 ```bash
-./scripts/dev-up.sh
+./scripts/dev.sh infra
+./scripts/dev.sh api
+./scripts/dev.sh worker
+./scripts/dev.sh discord-bot
+```
+
+`infra` brings up only the Docker infra. Use the host-service subcommands to run
+the app processes with per-worktree ports and derived localhost URLs.
+
+To launch infra plus all host-run services together with prefixed logs:
+
+```bash
+./scripts/dev.sh all
+```
+
+Show, export, or stop the local dev environment:
+
+```bash
+./scripts/dev.sh ports
+./scripts/dev.sh env
+./scripts/dev.sh down
 ```
 
 4. Run services on the host:
@@ -57,8 +77,10 @@ uv run --package five08 crmctl repl
 
 ## Docker Compose Workflow
 
-For day-to-day development, prefer `./scripts/dev-up.sh` plus host-run app
-services. Use full Docker Compose when you need container parity, including
+For day-to-day development, prefer `./scripts/dev.sh` plus host-run app
+services. That entrypoint pins standard localhost ports so the app defaults
+work without extra overrides. Use the Compose wrapper when you need
+deterministic per-worktree ports or full container parity, including
 Coolify-style runs.
 
 Start full stack (discord_bot + api + worker + redis + postgres + minio):

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,7 +33,13 @@ cp .env.example .env
 
 The backend API process runs Alembic migrations on startup (`apps/worker/src/five08/worker/db_migrations.py`) so the `jobs` table is created or upgraded before requests are accepted.
 
-3. Run services:
+3. Start local infrastructure:
+
+```bash
+./scripts/dev-up.sh
+```
+
+4. Run services on the host:
 
 ```bash
 # bot
@@ -50,6 +56,10 @@ uv run --package five08 crmctl repl
 ```
 
 ## Docker Compose Workflow
+
+For day-to-day development, prefer `./scripts/dev-up.sh` plus host-run app
+services. Use full Docker Compose when you need container parity, including
+Coolify-style runs.
 
 Start full stack (discord_bot + api + worker + redis + postgres + minio):
 
@@ -146,7 +156,7 @@ contact.save()
 
 Use `.env.example` as source of truth. Key categories:
 
-- Shared queue/runtime: `REDIS_URL`, `REDIS_QUEUE_NAME`, `POSTGRES_URL`, `JOB_MAX_ATTEMPTS`, `JOB_RETRY_BASE_SECONDS`, `JOB_RETRY_MAX_SECONDS`, `LOG_LEVEL`, webhook settings
+- Shared queue/runtime: `REDIS_URL`, `REDIS_QUEUE_NAME`, `POSTGRES_URL`, `JOB_MAX_ATTEMPTS`, `JOB_RETRY_BASE_SECONDS`, `JOB_RETRY_MAX_SECONDS`, `LOG_LEVEL`, webhook settings. Local defaults target host-run services; `docker-compose.yml` injects Docker-network URLs for containerized runs.
 - Bot credentials/integrations: Discord, email, Espo, Kimai
 - Discord CRM audit writer: `AUDIT_API_BASE_URL`, `AUDIT_API_TIMEOUT_SECONDS` (plus shared `API_SHARED_SECRET`)
 - Worker controls: `WORKER_NAME`, `WORKER_QUEUE_NAMES`, `WORKER_BURST`

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -78,10 +78,9 @@ uv run --package five08 crmctl repl
 ## Docker Compose Workflow
 
 For day-to-day development, prefer `./scripts/dev.sh` plus host-run app
-services. That entrypoint pins standard localhost ports so the app defaults
-work without extra overrides. Use the Compose wrapper when you need
-deterministic per-worktree ports or full container parity, including
-Coolify-style runs.
+services. That entrypoint exports deterministic per-worktree localhost ports
+and service URLs so the apps work without manual overrides. Use the Compose
+wrapper when you need full container parity, including Coolify-style runs.
 
 Start full stack (discord_bot + api + worker + redis + postgres + minio):
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -21,9 +21,11 @@ Use `.env.example` as the source of defaults.
 ## Queue + Job Runtime
 
 - `Optional`: `LOG_LEVEL` (default: `INFO`)
-- `Optional`: `REDIS_URL` (default: `redis://redis:6379/0`)
+- `Optional`: `REDIS_URL` (default: `redis://127.0.0.1:6379/0`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects `redis://redis:6379/0`)
 - `Optional`: `REDIS_QUEUE_NAME` (default: `jobs.default`)
 - `Optional`: `REDIS_KEY_PREFIX` (default: `jobs`)
+- `Optional`: `REDIS_HOST_BIND` (default: `127.0.0.1`)
+- `Optional`: `REDIS_HOST_PORT` (default: `6379` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 - `Optional`: `JOB_TIMEOUT_SECONDS` (default: `600`)
 - `Optional`: `JOB_RESULT_TTL_SECONDS` (default: `3600`)
 - `Optional`: `JOB_MAX_ATTEMPTS` (default: `8`)
@@ -32,21 +34,21 @@ Use `.env.example` as the source of defaults.
 
 ## Postgres + Compose Exposure
 
-- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres@postgres:5432/workflows`)
+- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres:postgres@127.0.0.1:5432/workflows`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects a Docker-network URL)
 - `Optional` (Compose DB container): `POSTGRES_DB` (default: `workflows`)
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ## MinIO + Internal Transfers
 
-- `Optional`: `MINIO_ENDPOINT` (default: `http://minio:9000`)
+- `Optional`: `MINIO_ENDPOINT` (default: `http://127.0.0.1:9000`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects `http://minio:9000`)
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### Notes
 
@@ -119,7 +121,7 @@ Use `.env.example` as the source of defaults.
 
 ## Discord Bot Core
 
-- `Optional`: `BACKEND_API_BASE_URL` (default: `http://api:8090`)
+- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
 - `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
 - Note: bot message chunking follows Discord's 2000 character limit in code.
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -25,7 +25,7 @@ Use `.env.example` as the source of defaults.
 - `Optional`: `REDIS_QUEUE_NAME` (default: `jobs.default`)
 - `Optional`: `REDIS_KEY_PREFIX` (default: `jobs`)
 - `Optional`: `REDIS_HOST_BIND` (default: `127.0.0.1`)
-- `Optional`: `REDIS_HOST_PORT` (default: `6379` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `REDIS_HOST_PORT` (default: computed per worktree as `12000 + WORKTREE_ENV_SLOT` when unset; use `6379` only if explicitly pinned via env/.env; see `./scripts/docker-compose.sh print-ports`)
 - `Optional`: `JOB_TIMEOUT_SECONDS` (default: `600`)
 - `Optional`: `JOB_RESULT_TTL_SECONDS` (default: `3600`)
 - `Optional`: `JOB_MAX_ATTEMPTS` (default: `8`)
@@ -39,7 +39,7 @@ Use `.env.example` as the source of defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default when unset: deterministic per-worktree value `15432 + WORKTREE_ENV_SLOT`; set `POSTGRES_HOST_PORT=5432` to pin it to `5432`; see `./scripts/docker-compose.sh print-ports`)
 
 ## MinIO + Internal Transfers
 
@@ -47,8 +47,8 @@ Use `.env.example` as the source of defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; set `MINIO_API_HOST_PORT=9000` to pin it to `9000`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; set `MINIO_CONSOLE_HOST_PORT=9001` to pin it to `9001`; see `./scripts/docker-compose.sh print-ports`)
 
 ### Notes
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -59,7 +59,7 @@ Use `.env.example` as the source of defaults.
 
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; host-run API listen port. Compose pins the container listen port to `8090` and varies only the published host port)
 - `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 - `Required`: `API_SHARED_SECRET` (global shared secret for protected endpoints and webhooks)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ Show, export, or stop the local dev environment:
 ./scripts/dev.sh down
 ```
 
+`./scripts/dev.sh env` emits shell-safe exports for the current worktree and
+avoids printing the resolved Postgres password directly.
+
 ### 4. Run app services on the host
 
 ```bash
@@ -197,7 +200,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Required` for protected endpoints: `API_SHARED_SECRET` (ingest requests are rejected when unset)
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; API listen port inside the container)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; host-run API listen port. Compose pins the container listen port to `8090` and only varies the published host port.)
 - `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### Backend API OIDC Session Auth

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository follows a service-oriented monorepo layout:
 ├── packages/
 │   └── shared/
 │       └── src/five08/      # Shared settings, queue helpers, shared clients
-├── docker-compose.yml      # discord_bot + api + worker + redis + postgres + minio
+├── docker-compose.yml      # full container stack for Coolify/local parity
 ├── tests/                  # Unit and integration tests
 └── pyproject.toml          # uv workspace root
 ```
@@ -72,9 +72,16 @@ cp .env.example .env
 # then edit .env
 ```
 
-### 3. Run services
+### 3. Start local infrastructure
 
-Run directly with uv:
+For development, run Redis, Postgres, and MinIO in Docker and run the app
+processes on the host:
+
+```bash
+./scripts/dev-up.sh
+```
+
+### 4. Run app services on the host
 
 ```bash
 # Discord bot
@@ -97,7 +104,7 @@ uv run --package five08 crmctl search --where timezone__is_null=true --where loc
 uv run --package five08 crmctl batch-update --where timezone__is_null=true --where location__is_not_null=true --update timezone=@location
 ```
 
-Or run the full stack with Docker Compose:
+For full containerized runs, including Coolify-style deployment parity:
 
 ```bash
 docker compose up --build
@@ -120,7 +127,7 @@ Use `.env.example` as the source of truth for defaults.
 
 ### Queue + Job Runtime
 
-- `Optional`: `REDIS_URL` (default: `redis://redis:6379/0`)
+- `Optional`: `REDIS_URL` (default: `redis://127.0.0.1:6379/0` for host-run app services; Compose injects `redis://redis:6379/0`)
 - `Optional`: `REDIS_QUEUE_NAME` (default: `jobs.default`)
 - `Optional`: `REDIS_KEY_PREFIX` (default: `jobs`)
 - `Optional`: `JOB_TIMEOUT_SECONDS` (default: `600`)
@@ -131,7 +138,7 @@ Use `.env.example` as the source of truth for defaults.
 
 ### Postgres + Compose Exposure
 
-- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres@postgres:5432/workflows`)
+- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres:postgres@127.0.0.1:5432/workflows` for host-run app services; Compose injects a Docker-network URL)
 - `Optional` (Compose DB container): `POSTGRES_DB` (default: `workflows`)
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
@@ -141,7 +148,7 @@ Use `.env.example` as the source of truth for defaults.
 ### MinIO + Internal Transfers
 
 - `Required` in non-local environments: `MINIO_ROOT_PASSWORD`
-- `Optional`: `MINIO_ENDPOINT` (default: `http://minio:9000`)
+- `Optional`: `MINIO_ENDPOINT` (default: `http://127.0.0.1:9000` for host-run app services; Compose injects `http://minio:9000`)
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
@@ -180,7 +187,7 @@ Use `.env.example` as the source of truth for defaults.
 ### Worker Consumer
 
 - `Optional`: `WORKER_NAME` (default: `worker`)
-- `Optional`: `DISCORD_BOT_INTERNAL_BASE_URL` (default: `http://discord_bot:3000`; used for best-effort Member role grants after Docuseal signatures)
+- `Optional`: `DISCORD_BOT_INTERNAL_BASE_URL` (default: `http://127.0.0.1:3000` for host-run app services; Compose injects `http://discord_bot:3000`)
 - `Optional`: `WORKER_QUEUE_NAMES` (default: `jobs.default`, comma-separated)
 - `Optional`: `WORKER_BURST` (default: `false`)
 
@@ -211,7 +218,7 @@ Use `.env.example` as the source of truth for defaults.
 ### Discord Bot Core
 
 - `Required`: `DISCORD_BOT_TOKEN`
-- `Optional`: `BACKEND_API_BASE_URL` (default: `http://api:8090`)
+- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090` for host-run app services; Compose injects `http://api:8090`)
 - `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
 - Note: bot message chunking uses Discord's 2000 character limit in code.
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ uv run --package five08 crmctl search --where timezone__is_null=true --where loc
 uv run --package five08 crmctl batch-update --where timezone__is_null=true --where location__is_not_null=true --update timezone=@location
 ```
 
-`./scripts/dev.sh` pins localhost ports to the standard defaults used by the
-app settings. Use the lower-level Compose wrapper when you want deterministic
-per-worktree ports or full containerized parity.
+`./scripts/dev.sh` exports deterministic per-worktree localhost ports and
+service URLs so the apps can run on the host without manual overrides. Use
+the lower-level Compose wrapper when you want full containerized parity.
 
 For full containerized runs, including Coolify-style deployment parity:
 
@@ -164,7 +164,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `REDIS_QUEUE_NAME` (default: `jobs.default`)
 - `Optional`: `REDIS_KEY_PREFIX` (default: `jobs`)
 - `Optional`: `REDIS_HOST_BIND` (default: `127.0.0.1`)
-- `Optional`: `REDIS_HOST_PORT` (default: `6379` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset)
+- `Optional`: `REDIS_HOST_PORT` (default when unset: deterministic per-worktree value `12000 + WORKTREE_ENV_SLOT`; set `REDIS_HOST_PORT=6379` in your shell or `.env` to pin it to `6379`)
 - `Optional`: `JOB_TIMEOUT_SECONDS` (default: `600`)
 - `Optional`: `JOB_RESULT_TTL_SECONDS` (default: `3600`)
 - `Optional`: `JOB_MAX_ATTEMPTS` (default: `8`)
@@ -178,7 +178,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default when unset: deterministic per-worktree value `15432 + WORKTREE_ENV_SLOT`; use `5432` only if you explicitly pin it, e.g. `POSTGRES_HOST_PORT=5432`; see `./scripts/docker-compose.sh print-ports`)
 
 ### MinIO + Internal Transfers
 
@@ -187,8 +187,8 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; set `MINIO_API_HOST_PORT=9000` to pin it to `9000`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; set `MINIO_CONSOLE_HOST_PORT=9001` to pin it to `9001`; see `./scripts/docker-compose.sh print-ports`)
 - Note: `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are `SharedSettings` alias properties (`minio_access_key`, `minio_secret_key`) and are not env-loaded fields.
 - Note: use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` as the actual env vars.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,27 @@ For development, run Redis, Postgres, and MinIO in Docker and run the app
 processes on the host:
 
 ```bash
-./scripts/dev-up.sh
+./scripts/dev.sh infra
+./scripts/dev.sh api
+./scripts/dev.sh worker
+./scripts/dev.sh discord-bot
+```
+
+`infra` brings up only the Docker infra. Use the host-service subcommands to run
+the app processes with per-worktree ports and derived localhost URLs.
+
+To launch infra plus all host-run services together with prefixed logs:
+
+```bash
+./scripts/dev.sh all
+```
+
+Show, export, or stop the local dev environment:
+
+```bash
+./scripts/dev.sh ports
+./scripts/dev.sh env
+./scripts/dev.sh down
 ```
 
 ### 4. Run app services on the host
@@ -103,6 +123,10 @@ uv run --package five08 crmctl repl
 uv run --package five08 crmctl search --where timezone__is_null=true --where location__is_not_null=true
 uv run --package five08 crmctl batch-update --where timezone__is_null=true --where location__is_not_null=true --update timezone=@location
 ```
+
+`./scripts/dev.sh` pins localhost ports to the standard defaults used by the
+app settings. Use the lower-level Compose wrapper when you want deterministic
+per-worktree ports or full containerized parity.
 
 For full containerized runs, including Coolify-style deployment parity:
 
@@ -136,9 +160,11 @@ Use `.env.example` as the source of truth for defaults.
 
 ### Queue + Job Runtime
 
-- `Optional`: `REDIS_URL` (default: `redis://127.0.0.1:6379/0` for host-run app services; Compose injects `redis://redis:6379/0`)
+- `Optional`: `REDIS_URL` (default: `redis://127.0.0.1:6379/0`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects `redis://redis:6379/0`)
 - `Optional`: `REDIS_QUEUE_NAME` (default: `jobs.default`)
 - `Optional`: `REDIS_KEY_PREFIX` (default: `jobs`)
+- `Optional`: `REDIS_HOST_BIND` (default: `127.0.0.1`)
+- `Optional`: `REDIS_HOST_PORT` (default: `6379` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset)
 - `Optional`: `JOB_TIMEOUT_SECONDS` (default: `600`)
 - `Optional`: `JOB_RESULT_TTL_SECONDS` (default: `3600`)
 - `Optional`: `JOB_MAX_ATTEMPTS` (default: `8`)
@@ -147,22 +173,22 @@ Use `.env.example` as the source of truth for defaults.
 
 ### Postgres + Compose Exposure
 
-- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres:postgres@127.0.0.1:5432/workflows` for host-run app services; Compose injects a Docker-network URL)
+- `Optional`: `POSTGRES_URL` (default: `postgresql://postgres:postgres@127.0.0.1:5432/workflows`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects a Docker-network URL)
 - `Optional` (Compose DB container): `POSTGRES_DB` (default: `workflows`)
 - `Optional` (Compose DB container): `POSTGRES_USER` (default: `postgres`)
 - `Optional` (Compose DB container): `POSTGRES_PASSWORD` (default: `postgres`)
 - `Optional` (Compose host bind): `POSTGRES_HOST_BIND` (default: `127.0.0.1`)
-- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional` (Compose host port): `POSTGRES_HOST_PORT` (default: `5432` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 
 ### MinIO + Internal Transfers
 
 - `Required` in non-local environments: `MINIO_ROOT_PASSWORD`
-- `Optional`: `MINIO_ENDPOINT` (default: `http://127.0.0.1:9000` for host-run app services; Compose injects `http://minio:9000`)
+- `Optional`: `MINIO_ENDPOINT` (default: `http://127.0.0.1:9000`; `./scripts/dev.sh` overrides it to a deterministic per-worktree localhost port, Compose injects `http://minio:9000`)
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default: `9000` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default: `9001` when using `./scripts/dev.sh`; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
 - Note: `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are `SharedSettings` alias properties (`minio_access_key`, `minio_secret_key`) and are not env-loaded fields.
 - Note: use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` as the actual env vars.
 
@@ -198,7 +224,7 @@ Use `.env.example` as the source of truth for defaults.
 ### Worker Consumer
 
 - `Optional`: `WORKER_NAME` (default: `worker`)
-- `Optional`: `DISCORD_BOT_INTERNAL_BASE_URL` (default: `http://127.0.0.1:3000` for host-run app services; Compose injects `http://discord_bot:3000`)
+- `Optional`: `DISCORD_BOT_INTERNAL_BASE_URL` (default: `http://127.0.0.1:3000`; `./scripts/dev.sh worker` overrides it to the worktree bot port, Compose injects `http://discord_bot:3000`)
 - `Optional`: `WORKER_QUEUE_NAMES` (default: `jobs.default`, comma-separated)
 - `Optional`: `WORKER_BURST` (default: `false`)
 
@@ -229,7 +255,7 @@ Use `.env.example` as the source of truth for defaults.
 ### Discord Bot Core
 
 - `Required`: `DISCORD_BOT_TOKEN`
-- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090` for host-run app services; Compose injects `http://api:8090`)
+- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
 - `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
 - Note: bot message chunking uses Discord's 2000 character limit in code.
 

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -27,7 +27,7 @@ class Settings(SharedSettings):
     espo_api_key: str
     espo_base_url: str
     discord_server_id: str | None = None
-    backend_api_base_url: str = "http://api:8090"
+    backend_api_base_url: str = "http://127.0.0.1:8090"
     audit_api_base_url: str | None = None
     audit_api_timeout_seconds: float = 2.0
     migadu_api_user: str | None = None

--- a/apps/worker/src/five08/worker/config.py
+++ b/apps/worker/src/five08/worker/config.py
@@ -15,7 +15,7 @@ class WorkerSettings(SharedSettings):
     worker_name: str = "worker"
     worker_queue_names: str = "jobs.default"
     worker_burst: bool = False
-    discord_bot_internal_base_url: str = "http://discord_bot:3000"
+    discord_bot_internal_base_url: str = "http://127.0.0.1:3000"
 
     espo_base_url: str
     espo_api_key: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
+      POSTGRES_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}
@@ -99,7 +99,7 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
       MINIO_INTERNAL_BUCKET: ${MINIO_INTERNAL_BUCKET:-internal-transfers}
       WEBHOOK_INGEST_HOST: 0.0.0.0
-      WEBHOOK_INGEST_PORT: ${WEBHOOK_INGEST_PORT:-8090}
+      WEBHOOK_INGEST_PORT: 8090
     restart: unless-stopped
     depends_on:
       redis:
@@ -109,7 +109,7 @@ services:
       minio-init:
         condition: service_completed_successfully
     ports:
-      - "${WEBHOOK_INGEST_HOST_BIND:-127.0.0.1}:${WEBHOOK_INGEST_HOST_PORT:-8090}:${WEBHOOK_INGEST_PORT:-8090}"
+      - "${WEBHOOK_INGEST_HOST_BIND:-127.0.0.1}:${WEBHOOK_INGEST_HOST_PORT:-8090}:8090"
 
   worker:
     build:
@@ -131,7 +131,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
+      POSTGRES_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     image: redis:7-alpine
     command: ["redis-server", "--save", "60", "1", "--loglevel", "warning"]
     restart: unless-stopped
+    ports:
+      - "${REDIS_HOST_BIND:-127.0.0.1}:${REDIS_HOST_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,8 +67,9 @@ services:
     env_file:
       - .env
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_URL: redis://redis:6379/0
       REDIS_QUEUE_NAME: ${REDIS_QUEUE_NAME:-jobs.default}
+      BACKEND_API_BASE_URL: http://api:8090
     restart: unless-stopped
     depends_on:
       redis:
@@ -82,16 +83,16 @@ services:
     env_file:
       - .env
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_URL: redis://redis:6379/0
       REDIS_QUEUE_NAME: ${REDIS_QUEUE_NAME:-jobs.default}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-workflows}}
+      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}
-      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ENDPOINT: http://minio:9000
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-internal}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
       MINIO_INTERNAL_BUCKET: ${MINIO_INTERNAL_BUCKET:-internal-transfers}
@@ -121,21 +122,22 @@ services:
     env_file:
       - .env
     environment:
-      REDIS_URL: ${REDIS_URL:-redis://redis:6379/0}
+      REDIS_URL: redis://redis:6379/0
       REDIS_QUEUE_NAME: ${REDIS_QUEUE_NAME:-jobs.default}
-      WORKER_API_BASE_URL: ${WORKER_API_BASE_URL:-}
+      WORKER_API_BASE_URL: http://api:8090
       WORKER_QUEUE_NAMES: ${WORKER_QUEUE_NAMES:-jobs.default}
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-workflows}
-      POSTGRES_URL: ${POSTGRES_URL:-postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:${POSTGRES_PORT:-5432}/${POSTGRES_DB:-workflows}}
+      POSTGRES_URL: postgresql://postgres:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
       JOB_MAX_ATTEMPTS: ${JOB_MAX_ATTEMPTS:-8}
       JOB_RETRY_BASE_SECONDS: ${JOB_RETRY_BASE_SECONDS:-5}
       JOB_RETRY_MAX_SECONDS: ${JOB_RETRY_MAX_SECONDS:-300}
-      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://minio:9000}
+      MINIO_ENDPOINT: http://minio:9000
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-internal}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-change-me}
       MINIO_INTERNAL_BUCKET: ${MINIO_INTERNAL_BUCKET:-internal-transfers}
+      DISCORD_BOT_INTERNAL_BASE_URL: http://discord_bot:3000
     restart: unless-stopped
     depends_on:
       api:

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -24,18 +24,20 @@ class SharedSettings(BaseSettings):
     sentry_send_default_pii: bool = False
     sentry_debug: bool = False
 
-    redis_url: str = "redis://redis:6379/0"  # Docker Compose default; set REDIS_URL when running outside Compose.
+    # Local development defaults to host-run app services. Containerized runtimes
+    # should inject Docker-network service URLs explicitly.
+    redis_url: str = "redis://127.0.0.1:6379/0"
     redis_queue_name: str = "jobs.default"
     redis_key_prefix: str = "jobs"
     redis_socket_connect_timeout: float | None = 5.0
     redis_socket_timeout: float | None = 5.0
-    postgres_url: str = "postgresql://postgres@postgres:5432/workflows"
+    postgres_url: str = "postgresql://postgres:postgres@127.0.0.1:5432/workflows"
     job_max_attempts: int = 8
     job_retry_base_seconds: int = 5
     job_retry_max_seconds: int = 300
     job_timeout_seconds: int = 600
     job_result_ttl_seconds: int = 3600
-    minio_endpoint: str = "http://minio:9000"
+    minio_endpoint: str = "http://127.0.0.1:9000"
     minio_root_user: str = "internal"
     minio_root_password: str = ""
     minio_internal_bucket: str = "internal-transfers"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+echo "Starting local infrastructure containers..."
+docker compose up -d redis postgres minio minio-init
+
+echo
+echo "Infrastructure is starting in Docker."
+echo "Run app services on the host with:"
+echo "  uv run --package api backend-api"
+echo "  uv run --package worker worker-consumer"
+echo "  uv run --package discord_bot discord-bot"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,12 +1,9 @@
-#!/bin/bash
-set -e
+#!/bin/sh
+set -eu
 
-echo "Starting local infrastructure containers..."
-docker compose up -d redis postgres minio minio-init
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+if [ "$#" -eq 0 ]; then
+  exec "$script_dir/dev.sh" infra
+fi
 
-echo
-echo "Infrastructure is starting in Docker."
-echo "Run app services on the host with:"
-echo "  uv run --package api backend-api"
-echo "  uv run --package worker worker-consumer"
-echo "  uv run --package discord_bot discord-bot"
+exec "$script_dir/dev.sh" "$@"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
+. "$script_dir/worktree-env.sh"
+worktree_env_load "$script_dir"
+
+export REDIS_URL="redis://127.0.0.1:${REDIS_HOST_PORT}/0"
+export POSTGRES_URL="postgresql://postgres:postgres@127.0.0.1:${POSTGRES_HOST_PORT}/workflows"
+export MINIO_ENDPOINT="http://127.0.0.1:${MINIO_API_HOST_PORT}"
+export BACKEND_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
+export WORKER_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
+export DISCORD_BOT_INTERNAL_BASE_URL="http://127.0.0.1:${HEALTHCHECK_PORT}"
+
+command=${1:-infra}
+case "$command" in
+  infra)
+    "$script_dir/docker-compose.sh" up -d redis postgres minio minio-init
+    cat <<EOF
+
+Infrastructure is running in Docker on localhost:
+  Redis:    127.0.0.1:${REDIS_HOST_PORT}
+  Postgres: 127.0.0.1:${POSTGRES_HOST_PORT}
+  MinIO:    127.0.0.1:${MINIO_API_HOST_PORT}
+  Console:  127.0.0.1:${MINIO_CONSOLE_HOST_PORT}
+
+Host-run app ports for this worktree:
+  API:      127.0.0.1:${WEBHOOK_INGEST_PORT}
+  Bot:      127.0.0.1:${HEALTHCHECK_PORT}
+
+Run app services on the host with:
+  ./scripts/dev.sh api
+  ./scripts/dev.sh worker
+  ./scripts/dev.sh discord-bot
+  ./scripts/dev.sh all
+EOF
+    ;;
+  all)
+    "$script_dir/docker-compose.sh" up -d redis postgres minio minio-init
+    exec python3 "$script_dir/dev_mux.py"
+    ;;
+  down)
+    "$script_dir/docker-compose.sh" down
+    ;;
+  ports)
+    cat <<EOF
+REDIS_HOST_PORT=$REDIS_HOST_PORT
+POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
+MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT
+MINIO_CONSOLE_HOST_PORT=$MINIO_CONSOLE_HOST_PORT
+WEBHOOK_INGEST_PORT=$WEBHOOK_INGEST_PORT
+HEALTHCHECK_PORT=$HEALTHCHECK_PORT
+EOF
+    ;;
+  env)
+    cat <<EOF
+export REDIS_HOST_PORT=$REDIS_HOST_PORT
+export POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
+export MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT
+export MINIO_CONSOLE_HOST_PORT=$MINIO_CONSOLE_HOST_PORT
+export WEBHOOK_INGEST_PORT=$WEBHOOK_INGEST_PORT
+export HEALTHCHECK_PORT=$HEALTHCHECK_PORT
+export REDIS_URL=$REDIS_URL
+export POSTGRES_URL=$POSTGRES_URL
+export MINIO_ENDPOINT=$MINIO_ENDPOINT
+export BACKEND_API_BASE_URL=$BACKEND_API_BASE_URL
+export WORKER_API_BASE_URL=$WORKER_API_BASE_URL
+export DISCORD_BOT_INTERNAL_BASE_URL=$DISCORD_BOT_INTERNAL_BASE_URL
+EOF
+    ;;
+  api)
+    exec uv run --package api backend-api
+    ;;
+  worker)
+    exec uv run --package worker worker-consumer
+    ;;
+  discord-bot|bot)
+    exec uv run --package discord_bot discord-bot
+    ;;
+  *)
+    echo "Usage: ./scripts/dev.sh [infra|all|down|ports|env|api|worker|discord-bot]" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -6,16 +6,22 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 worktree_env_load "$script_dir"
 
 export REDIS_URL="redis://127.0.0.1:${REDIS_HOST_PORT}/0"
-export POSTGRES_URL="postgresql://postgres:postgres@127.0.0.1:${POSTGRES_HOST_PORT}/workflows"
+if [ -z "${POSTGRES_URL-}" ]; then
+  export POSTGRES_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_HOST_PORT}/${POSTGRES_DB}"
+fi
 export MINIO_ENDPOINT="http://127.0.0.1:${MINIO_API_HOST_PORT}"
 export BACKEND_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
 export WORKER_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
 export DISCORD_BOT_INTERNAL_BASE_URL="http://127.0.0.1:${HEALTHCHECK_PORT}"
 
+start_infra() {
+  "$script_dir/docker-compose.sh" up -d --wait redis postgres minio minio-init
+}
+
 command=${1:-infra}
 case "$command" in
   infra)
-    "$script_dir/docker-compose.sh" up -d redis postgres minio minio-init
+    start_infra
     cat <<EOF
 
 Infrastructure is running in Docker on localhost:
@@ -36,7 +42,7 @@ Run app services on the host with:
 EOF
     ;;
   all)
-    "$script_dir/docker-compose.sh" up -d redis postgres minio minio-init
+    start_infra
     exec python3 "$script_dir/dev_mux.py"
     ;;
   down)
@@ -56,6 +62,9 @@ EOF
     cat <<EOF
 export REDIS_HOST_PORT=$REDIS_HOST_PORT
 export POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
+export POSTGRES_USER=$POSTGRES_USER
+export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+export POSTGRES_DB=$POSTGRES_DB
 export MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT
 export MINIO_CONSOLE_HOST_PORT=$MINIO_CONSOLE_HOST_PORT
 export WEBHOOK_INGEST_PORT=$WEBHOOK_INGEST_PORT

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,17 +5,28 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 . "$script_dir/worktree-env.sh"
 worktree_env_load "$script_dir"
 
+# dev.sh owns host-run service URLs so every launched process shares the same
+# worktree-local infra and app ports.
 export REDIS_URL="redis://127.0.0.1:${REDIS_HOST_PORT}/0"
-if [ -z "${POSTGRES_URL-}" ]; then
-  export POSTGRES_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_HOST_PORT}/${POSTGRES_DB}"
-fi
+export POSTGRES_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_HOST_PORT}/${POSTGRES_DB}"
 export MINIO_ENDPOINT="http://127.0.0.1:${MINIO_API_HOST_PORT}"
 export BACKEND_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
 export WORKER_API_BASE_URL="http://127.0.0.1:${WEBHOOK_INGEST_PORT}"
 export DISCORD_BOT_INTERNAL_BASE_URL="http://127.0.0.1:${HEALTHCHECK_PORT}"
 
+shell_quote() {
+  python3 -c 'import shlex, sys; print(shlex.quote(sys.argv[1]))' "$1"
+}
+
+emit_export() {
+  key=$1
+  value=$2
+  printf 'export %s=%s\n' "$key" "$(shell_quote "$value")"
+}
+
 start_infra() {
-  "$script_dir/docker-compose.sh" up -d --wait redis postgres minio minio-init
+  "$script_dir/docker-compose.sh" up -d --wait redis postgres minio
+  "$script_dir/docker-compose.sh" up minio-init
 }
 
 command=${1:-infra}
@@ -59,23 +70,23 @@ HEALTHCHECK_PORT=$HEALTHCHECK_PORT
 EOF
     ;;
   env)
-    cat <<EOF
-export REDIS_HOST_PORT=$REDIS_HOST_PORT
-export POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
-export POSTGRES_USER=$POSTGRES_USER
-export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
-export POSTGRES_DB=$POSTGRES_DB
-export MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT
-export MINIO_CONSOLE_HOST_PORT=$MINIO_CONSOLE_HOST_PORT
-export WEBHOOK_INGEST_PORT=$WEBHOOK_INGEST_PORT
-export HEALTHCHECK_PORT=$HEALTHCHECK_PORT
-export REDIS_URL=$REDIS_URL
-export POSTGRES_URL=$POSTGRES_URL
-export MINIO_ENDPOINT=$MINIO_ENDPOINT
-export BACKEND_API_BASE_URL=$BACKEND_API_BASE_URL
-export WORKER_API_BASE_URL=$WORKER_API_BASE_URL
-export DISCORD_BOT_INTERNAL_BASE_URL=$DISCORD_BOT_INTERNAL_BASE_URL
-EOF
+    emit_export REDIS_HOST_PORT "$REDIS_HOST_PORT"
+    emit_export POSTGRES_HOST_PORT "$POSTGRES_HOST_PORT"
+    emit_export POSTGRES_USER "$POSTGRES_USER"
+    emit_export POSTGRES_DB "$POSTGRES_DB"
+    emit_export MINIO_API_HOST_PORT "$MINIO_API_HOST_PORT"
+    emit_export MINIO_CONSOLE_HOST_PORT "$MINIO_CONSOLE_HOST_PORT"
+    emit_export WEBHOOK_INGEST_PORT "$WEBHOOK_INGEST_PORT"
+    emit_export HEALTHCHECK_PORT "$HEALTHCHECK_PORT"
+    emit_export REDIS_URL "$REDIS_URL"
+    emit_export MINIO_ENDPOINT "$MINIO_ENDPOINT"
+    emit_export BACKEND_API_BASE_URL "$BACKEND_API_BASE_URL"
+    emit_export WORKER_API_BASE_URL "$WORKER_API_BASE_URL"
+    emit_export DISCORD_BOT_INTERNAL_BASE_URL "$DISCORD_BOT_INTERNAL_BASE_URL"
+    printf 'export POSTGRES_URL="$('%s' print-postgres-url)"\n' "$(shell_quote "$script_dir/dev.sh")"
+    ;;
+  print-postgres-url)
+    printf '%s\n' "$POSTGRES_URL"
     ;;
   api)
     exec uv run --package api backend-api

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -23,6 +23,7 @@ def _stream_output(name: str, process: subprocess.Popen[str]) -> None:
     assert process.stdout is not None
     for line in process.stdout:
         sys.stdout.write(f"[{name}] {line}")
+        sys.stdout.flush()
     process.stdout.close()
 
 
@@ -70,6 +71,7 @@ def main() -> int:
             return
         interrupted = True
         sys.stdout.write(f"\nReceived signal {signum}, stopping services...\n")
+        sys.stdout.flush()
         _stop_processes(processes)
 
     signal.signal(signal.SIGINT, handle_signal)
@@ -105,7 +107,9 @@ def main() -> int:
             for process in processes:
                 return_code = process.poll()
                 if return_code is not None:
-                    exit_code = return_code
+                    exit_code = (
+                        128 + abs(return_code) if return_code < 0 else return_code
+                    )
                     _stop_processes(processes)
                     interrupted = True
                     break

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Run host services concurrently with prefixed logs."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterable
+
+
+SERVICES: list[tuple[str, list[str]]] = [
+    ("api", ["uv", "run", "--package", "api", "backend-api"]),
+    ("worker", ["uv", "run", "--package", "worker", "worker-consumer"]),
+    ("discord-bot", ["uv", "run", "--package", "discord_bot", "discord-bot"]),
+]
+
+
+def _stream_output(name: str, process: subprocess.Popen[str]) -> None:
+    assert process.stdout is not None
+    for line in process.stdout:
+        sys.stdout.write(f"[{name}] {line}")
+    process.stdout.close()
+
+
+def _terminate_process_group(process: subprocess.Popen[str], sig: int) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, sig)
+    except ProcessLookupError:
+        pass
+
+
+def _stop_processes(processes: Iterable[subprocess.Popen[str]]) -> None:
+    active = [process for process in processes if process.poll() is None]
+    for process in active:
+        _terminate_process_group(process, signal.SIGTERM)
+
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        if all(process.poll() is not None for process in active):
+            return
+        time.sleep(0.1)
+
+    for process in active:
+        _terminate_process_group(process, signal.SIGKILL)
+
+
+def main() -> int:
+    env = os.environ.copy()
+    env.setdefault("PYTHONUNBUFFERED", "1")
+
+    print("Launching host-run services with shared worktree env:")
+    print(f"  API:      {env.get('BACKEND_API_BASE_URL', '')}")
+    print(f"  Worker:   {env.get('WORKER_API_BASE_URL', '')}")
+    print(f"  Bot:      {env.get('DISCORD_BOT_INTERNAL_BASE_URL', '')}")
+    print()
+
+    processes: list[subprocess.Popen[str]] = []
+    threads: list[threading.Thread] = []
+    interrupted = False
+
+    def handle_signal(signum: int, _frame: object) -> None:
+        nonlocal interrupted
+        if interrupted:
+            return
+        interrupted = True
+        sys.stdout.write(f"\nReceived signal {signum}, stopping services...\n")
+        _stop_processes(processes)
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
+    try:
+        for name, command in SERVICES:
+            process = subprocess.Popen(
+                command,
+                cwd=env.get("WORKTREE_ENV_REPO_ROOT") or None,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+                start_new_session=True,
+            )
+            processes.append(process)
+            thread = threading.Thread(
+                target=_stream_output,
+                args=(name, process),
+                daemon=True,
+            )
+            thread.start()
+            threads.append(thread)
+
+        exit_code = 0
+        while True:
+            if interrupted:
+                exit_code = 130
+                break
+
+            for process in processes:
+                return_code = process.poll()
+                if return_code is not None:
+                    exit_code = return_code
+                    _stop_processes(processes)
+                    interrupted = True
+                    break
+            if interrupted:
+                break
+            time.sleep(0.2)
+    finally:
+        _stop_processes(processes)
+        for thread in threads:
+            thread.join(timeout=1.0)
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -10,12 +10,18 @@ import sys
 import threading
 import time
 from collections.abc import Iterable
+from urllib.parse import urlparse
 
 
 SERVICES: list[tuple[str, list[str]]] = [
     ("api", ["uv", "run", "--package", "api", "backend-api"]),
     ("worker", ["uv", "run", "--package", "worker", "worker-consumer"]),
     ("discord-bot", ["uv", "run", "--package", "discord_bot", "discord-bot"]),
+]
+
+PORT_SERVICES: list[tuple[str, str]] = [
+    ("api", "BACKEND_API_BASE_URL"),
+    ("discord-bot", "DISCORD_BOT_INTERNAL_BASE_URL"),
 ]
 
 
@@ -51,6 +57,100 @@ def _stop_processes(processes: Iterable[subprocess.Popen[str]]) -> None:
         _terminate_process_group(process, signal.SIGKILL)
 
 
+def _service_port(env: dict[str, str], env_key: str) -> int | None:
+    value = env.get(env_key)
+    if not value:
+        return None
+    parsed = urlparse(value)
+    return parsed.port
+
+
+def _port_is_free(port: int) -> bool:
+    return not _listening_pids(port)
+
+
+def _listening_pids(port: int) -> list[int]:
+    result = subprocess.run(
+        ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return [int(line) for line in result.stdout.splitlines() if line.strip().isdigit()]
+
+
+def _pid_command(pid: int) -> str:
+    result = subprocess.run(
+        ["ps", "-p", str(pid), "-o", "command="],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _stop_pid(pid: int) -> None:
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        return
+
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.1)
+
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+
+
+def _ensure_ports_available(env: dict[str, str]) -> tuple[bool, str | None]:
+    worktree_root = env.get("WORKTREE_ENV_REPO_ROOT", "")
+
+    for service_name, env_key in PORT_SERVICES:
+        port = _service_port(env, env_key)
+        if port is None or _port_is_free(port):
+            continue
+
+        pids = _listening_pids(port)
+        commands = {pid: _pid_command(pid) for pid in pids}
+        stale_pids = [
+            pid
+            for pid, command in commands.items()
+            if worktree_root and worktree_root in command
+        ]
+        if stale_pids and len(stale_pids) == len(pids):
+            print(
+                f"{service_name} port {port} is already in use by stale "
+                "same-worktree process(es); reclaiming it."
+            )
+            for pid in stale_pids:
+                _stop_pid(pid)
+            if _port_is_free(port):
+                continue
+            pids = _listening_pids(port)
+            commands = {pid: _pid_command(pid) for pid in pids}
+
+        owners = (
+            ", ".join(
+                f"pid={pid} command={command or '<unknown>'}"
+                for pid, command in commands.items()
+            )
+            or "<unknown>"
+        )
+        return False, (
+            f"{service_name} port {port} is already in use; "
+            f"stop the existing listener and retry. Owners: {owners}"
+        )
+
+    return True, None
+
+
 def main() -> int:
     env = os.environ.copy()
     env.setdefault("PYTHONUNBUFFERED", "1")
@@ -60,6 +160,11 @@ def main() -> int:
     print(f"  Worker:   {env.get('WORKER_API_BASE_URL', '')}")
     print(f"  Bot:      {env.get('DISCORD_BOT_INTERNAL_BASE_URL', '')}")
     print()
+
+    ports_ok, port_error = _ensure_ports_available(env)
+    if not ports_ok:
+        print(port_error, file=sys.stderr)
+        return 1
 
     processes: list[subprocess.Popen[str]] = []
     threads: list[threading.Thread] = []

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -62,20 +63,41 @@ def _service_port(env: dict[str, str], env_key: str) -> int | None:
     if not value:
         return None
     parsed = urlparse(value)
-    return parsed.port
+    try:
+        return parsed.port
+    except ValueError as exc:
+        raise ValueError(
+            f"{env_key} must include a valid numeric port: {value!r}"
+        ) from exc
+
+
+def _can_bind_port(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
 
 
 def _port_is_free(port: int) -> bool:
-    return not _listening_pids(port)
+    pids = _listening_pids(port)
+    if pids is None:
+        return _can_bind_port(port)
+    return not pids
 
 
-def _listening_pids(port: int) -> list[int]:
-    result = subprocess.run(
-        ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
-        check=False,
-        capture_output=True,
-        text=True,
-    )
+def _listening_pids(port: int) -> list[int] | None:
+    try:
+        result = subprocess.run(
+            ["lsof", "-nP", f"-iTCP:{port}", "-sTCP:LISTEN", "-t"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return None
     return [int(line) for line in result.stdout.splitlines() if line.strip().isdigit()]
 
 
@@ -113,11 +135,26 @@ def _ensure_ports_available(env: dict[str, str]) -> tuple[bool, str | None]:
     worktree_root = env.get("WORKTREE_ENV_REPO_ROOT", "")
 
     for service_name, env_key in PORT_SERVICES:
-        port = _service_port(env, env_key)
-        if port is None or _port_is_free(port):
+        try:
+            port = _service_port(env, env_key)
+        except ValueError as exc:
+            return False, str(exc)
+
+        if port is None:
             continue
 
         pids = _listening_pids(port)
+        if pids is None:
+            if _can_bind_port(port):
+                continue
+            return False, (
+                f"{service_name} port {port} is already in use; "
+                "install lsof for owner details or stop the existing listener and retry."
+            )
+
+        if not pids:
+            continue
+
         commands = {pid: _pid_command(pid) for pid in pids}
         stale_pids = [
             pid

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -2,96 +2,12 @@
 set -eu
 
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
-repo_root=$(CDPATH= cd "$script_dir/.." && pwd)
-env_file="$repo_root/.env"
-
-hash_value=$(printf '%s' "$repo_root" | cksum | awk '{print $1}')
-slot=$((hash_value % 2000))
-
-project_name=$(basename "$repo_root" | tr -cs 'A-Za-z0-9' '-' | tr 'A-Z' 'a-z' | sed 's/^-*//; s/-*$//')
-if [ -z "$project_name" ]; then
-  project_name="worktree"
-fi
-
-get_env_file_value() {
-  key=$1
-  [ -f "$env_file" ] || return 1
-
-  awk -F= -v key="$key" '
-    function parse_value(raw,    first, quote, value, i, c, escaped) {
-      sub(/^[[:space:]]*/, "", raw)
-
-      first = substr(raw, 1, 1)
-      if (first == "\"" || first == "'\''") {
-        quote = first
-        value = ""
-        escaped = 0
-
-        for (i = 2; i <= length(raw); i++) {
-          c = substr(raw, i, 1)
-
-          if (quote == "\"" && escaped) {
-            value = value c
-            escaped = 0
-            continue
-          }
-
-          if (quote == "\"" && c == "\\") {
-            escaped = 1
-            continue
-          }
-
-          if (c == quote) {
-            return value
-          }
-
-          value = value c
-        }
-
-        return value
-      }
-
-      sub(/[[:space:]]+#.*$/, "", raw)
-      sub(/[[:space:]]*$/, "", raw)
-      return raw
-    }
-
-    /^[[:space:]]*#/ { next }
-    $0 ~ "^[[:space:]]*" key "=" {
-      value = parse_value(substr($0, index($0, "=") + 1))
-      print value
-      found = 1
-      exit
-    }
-    END { if (!found) exit 1 }
-  ' "$env_file"
-}
-
-resolve_value() {
-  key=$1
-  default_value=$2
-  eval "shell_value=\${$key-}"
-
-  if [ -n "$shell_value" ]; then
-    printf '%s' "$shell_value"
-    return
-  fi
-
-  if file_value=$(get_env_file_value "$key" 2>/dev/null); then
-    printf '%s' "$file_value"
-    return
-  fi
-
-  printf '%s' "$default_value"
-}
-
-COMPOSE_PROJECT_NAME=$(resolve_value COMPOSE_PROJECT_NAME "${project_name}-$(printf '%04d' "$slot")")
-POSTGRES_HOST_PORT=$(resolve_value POSTGRES_HOST_PORT "$((15432 + slot))")
-WEBHOOK_INGEST_HOST_PORT=$(resolve_value WEBHOOK_INGEST_HOST_PORT "$((20080 + slot))")
-MINIO_API_HOST_PORT=$(resolve_value MINIO_API_HOST_PORT "$((24000 + slot))")
-MINIO_CONSOLE_HOST_PORT=$(resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + slot))")
+. "$script_dir/worktree-env.sh"
+worktree_env_load "$script_dir"
+repo_root=$WORKTREE_ENV_REPO_ROOT
 
 export COMPOSE_PROJECT_NAME
+export REDIS_HOST_PORT
 export POSTGRES_HOST_PORT
 export WEBHOOK_INGEST_HOST_PORT
 export MINIO_API_HOST_PORT
@@ -101,6 +17,7 @@ if [ "${1:-}" = "print-ports" ]; then
   cat <<EOF
 WORKTREE=$repo_root
 COMPOSE_PROJECT_NAME=$COMPOSE_PROJECT_NAME
+REDIS_HOST_PORT=$REDIS_HOST_PORT
 POSTGRES_HOST_PORT=$POSTGRES_HOST_PORT
 WEBHOOK_INGEST_HOST_PORT=$WEBHOOK_INGEST_HOST_PORT
 MINIO_API_HOST_PORT=$MINIO_API_HOST_PORT

--- a/scripts/docker-compose.sh
+++ b/scripts/docker-compose.sh
@@ -3,7 +3,7 @@ set -eu
 
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 . "$script_dir/worktree-env.sh"
-worktree_env_load "$script_dir"
+worktree_env_load "$script_dir" compose
 repo_root=$WORKTREE_ENV_REPO_ROOT
 
 export COMPOSE_PROJECT_NAME
@@ -12,6 +12,11 @@ export POSTGRES_HOST_PORT
 export WEBHOOK_INGEST_HOST_PORT
 export MINIO_API_HOST_PORT
 export MINIO_CONSOLE_HOST_PORT
+
+# Host-run-only app ports must not leak into Compose interpolation, or the API
+# container can start on a high worktree port while peers still target :8090.
+unset WEBHOOK_INGEST_PORT
+unset HEALTHCHECK_PORT
 
 if [ "${1:-}" = "print-ports" ]; then
   cat <<EOF

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -89,6 +89,7 @@ worktree_env_resolve_shell_or_default() {
 
 worktree_env_load() {
   script_dir=$1
+  mode=${2:-host}
 
   WORKTREE_ENV_REPO_ROOT=$(CDPATH= cd "$script_dir/.." && pwd)
   WORKTREE_ENV_FILE="$WORKTREE_ENV_REPO_ROOT/.env"
@@ -108,10 +109,6 @@ worktree_env_load() {
   MINIO_API_HOST_PORT=$(worktree_env_resolve_value MINIO_API_HOST_PORT "$((24000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
   MINIO_CONSOLE_HOST_PORT=$(worktree_env_resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
 
-  # Host-run app ports are launcher-managed and intentionally ignore .env defaults.
-  WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((32080 + WORKTREE_ENV_SLOT))")
-  HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((36000 + WORKTREE_ENV_SLOT))")
-
   export WORKTREE_ENV_REPO_ROOT
   export WORKTREE_ENV_FILE
   export WORKTREE_ENV_SLOT
@@ -121,6 +118,16 @@ worktree_env_load() {
   export WEBHOOK_INGEST_HOST_PORT
   export MINIO_API_HOST_PORT
   export MINIO_CONSOLE_HOST_PORT
-  export WEBHOOK_INGEST_PORT
-  export HEALTHCHECK_PORT
+
+  if [ "$mode" = "host" ]; then
+    # Host-run app ports are launcher-managed and intentionally ignore .env
+    # defaults so each worktree gets its own API and bot ports.
+    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((32080 + WORKTREE_ENV_SLOT))")
+    HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((36000 + WORKTREE_ENV_SLOT))")
+    export WEBHOOK_INGEST_PORT
+    export HEALTHCHECK_PORT
+  else
+    unset WEBHOOK_INGEST_PORT
+    unset HEALTHCHECK_PORT
+  fi
 }

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -105,6 +105,9 @@ worktree_env_load() {
   COMPOSE_PROJECT_NAME=$(worktree_env_resolve_value COMPOSE_PROJECT_NAME "${project_name}-$(printf '%04d' "$WORKTREE_ENV_SLOT")" "$WORKTREE_ENV_FILE")
   REDIS_HOST_PORT=$(worktree_env_resolve_value REDIS_HOST_PORT "$((12000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
   POSTGRES_HOST_PORT=$(worktree_env_resolve_value POSTGRES_HOST_PORT "$((15432 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  POSTGRES_USER=$(worktree_env_resolve_value POSTGRES_USER "postgres" "$WORKTREE_ENV_FILE")
+  POSTGRES_PASSWORD=$(worktree_env_resolve_value POSTGRES_PASSWORD "postgres" "$WORKTREE_ENV_FILE")
+  POSTGRES_DB=$(worktree_env_resolve_value POSTGRES_DB "workflows" "$WORKTREE_ENV_FILE")
   WEBHOOK_INGEST_HOST_PORT=$(worktree_env_resolve_value WEBHOOK_INGEST_HOST_PORT "$((20080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
   MINIO_API_HOST_PORT=$(worktree_env_resolve_value MINIO_API_HOST_PORT "$((24000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
   MINIO_CONSOLE_HOST_PORT=$(worktree_env_resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
@@ -115,6 +118,9 @@ worktree_env_load() {
   export COMPOSE_PROJECT_NAME
   export REDIS_HOST_PORT
   export POSTGRES_HOST_PORT
+  export POSTGRES_USER
+  export POSTGRES_PASSWORD
+  export POSTGRES_DB
   export WEBHOOK_INGEST_HOST_PORT
   export MINIO_API_HOST_PORT
   export MINIO_CONSOLE_HOST_PORT

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -126,10 +126,10 @@ worktree_env_load() {
   export MINIO_CONSOLE_HOST_PORT
 
   if [ "$mode" = "host" ]; then
-    # Host-run app ports are launcher-managed and intentionally ignore .env
-    # defaults so each worktree gets its own API and bot ports.
-    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((32080 + WORKTREE_ENV_SLOT))")
-    HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((36000 + WORKTREE_ENV_SLOT))")
+    # Keep host-run app ports below the Linux default ephemeral range
+    # (32768-60999) to avoid rare EADDRINUSE races with outbound sockets.
+    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((18080 + WORKTREE_ENV_SLOT))")
+    HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((30000 + WORKTREE_ENV_SLOT))")
     export WEBHOOK_INGEST_PORT
     export HEALTHCHECK_PORT
   else

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -1,0 +1,126 @@
+#!/bin/sh
+
+worktree_env_get_env_file_value() {
+  key=$1
+  env_file=$2
+  [ -f "$env_file" ] || return 1
+
+  awk -F= -v key="$key" '
+    function parse_value(raw,    first, quote, value, i, c, escaped) {
+      sub(/^[[:space:]]*/, "", raw)
+
+      first = substr(raw, 1, 1)
+      if (first == "\"" || first == "'\''") {
+        quote = first
+        value = ""
+        escaped = 0
+
+        for (i = 2; i <= length(raw); i++) {
+          c = substr(raw, i, 1)
+
+          if (quote == "\"" && escaped) {
+            value = value c
+            escaped = 0
+            continue
+          }
+
+          if (quote == "\"" && c == "\\") {
+            escaped = 1
+            continue
+          }
+
+          if (c == quote) {
+            return value
+          }
+
+          value = value c
+        }
+
+        return value
+      }
+
+      sub(/[[:space:]]+#.*$/, "", raw)
+      sub(/[[:space:]]*$/, "", raw)
+      return raw
+    }
+
+    /^[[:space:]]*#/ { next }
+    $0 ~ "^[[:space:]]*" key "=" {
+      value = parse_value(substr($0, index($0, "=") + 1))
+      print value
+      found = 1
+      exit
+    }
+    END { if (!found) exit 1 }
+  ' "$env_file"
+}
+
+worktree_env_resolve_value() {
+  key=$1
+  default_value=$2
+  env_file=$3
+  eval "shell_value=\${$key-}"
+
+  if [ -n "$shell_value" ]; then
+    printf '%s' "$shell_value"
+    return
+  fi
+
+  if file_value=$(worktree_env_get_env_file_value "$key" "$env_file" 2>/dev/null); then
+    printf '%s' "$file_value"
+    return
+  fi
+
+  printf '%s' "$default_value"
+}
+
+worktree_env_resolve_shell_or_default() {
+  key=$1
+  default_value=$2
+  eval "shell_value=\${$key-}"
+
+  if [ -n "$shell_value" ]; then
+    printf '%s' "$shell_value"
+    return
+  fi
+
+  printf '%s' "$default_value"
+}
+
+worktree_env_load() {
+  script_dir=$1
+
+  WORKTREE_ENV_REPO_ROOT=$(CDPATH= cd "$script_dir/.." && pwd)
+  WORKTREE_ENV_FILE="$WORKTREE_ENV_REPO_ROOT/.env"
+
+  hash_value=$(printf '%s' "$WORKTREE_ENV_REPO_ROOT" | cksum | awk '{print $1}')
+  WORKTREE_ENV_SLOT=$((hash_value % 2000))
+
+  project_name=$(basename "$WORKTREE_ENV_REPO_ROOT" | tr -cs 'A-Za-z0-9' '-' | tr 'A-Z' 'a-z' | sed 's/^-*//; s/-*$//')
+  if [ -z "$project_name" ]; then
+    project_name="worktree"
+  fi
+
+  COMPOSE_PROJECT_NAME=$(worktree_env_resolve_value COMPOSE_PROJECT_NAME "${project_name}-$(printf '%04d' "$WORKTREE_ENV_SLOT")" "$WORKTREE_ENV_FILE")
+  REDIS_HOST_PORT=$(worktree_env_resolve_value REDIS_HOST_PORT "$((12000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  POSTGRES_HOST_PORT=$(worktree_env_resolve_value POSTGRES_HOST_PORT "$((15432 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  WEBHOOK_INGEST_HOST_PORT=$(worktree_env_resolve_value WEBHOOK_INGEST_HOST_PORT "$((20080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  MINIO_API_HOST_PORT=$(worktree_env_resolve_value MINIO_API_HOST_PORT "$((24000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  MINIO_CONSOLE_HOST_PORT=$(worktree_env_resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+
+  # Host-run app ports are launcher-managed and intentionally ignore .env defaults.
+  WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((32080 + WORKTREE_ENV_SLOT))")
+  HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((36000 + WORKTREE_ENV_SLOT))")
+
+  export WORKTREE_ENV_REPO_ROOT
+  export WORKTREE_ENV_FILE
+  export WORKTREE_ENV_SLOT
+  export COMPOSE_PROJECT_NAME
+  export REDIS_HOST_PORT
+  export POSTGRES_HOST_PORT
+  export WEBHOOK_INGEST_HOST_PORT
+  export MINIO_API_HOST_PORT
+  export MINIO_CONSOLE_HOST_PORT
+  export WEBHOOK_INGEST_PORT
+  export HEALTHCHECK_PORT
+}

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -141,6 +141,17 @@ class TestBot508:
 
         assert config.discord_sendmsg_character_limit == 2000
 
+    def test_backend_api_base_url_defaults_to_host_runtime(self):
+        config = Settings(
+            discord_bot_token="token",
+            espo_api_key="espo-key",
+            espo_base_url="https://crm.example.com",
+            kimai_base_url="https://kimai.example.com",
+            kimai_api_token="kimai-token",
+        )
+
+        assert config.backend_api_base_url == "http://127.0.0.1:8090"
+
     def test_validate_app_command_descriptions_accepts_valid_lengths(self):
         """Test that valid command descriptions pass validation."""
         tree = Mock()

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -141,7 +141,12 @@ class TestBot508:
 
         assert config.discord_sendmsg_character_limit == 2000
 
-    def test_backend_api_base_url_defaults_to_host_runtime(self):
+    def test_backend_api_base_url_defaults_to_host_runtime(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.delenv("BACKEND_API_BASE_URL", raising=False)
+
         config = Settings(
             discord_bot_token="token",
             espo_api_key="espo-key",

--- a/tests/unit/test_dev_mux.py
+++ b/tests/unit/test_dev_mux.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+import socket
+from pathlib import Path
+
+
+def _load_dev_mux_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "dev_mux.py"
+    spec = importlib.util.spec_from_file_location("test_dev_mux_module", script_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ensure_ports_available_reports_invalid_url_port() -> None:
+    module = _load_dev_mux_module()
+
+    ok, error = module._ensure_ports_available(
+        {"BACKEND_API_BASE_URL": "http://127.0.0.1:abc"}
+    )
+
+    assert ok is False
+    assert error == (
+        "BACKEND_API_BASE_URL must include a valid numeric port: 'http://127.0.0.1:abc'"
+    )
+
+
+def test_ensure_ports_available_handles_missing_lsof_gracefully(
+    monkeypatch,
+) -> None:
+    module = _load_dev_mux_module()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        sock.listen()
+        port = sock.getsockname()[1]
+
+        def fake_run(*args, **kwargs):
+            raise FileNotFoundError("lsof")
+
+        monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+        ok, error = module._ensure_ports_available(
+            {"BACKEND_API_BASE_URL": f"http://127.0.0.1:{port}"}
+        )
+
+    assert ok is False
+    assert error == (
+        f"api port {port} is already in use; "
+        "install lsof for owner details or stop the existing listener and retry."
+    )

--- a/tests/unit/test_docuseal_processor.py
+++ b/tests/unit/test_docuseal_processor.py
@@ -54,7 +54,7 @@ def test_docuseal_processor_marks_member_agreement_signed_timestamp() -> None:
     assert result["discord_user_id"] == "1234"
     assert result["member_role"]["status"] == "applied"
     mock_grant_role.assert_called_once_with(
-        base_url="http://discord_bot:3000",
+        base_url="http://127.0.0.1:3000",
         api_secret="top-secret",
         discord_user_id="1234",
         contact_id="contact-1",

--- a/tests/unit/test_docuseal_processor.py
+++ b/tests/unit/test_docuseal_processor.py
@@ -30,6 +30,10 @@ def test_docuseal_processor_marks_member_agreement_signed_timestamp() -> None:
             "top-secret",
         ),
         patch(
+            "five08.worker.crm.docuseal_processor.settings.discord_bot_internal_base_url",
+            "http://127.0.0.1:3000",
+        ),
+        patch(
             "five08.worker.crm.docuseal_processor.grant_member_role_for_signed_agreement",
             return_value={"status": "applied", "role": "Member"},
         ) as mock_grant_role,

--- a/tests/unit/test_shared_settings.py
+++ b/tests/unit/test_shared_settings.py
@@ -64,3 +64,15 @@ def test_shared_settings_docuseal_template_id_rejects_non_numeric_string() -> No
         match="DOCUSEAL_MEMBER_AGREEMENT_TEMPLATE_ID must be an integer",
     ):
         SharedSettings(docuseal_member_agreement_template_id="abc")
+
+
+def test_local_service_defaults_target_host_runtime() -> None:
+    """Local defaults should work when app services run directly on the host."""
+    settings = SharedSettings()
+
+    assert settings.redis_url == "redis://127.0.0.1:6379/0"
+    assert (
+        settings.postgres_url
+        == "postgresql://postgres:postgres@127.0.0.1:5432/workflows"
+    )
+    assert settings.minio_endpoint == "http://127.0.0.1:9000"

--- a/tests/unit/test_shared_settings.py
+++ b/tests/unit/test_shared_settings.py
@@ -66,8 +66,14 @@ def test_shared_settings_docuseal_template_id_rejects_non_numeric_string() -> No
         SharedSettings(docuseal_member_agreement_template_id="abc")
 
 
-def test_local_service_defaults_target_host_runtime() -> None:
+def test_local_service_defaults_target_host_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Local defaults should work when app services run directly on the host."""
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    monkeypatch.delenv("POSTGRES_URL", raising=False)
+    monkeypatch.delenv("MINIO_ENDPOINT", raising=False)
+
     settings = SharedSettings()
 
     assert settings.redis_url == "redis://127.0.0.1:6379/0"

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -90,13 +90,13 @@ def test_docuseal_template_id_accepts_numeric_string() -> None:
     assert settings.docuseal_member_agreement_template_id == 68
 
 
-def test_discord_bot_internal_base_url_defaults_to_compose_service() -> None:
+def test_discord_bot_internal_base_url_defaults_to_host_runtime() -> None:
     settings = WorkerSettings(
         espo_base_url="https://crm.test.com",
         espo_api_key="test-key",
     )
 
-    assert settings.discord_bot_internal_base_url == "http://discord_bot:3000"
+    assert settings.discord_bot_internal_base_url == "http://127.0.0.1:3000"
 
 
 def test_google_forms_allowed_form_ids_parses_as_set() -> None:

--- a/tests/unit/test_worker_config.py
+++ b/tests/unit/test_worker_config.py
@@ -90,7 +90,11 @@ def test_docuseal_template_id_accepts_numeric_string() -> None:
     assert settings.docuseal_member_agreement_template_id == 68
 
 
-def test_discord_bot_internal_base_url_defaults_to_host_runtime() -> None:
+def test_discord_bot_internal_base_url_defaults_to_host_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DISCORD_BOT_INTERNAL_BASE_URL", raising=False)
+
     settings = WorkerSettings(
         espo_base_url="https://crm.test.com",
         espo_api_key="test-key",


### PR DESCRIPTION
## Description
- Default local dev config to host-run `api`, `worker`, and `discord_bot` on localhost, while Compose/Coolify still inject Docker network endpoints for full container runs.
- Add `scripts/dev.sh` with shared worktree port allocation, plus `all` for infra + multiplexed host-run logs and a refactored `docker-compose.sh` for deterministic Compose ports.
- Expose Redis on the host for local dev and update docs/tests to cover the new workflow.

## Related Issue
- None.

## How Has This Been Tested?
- `uv run pytest tests/unit/test_shared_settings.py tests/unit/test_worker_config.py tests/unit/test_bot.py -v --tb=short`
- `python3 -m py_compile scripts/dev_mux.py`
- `sh -n scripts/dev.sh scripts/dev-up.sh scripts/docker-compose.sh scripts/worktree-env.sh`
- `./scripts/dev.sh ports`
- `./scripts/docker-compose.sh print-ports`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New local dev CLI and orchestration scripts for starting infra and host-run services with deterministic per‑worktree ports.

* **Documentation**
  * Updated README/DEVELOPMENT/ENVIRONMENT/AGENTS to document the new dev workflow, port behavior, and env variable semantics.

* **Chores**
  * Default environment values and compose files updated to target localhost for host-run dev while preserving container network URLs for containerized runs.

* **Tests**
  * Added/updated unit tests covering new defaults and port-validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->