### PR TITLE
fix: harden shared CA bundle handling

### DIFF
--- a/packages/shared/src/five08/clients/authentik.py
+++ b/packages/shared/src/five08/clients/authentik.py
@@ -8,6 +8,8 @@ from urllib.parse import urljoin
 
 import requests
 
+from five08.tls import default_ca_bundle_path
+
 
 class AuthentikAPIError(Exception):
     """Raised when an Authentik API call fails."""
@@ -118,6 +120,7 @@ class AuthentikClient:
                     params=params,
                     json=payload,
                     timeout=self.timeout_seconds,
+                    verify=default_ca_bundle_path(),
                     allow_redirects=False,
                 )
             except requests.RequestException as exc:

--- a/packages/shared/src/five08/clients/discord_bot.py
+++ b/packages/shared/src/five08/clients/discord_bot.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import requests
 
+from five08.tls import default_ca_bundle_path
+
 
 class DiscordBotAPIError(Exception):
     """Raised when a Discord bot internal API call fails."""
@@ -41,6 +43,7 @@ class DiscordBotClient:
             "url": url,
             "headers": headers,
             "timeout": self.timeout_seconds,
+            "verify": default_ca_bundle_path(),
         }
         if payload is not None:
             request_kwargs["json"] = payload

--- a/packages/shared/src/five08/clients/docuseal.py
+++ b/packages/shared/src/five08/clients/docuseal.py
@@ -4,6 +4,8 @@ from typing import Any
 
 import requests
 
+from five08.tls import default_ca_bundle_path
+
 
 class DocusealAPIError(Exception):
     """Raised when a DocuSeal API call fails."""
@@ -43,6 +45,7 @@ class DocusealClient:
                 headers=headers,
                 json=payload,
                 timeout=self.timeout_seconds,
+                verify=default_ca_bundle_path(),
             )
         except requests.RequestException as exc:
             raise DocusealAPIError(f"HTTP request failed: {exc}") from exc

--- a/packages/shared/src/five08/clients/espo.py
+++ b/packages/shared/src/five08/clients/espo.py
@@ -2,6 +2,8 @@ import requests
 import urllib
 from typing import Any, Dict, List
 
+from five08.tls import default_ca_bundle_path
+
 
 class EspoAPIError(Exception):
     """An exception class for the client"""
@@ -64,6 +66,7 @@ class EspoAPI:
                     headers=headers,
                     json=params,
                     timeout=self.timeout_seconds,
+                    verify=default_ca_bundle_path(),
                 )
             else:
                 if params:
@@ -73,6 +76,7 @@ class EspoAPI:
                     url,
                     headers=headers,
                     timeout=self.timeout_seconds,
+                    verify=default_ca_bundle_path(),
                 )
         except requests.RequestException as exc:
             raise EspoAPIError(f"HTTP request failed: {exc}") from exc
@@ -106,7 +110,12 @@ class EspoAPI:
             url = url + "?" + http_build_query(params)
 
         try:
-            response = requests.get(url, headers=headers, timeout=self.timeout_seconds)
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=self.timeout_seconds,
+                verify=default_ca_bundle_path(),
+            )
         except requests.RequestException as exc:
             raise EspoAPIError(f"HTTP request failed: {exc}") from exc
 

--- a/packages/shared/src/five08/clients/kimai.py
+++ b/packages/shared/src/five08/clients/kimai.py
@@ -8,6 +8,8 @@ import requests
 from typing import Any
 from datetime import datetime
 
+from five08.tls import default_ca_bundle_path
+
 
 class KimaiAPIError(Exception):
     """An exception class for Kimai API errors"""
@@ -86,11 +88,19 @@ class KimaiAPI:
         try:
             if method in ["POST", "PATCH", "PUT"]:
                 response = self._session.request(
-                    method, url, json=params, timeout=self.timeout
+                    method,
+                    url,
+                    json=params,
+                    timeout=self.timeout,
+                    verify=default_ca_bundle_path(),
                 )
             else:
                 response = self._session.request(
-                    method, url, params=params, timeout=self.timeout
+                    method,
+                    url,
+                    params=params,
+                    timeout=self.timeout,
+                    verify=default_ca_bundle_path(),
                 )
 
             self.status_code = response.status_code

--- a/packages/shared/src/five08/tls.py
+++ b/packages/shared/src/five08/tls.py
@@ -1,0 +1,16 @@
+"""Shared TLS helpers for outbound HTTP clients."""
+
+import os
+from functools import lru_cache
+
+import certifi
+
+
+@lru_cache(maxsize=1)
+def default_ca_bundle_path() -> str:
+    """Return a valid CA bundle path, ignoring stale inherited overrides."""
+    for env_var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "SSL_CERT_FILE"):
+        candidate = os.getenv(env_var, "").strip()
+        if candidate and os.path.exists(candidate):
+            return candidate
+    return certifi.where()

--- a/packages/shared/src/five08/tls.py
+++ b/packages/shared/src/five08/tls.py
@@ -11,6 +11,6 @@ def default_ca_bundle_path() -> str:
     """Return a valid CA bundle path, ignoring stale inherited overrides."""
     for env_var in ("REQUESTS_CA_BUNDLE", "CURL_CA_BUNDLE", "SSL_CERT_FILE"):
         candidate = os.getenv(env_var, "").strip()
-        if candidate and os.path.exists(candidate):
+        if candidate and os.path.isfile(candidate) and os.access(candidate, os.R_OK):
             return candidate
     return certifi.where()

--- a/tests/unit/test_authentik_client.py
+++ b/tests/unit/test_authentik_client.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from five08.clients.authentik import AuthentikAPIError, AuthentikClient
+from five08.tls import default_ca_bundle_path
 
 
 def test_create_user_posts_expected_payload() -> None:
@@ -45,6 +46,7 @@ def test_create_user_posts_expected_payload() -> None:
             "email": "jane@508.dev",
         },
         timeout=20.0,
+        verify=default_ca_bundle_path(),
         allow_redirects=False,
     )
 
@@ -122,6 +124,7 @@ def test_send_recovery_email_posts_required_stage() -> None:
         params=None,
         json={"email_stage": "3fa85f64-5717-4562-b3fc-2c963f66afa6"},
         timeout=20.0,
+        verify=default_ca_bundle_path(),
         allow_redirects=False,
     )
 

--- a/tests/unit/test_discord_bot_client.py
+++ b/tests/unit/test_discord_bot_client.py
@@ -9,6 +9,7 @@ from five08.clients.discord_bot import (
     DiscordBotClient,
     grant_member_role_for_signed_agreement,
 )
+from five08.tls import default_ca_bundle_path
 
 
 def test_grant_member_role_posts_expected_payload() -> None:
@@ -48,6 +49,7 @@ def test_grant_member_role_posts_expected_payload() -> None:
             "completed_at": "2026-03-25 12:00:00",
         },
         timeout=10.0,
+        verify=default_ca_bundle_path(),
     )
 
 
@@ -93,4 +95,5 @@ def test_request_omits_json_argument_when_payload_is_none() -> None:
             "X-API-Secret": "secret",
         },
         timeout=10.0,
+        verify=default_ca_bundle_path(),
     )

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from five08.clients.docuseal import DocusealAPIError, create_member_agreement_submission
+from five08.tls import default_ca_bundle_path
 
 
 def test_create_member_agreement_submission_posts_expected_payload() -> None:
@@ -46,6 +47,7 @@ def test_create_member_agreement_submission_posts_expected_payload() -> None:
             ],
         },
         timeout=20.0,
+        verify=default_ca_bundle_path(),
     )
 
 

--- a/tests/unit/test_espo_client.py
+++ b/tests/unit/test_espo_client.py
@@ -1,0 +1,31 @@
+"""Unit tests for the shared Espo client."""
+
+from unittest.mock import Mock, patch
+
+from five08.clients.espo import EspoClient
+from five08.tls import default_ca_bundle_path
+
+
+def test_list_contacts_uses_explicit_ca_bundle() -> None:
+    """Espo requests should pin the repo's certifi bundle explicitly."""
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.content = b'{"list": [], "total": 0}'
+    mock_response.json.return_value = {"list": [], "total": 0}
+
+    with patch(
+        "five08.clients.espo.requests.request",
+        return_value=mock_response,
+    ) as mock_request:
+        result = EspoClient("https://crm.example.com", "secret").list_contacts(
+            {"offset": 0, "maxSize": 50}
+        )
+
+    assert result == {"list": [], "total": 0}
+    mock_request.assert_called_once_with(
+        "GET",
+        "https://crm.example.com/api/v1/Contact?offset=0&maxSize=50",
+        headers={"X-Api-Key": "secret"},
+        timeout=20.0,
+        verify=default_ca_bundle_path(),
+    )

--- a/tests/unit/test_kimai_api_client.py
+++ b/tests/unit/test_kimai_api_client.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock, patch
 from datetime import datetime
 
 from five08.clients.kimai import KimaiAPI, KimaiAPIError
+from five08.tls import default_ca_bundle_path
 
 
 class TestKimaiAPI:
@@ -59,6 +60,7 @@ class TestKimaiAPI:
             assert result == [{"id": 1, "name": "Test Project"}]
             assert kimai_api.status_code == 200
             mock_request.assert_called_once()
+            assert mock_request.call_args.kwargs["verify"] == default_ca_bundle_path()
 
     def test_request_post_success(self, kimai_api):
         """Test successful POST request."""
@@ -75,6 +77,7 @@ class TestKimaiAPI:
             assert result == {"id": 1, "name": "New Project"}
             assert kimai_api.status_code == 201
             mock_request.assert_called_once()
+            assert mock_request.call_args.kwargs["verify"] == default_ca_bundle_path()
 
     def test_request_empty_response(self, kimai_api):
         """Test request with empty response content."""

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import tempfile
-
 import certifi
 
 from five08.tls import default_ca_bundle_path
@@ -11,22 +9,43 @@ from five08.tls import default_ca_bundle_path
 
 def test_default_ca_bundle_path_falls_back_when_env_path_is_stale(
     monkeypatch,
+    tmp_path,
 ) -> None:
     """Stale inherited CA bundle paths should not break outbound requests."""
-    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/missing-ca.pem")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path / "missing-ca.pem"))
     default_ca_bundle_path.cache_clear()
 
-    assert default_ca_bundle_path() == certifi.where()
-
-    default_ca_bundle_path.cache_clear()
-
-
-def test_default_ca_bundle_path_preserves_valid_env_override(monkeypatch) -> None:
-    """Valid custom CA bundle paths should still be honored."""
-    with tempfile.NamedTemporaryFile() as bundle:
-        monkeypatch.setenv("REQUESTS_CA_BUNDLE", bundle.name)
+    try:
+        assert default_ca_bundle_path() == certifi.where()
+    finally:
         default_ca_bundle_path.cache_clear()
 
-        assert default_ca_bundle_path() == bundle.name
 
+def test_default_ca_bundle_path_falls_back_when_env_path_is_directory(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Directory overrides should be ignored because requests expects a file."""
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(tmp_path))
     default_ca_bundle_path.cache_clear()
+
+    try:
+        assert default_ca_bundle_path() == certifi.where()
+    finally:
+        default_ca_bundle_path.cache_clear()
+
+
+def test_default_ca_bundle_path_preserves_valid_env_override(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Valid custom CA bundle paths should still be honored."""
+    bundle = tmp_path / "custom-ca.pem"
+    bundle.write_text("", encoding="utf-8")
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", str(bundle))
+    default_ca_bundle_path.cache_clear()
+
+    try:
+        assert default_ca_bundle_path() == str(bundle)
+    finally:
+        default_ca_bundle_path.cache_clear()

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -1,0 +1,32 @@
+"""Unit tests for shared TLS helper behavior."""
+
+from __future__ import annotations
+
+import tempfile
+
+import certifi
+
+from five08.tls import default_ca_bundle_path
+
+
+def test_default_ca_bundle_path_falls_back_when_env_path_is_stale(
+    monkeypatch,
+) -> None:
+    """Stale inherited CA bundle paths should not break outbound requests."""
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/tmp/missing-ca.pem")
+    default_ca_bundle_path.cache_clear()
+
+    assert default_ca_bundle_path() == certifi.where()
+
+    default_ca_bundle_path.cache_clear()
+
+
+def test_default_ca_bundle_path_preserves_valid_env_override(monkeypatch) -> None:
+    """Valid custom CA bundle paths should still be honored."""
+    with tempfile.NamedTemporaryFile() as bundle:
+        monkeypatch.setenv("REQUESTS_CA_BUNDLE", bundle.name)
+        default_ca_bundle_path.cache_clear()
+
+        assert default_ca_bundle_path() == bundle.name
+
+    default_ca_bundle_path.cache_clear()


### PR DESCRIPTION
## Description
- Add a shared TLS helper that preserves valid custom CA bundle overrides and falls back to this workspace's `certifi` bundle when inherited env paths are stale.
- Route the shared `requests` clients through that helper so worker CRM sync and other outbound calls do not fail on deleted worktree CA bundle paths.
- Add unit coverage for the TLS helper and explicit `verify=` wiring across the shared clients.

## Related Issue
- N/A

## How Has This Been Tested?
- `uv run pytest tests/unit/test_tls.py tests/unit/test_espo_client.py tests/unit/test_authentik_client.py tests/unit/test_discord_bot_client.py tests/unit/test_docuseal_client.py tests/unit/test_kimai_api_client.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * API clients now use explicit TLS certificate verification for secure connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->