### PR TITLE
fix: relax job match hard needs

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -204,6 +204,15 @@ class ThreadPost:
     tags: list[str]
 
 
+@dataclass(frozen=True)
+class CandidateSearchOutcome:
+    """Resolved candidate search result, including any relaxed search note."""
+
+    candidates: list[Any]
+    effective_requirements: JobRequirements
+    search_note: str | None = None
+
+
 class JobsCog(DiscordAuditCogMixin, commands.Cog):
     """Job posting and candidate matching workflows."""
 
@@ -313,6 +322,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         requirements: JobRequirements,
         candidates_count: int,
         guild: discord.Guild | None,
+        search_note: str | None = None,
     ) -> tuple[list[str], str | None, list[int], str | None, list[int]]:
         """Build header lines plus discord/locality role mention details."""
         header_parts: list[str] = []
@@ -479,7 +489,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 "Skills: "
                 + ", ".join(f"`{s}`" for s in requirements.required_skills[:8])
             )
-        if requirements.soft_required_skills:
+        if requirements.hard_required_skills and requirements.soft_required_skills:
             header_parts.append(
                 "Other needs: "
                 + ", ".join(f"`{s}`" for s in requirements.soft_required_skills[:5])
@@ -499,6 +509,8 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         header_lines: list[str] = ["## Job Match Results"]
         if header_parts:
             header_lines.append(" · ".join(header_parts))
+        if search_note:
+            header_lines.append(search_note)
         header_lines.append(f"Found **{candidates_count}** candidate(s).")
 
         return (
@@ -900,6 +912,82 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
     def _has_match_requirements(requirements: JobRequirements) -> bool:
         return bool(requirements.required_skills or requirements.discord_role_types)
 
+    @staticmethod
+    def _build_candidate_search_plan(
+        requirements: JobRequirements,
+        *,
+        min_match_score: float,
+    ) -> list[tuple[JobRequirements, float, str | None]]:
+        plan: list[tuple[JobRequirements, float, str | None]] = []
+        seen: set[
+            tuple[
+                tuple[str, ...],
+                tuple[str, ...],
+                tuple[str, ...],
+                tuple[str, ...],
+                float,
+            ]
+        ] = set()
+
+        def add_plan_step(
+            planned_requirements: JobRequirements,
+            planned_min_match_score: float,
+            search_note: str | None,
+        ) -> None:
+            key = (
+                tuple(planned_requirements.hard_required_skills),
+                tuple(planned_requirements.soft_required_skills),
+                tuple(planned_requirements.required_skills),
+                tuple(planned_requirements.discord_role_types),
+                planned_min_match_score,
+            )
+            if key in seen:
+                return
+            seen.add(key)
+            plan.append((planned_requirements, planned_min_match_score, search_note))
+
+        add_plan_step(requirements, min_match_score, None)
+
+        if len(requirements.hard_required_skills) > 1:
+            anchor_skill = requirements.hard_required_skills[0]
+            add_plan_step(
+                replace(
+                    requirements,
+                    hard_required_skills=requirements.hard_required_skills[:1],
+                    soft_required_skills=requirements.hard_required_skills[1:]
+                    + requirements.soft_required_skills,
+                ),
+                min_match_score,
+                "Search note: no strict full-match candidates, so only anchor hard "
+                f"need `{anchor_skill}` stayed mandatory.",
+            )
+
+        if requirements.required_skills:
+            add_plan_step(
+                replace(
+                    requirements,
+                    hard_required_skills=[],
+                    soft_required_skills=requirements.required_skills,
+                ),
+                0.0,
+                "Search note: still no strict matches, so matching was broadened to "
+                "any relevant skill or role signal.",
+            )
+        elif requirements.discord_role_types and min_match_score > 0:
+            add_plan_step(
+                replace(
+                    requirements,
+                    required_skills=[],
+                    hard_required_skills=[],
+                    soft_required_skills=[],
+                ),
+                0.0,
+                "Search note: still no strict matches, so matching was broadened to "
+                "role-based signals.",
+            )
+
+        return plan
+
     async def _search_and_rerank_candidates(
         self,
         *,
@@ -908,20 +996,47 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         guild_id: str | None,
         limit: int,
         min_match_score: float = 0.0,
-    ) -> list[Any]:
-        candidates = await asyncio.to_thread(
-            search_candidates,
-            settings,
+    ) -> CandidateSearchOutcome:
+        search_plan = self._build_candidate_search_plan(
             requirements,
-            guild_id=guild_id,
-            limit=limit,
             min_match_score=min_match_score,
         )
+        last_requirements = requirements
+        last_search_note: str | None = None
 
-        return await self._rerank_candidates(
-            posting=posting,
-            requirements=requirements,
-            candidates=candidates,
+        for (
+            planned_requirements,
+            planned_min_match_score,
+            search_note,
+        ) in search_plan:
+            candidates = await asyncio.to_thread(
+                search_candidates,
+                settings,
+                planned_requirements,
+                guild_id=guild_id,
+                limit=limit,
+                min_match_score=planned_min_match_score,
+            )
+            last_requirements = planned_requirements
+            last_search_note = search_note
+            if not candidates:
+                continue
+
+            reranked_candidates = await self._rerank_candidates(
+                posting=posting,
+                requirements=planned_requirements,
+                candidates=candidates,
+            )
+            return CandidateSearchOutcome(
+                candidates=reranked_candidates,
+                effective_requirements=planned_requirements,
+                search_note=search_note,
+            )
+
+        return CandidateSearchOutcome(
+            candidates=[],
+            effective_requirements=last_requirements,
+            search_note=last_search_note,
         )
 
     @staticmethod
@@ -1287,6 +1402,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         requirements: JobRequirements,
         candidates: list[Any],
         guild: discord.Guild | None,
+        search_note: str | None = None,
     ) -> None:
         """Send the formatted match output for both manual and automatic runs."""
         (
@@ -1299,6 +1415,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             requirements=requirements,
             candidates_count=len(candidates),
             guild=guild,
+            search_note=search_note,
         )
 
         safe_mentions = discord.AllowedMentions(
@@ -1420,7 +1537,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         try:
-            candidates = await self._search_and_rerank_candidates(
+            search_outcome = await self._search_and_rerank_candidates(
                 posting=posting,
                 requirements=requirements,
                 guild_id=str(thread.guild.id) if thread.guild else None,
@@ -1443,9 +1560,10 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
 
         await self._publish_match_results(
             send=thread.send,
-            requirements=requirements,
-            candidates=candidates,
+            requirements=search_outcome.effective_requirements,
+            candidates=search_outcome.candidates,
             guild=guild,
+            search_note=search_outcome.search_note,
         )
 
     async def _bulk_sync_guild_roles(
@@ -1907,7 +2025,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         try:
-            candidates = await self._search_and_rerank_candidates(
+            search_outcome = await self._search_and_rerank_candidates(
                 posting=posting,
                 requirements=requirements,
                 guild_id=str(interaction.guild.id) if interaction.guild else None,
@@ -1935,9 +2053,10 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
 
         await self._publish_match_results(
             send=_send_match_result,
-            requirements=requirements,
-            candidates=candidates,
+            requirements=search_outcome.effective_requirements,
+            candidates=search_outcome.candidates,
             guild=interaction.guild,
+            search_note=search_outcome.search_note,
         )
 
         self._audit_command_safe(
@@ -1952,7 +2071,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 "preferred_skills_count": len(requirements.preferred_skills),
                 "required_evidence_count": len(requirements.required_evidence),
                 "discord_role_types": requirements.discord_role_types,
-                "candidates_returned": len(candidates),
+                "candidates_returned": len(search_outcome.candidates),
                 **posting_metadata,
             },
         )

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -9,9 +9,37 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from five08.discord_webhook import DiscordWebhookLogger
-from five08.skills import normalize_skill_list
+from five08.skills import normalize_skill, normalize_skill_list
 
 logger = logging.getLogger(__name__)
+
+_MAX_HARD_REQUIRED_SKILLS = 2
+
+# Normalize abstract or overly compound job-post phrases into concise, searchable
+# skill terms that are more likely to line up with CRM/resume skill records.
+_JOB_MATCH_SKILL_ALIASES: dict[str, str] = {
+    "product designer": "product design",
+    "ux designer": "ux design",
+    "ui designer": "ui design",
+    "user experience design": "ux design",
+    "user interface design": "ui design",
+    "agent ux": "ux design",
+    "agentic ux": "ux design",
+    "ai native ux": "ux design",
+    "ai native design": "product design",
+    "ai native product design": "product design",
+    "agentic design": "product design",
+    "figma to webflow": "webflow",
+    "webflow interaction": "webflow",
+    "webflow interactions": "webflow",
+    "webflow automation": "webflow",
+    "webflow automations": "webflow",
+    "hubspot integration": "hubspot",
+    "hubspot integrations": "hubspot",
+    "hubspot automation": "hubspot",
+    "hubspot automations": "hubspot",
+    "hubspot workflows": "hubspot",
+}
 
 # Canonical Discord role names used for skill/type classification.
 # These match the actual role names in the 508.dev Discord server.
@@ -387,6 +415,25 @@ _SENIORITY_RE = re.compile(
 SENIORITY_ORDER = ["junior", "midlevel", "senior", "staff"]
 
 
+def _normalize_job_skill_list(values: list[str]) -> list[str]:
+    """Normalize job-post skills toward short, searchable CRM terms."""
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        skill = normalize_skill(raw)
+        if not skill:
+            continue
+        skill = normalize_skill(_JOB_MATCH_SKILL_ALIASES.get(skill, skill))
+        if not skill:
+            continue
+        key = skill.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        normalized.append(skill)
+    return normalized
+
+
 @dataclass(frozen=True)
 class JobRequirements:
     """Normalized requirements extracted from a job posting."""
@@ -406,9 +453,13 @@ class JobRequirements:
     title: str | None = None
 
     def __post_init__(self) -> None:
-        hard_required_skills = normalize_skill_list(list(self.hard_required_skills))
-        soft_required_skills = normalize_skill_list(list(self.soft_required_skills))
-        legacy_required_skills = normalize_skill_list(list(self.required_skills))
+        hard_required_skills = _normalize_job_skill_list(
+            list(self.hard_required_skills)
+        )
+        soft_required_skills = _normalize_job_skill_list(
+            list(self.soft_required_skills)
+        )
+        legacy_required_skills = _normalize_job_skill_list(list(self.required_skills))
 
         if (
             not hard_required_skills
@@ -429,6 +480,12 @@ class JobRequirements:
                 if skill.casefold() not in hard_required_skill_keys
             ]
 
+        if len(hard_required_skills) > _MAX_HARD_REQUIRED_SKILLS:
+            soft_required_skills = (
+                hard_required_skills[_MAX_HARD_REQUIRED_SKILLS:] + soft_required_skills
+            )
+            hard_required_skills = hard_required_skills[:_MAX_HARD_REQUIRED_SKILLS]
+
         hard_required_skill_keys = {item.casefold() for item in hard_required_skills}
         soft_required_skills = [
             skill
@@ -439,7 +496,7 @@ class JobRequirements:
         required_skill_keys = {item.casefold() for item in required_skills}
         preferred_skills = [
             skill
-            for skill in normalize_skill_list(list(self.preferred_skills))
+            for skill in _normalize_job_skill_list(list(self.preferred_skills))
             if skill.casefold() not in required_skill_keys
         ]
 
@@ -525,10 +582,16 @@ def _build_prompt(posting_text: str, hints: dict[str, Any]) -> str:
         '- "hard_required_skills": array of strings — hard must-have TECHNICAL skills. '
         'Use concise canonical names (1-3 words, e.g. "webflow", "typescript", '
         '"postgresql"). Only include skills that should block a candidate if missing. '
-        "If the posting clearly hinges on one platform or tool, put that anchor skill "
-        'first (e.g. "webflow" before adjacent skills like "figma").\n'
+        "Keep this list short: usually 1 anchor skill, occasionally 2 when both are "
+        "clear blockers. Avoid custom compounds or conceptual phrases; rewrite them "
+        "to the closest searchable skill likely to appear verbatim in resumes/CRM "
+        'records (e.g. "ai native design" -> "product design", "agent ux" -> '
+        '"ux design", "hubspot integration" -> "hubspot"). If the posting clearly '
+        "hinges on one platform or tool, put that anchor skill first "
+        '(e.g. "webflow" before adjacent skills like "figma").\n'
         '- "soft_required_skills": array of strings — technical skills that matter a lot '
-        "but should not automatically disqualify a candidate if missing.\n"
+        "but should not automatically disqualify a candidate if missing. Use the same "
+        "search-friendly canonical naming rules.\n"
         '- "preferred_skills": array of strings — secondary technical skills, same format.\n'
         '- "required_evidence": array of strings — non-skill proof items the hiring team '
         'explicitly asks for, like "live webflow projects", "portfolio", or '

--- a/tests/unit/test_job_match.py
+++ b/tests/unit/test_job_match.py
@@ -240,6 +240,24 @@ def test_job_requirements_dedupes_soft_and_preferred_against_hard() -> None:
     assert requirements.preferred_skills == ["hubspot"]
 
 
+def test_job_requirements_caps_hard_skills_and_normalizes_searchable_aliases() -> None:
+    requirements = JobRequirements(
+        hard_required_skills=[
+            "Webflow",
+            "Figma",
+            "HubSpot integration",
+            "Webflow automations",
+        ],
+        soft_required_skills=["Agent UX"],
+        preferred_skills=["AI native design"],
+    )
+
+    assert requirements.hard_required_skills == ["webflow", "figma"]
+    assert requirements.soft_required_skills == ["hubspot", "ux design"]
+    assert requirements.required_skills == ["webflow", "figma", "hubspot", "ux design"]
+    assert requirements.preferred_skills == ["product design"]
+
+
 def test_extract_us_only_regex_overrides_remote_any() -> None:
     """Regex US-only detection must override the LLM returning remote_any."""
     payload = {
@@ -332,6 +350,12 @@ def test_build_prompt_includes_anchor_skill_instruction() -> None:
     prompt = _build_prompt("text", {})
     assert "anchor skill first" in prompt
     assert '"webflow" before adjacent skills like "figma"' in prompt
+
+
+def test_build_prompt_requests_searchable_skill_names() -> None:
+    prompt = _build_prompt("text", {})
+    assert "searchable skill likely to appear verbatim" in prompt
+    assert '"agent ux" -> "ux design"' in prompt
 
 
 def test_rerank_shortlisted_candidates_parses_structured_response() -> None:

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -133,6 +133,88 @@ def test_build_match_candidate_lines_omits_crm_link_for_prospect() -> None:
     assert "`@michaelmwu`" in lines[0]
     assert "<https://crm.example/#Contact/view/" not in lines[0]
     assert "<@" not in lines[0]
+
+
+def test_build_candidate_search_plan_relaxes_hard_requirements() -> None:
+    requirements = JobRequirements(
+        hard_required_skills=["webflow", "figma", "hubspot"],
+        discord_role_types=["Designer"],
+    )
+
+    plan = JobsCog._build_candidate_search_plan(requirements, min_match_score=8.0)
+
+    assert len(plan) == 3
+    assert plan[0][0].hard_required_skills == ["webflow", "figma"]
+    assert plan[0][1] == 8.0
+    assert plan[0][2] is None
+    assert plan[1][0].hard_required_skills == ["webflow"]
+    assert plan[1][0].soft_required_skills == ["figma", "hubspot"]
+    assert "anchor hard need `webflow`" in (plan[1][2] or "")
+    assert plan[2][0].hard_required_skills == []
+    assert plan[2][0].soft_required_skills == ["webflow", "figma", "hubspot"]
+    assert plan[2][1] == 0.0
+
+
+def test_build_job_match_header_uses_single_skills_line_when_hard_is_empty() -> None:
+    cog = JobsCog(Mock())
+    requirements = JobRequirements(
+        hard_required_skills=[],
+        soft_required_skills=["product design", "ux design"],
+        title="Product Designer",
+    )
+
+    header_lines, *_ = cog._build_job_match_header_and_mentions(
+        requirements=requirements,
+        candidates_count=2,
+        guild=None,
+        search_note="Search note: broadened matching.",
+    )
+
+    assert "Skills: `product design`, `ux design`" in header_lines[1]
+    assert "Other needs:" not in header_lines[1]
+    assert header_lines[2] == "Search note: broadened matching."
+    assert header_lines[3] == "Found **2** candidate(s)."
+
+
+def test_search_and_rerank_candidates_retries_with_relaxed_requirements() -> None:
+    cog = JobsCog(Mock())
+    candidate = _make_candidate(crm_name="Jamie", match_score=18.0)
+    requirements = JobRequirements(
+        hard_required_skills=["webflow", "figma", "hubspot"],
+        discord_role_types=["Designer"],
+    )
+
+    with (
+        patch(
+            "five08.discord_bot.cogs.jobs.search_candidates",
+            side_effect=[[], [candidate]],
+        ) as search_candidates_mock,
+        patch.object(
+            cog,
+            "_rerank_candidates",
+            AsyncMock(return_value=[candidate]),
+        ) as rerank_mock,
+    ):
+        outcome = asyncio.run(
+            cog._search_and_rerank_candidates(
+                posting="Webflow role",
+                requirements=requirements,
+                guild_id="123",
+                limit=20,
+                min_match_score=8.0,
+            )
+        )
+
+    assert search_candidates_mock.call_count == 2
+    first_requirements = search_candidates_mock.call_args_list[0].args[1]
+    second_requirements = search_candidates_mock.call_args_list[1].args[1]
+    assert first_requirements.hard_required_skills == ["webflow", "figma"]
+    assert second_requirements.hard_required_skills == ["webflow"]
+    assert second_requirements.soft_required_skills == ["figma", "hubspot"]
+    rerank_mock.assert_awaited_once()
+    assert outcome.candidates == [candidate]
+    assert outcome.effective_requirements.hard_required_skills == ["webflow"]
+    assert "anchor hard need `webflow`" in (outcome.search_note or "")
 
 
 def test_build_match_candidate_lines_keeps_name_discord_and_linkedin_on_first_line() -> (


### PR DESCRIPTION
## Description
- Normalize compound job-post skills into short, searchable terms, cap strict hard requirements, and steer extraction toward anchor skills.
- Add a fallback search ladder so job matching relaxes from strict hard-need matching when the first pass finds zero candidates.
- Update the match-results header to reflect broadened searches cleanly and add regression coverage for the new behavior.

## Related Issue
- N/A

## How Has This Been Tested?
- `uv run ruff check packages/shared/src/five08/job_match.py apps/discord_bot/src/five08/discord_bot/cogs/jobs.py tests/unit/test_job_match.py tests/unit/test_jobs.py`
- `uv run ruff format --check packages/shared/src/five08/job_match.py apps/discord_bot/src/five08/discord_bot/cogs/jobs.py tests/unit/test_job_match.py tests/unit/test_jobs.py`
- `uv run pytest tests/unit/test_job_match.py tests/unit/test_jobs.py tests/unit/test_crm.py -q`