### PR TITLE
fix: scope website www normalization

### DIFF
--- a/packages/shared/src/five08/crm_normalization.py
+++ b/packages/shared/src/five08/crm_normalization.py
@@ -931,22 +931,19 @@ def normalize_website_url(
     if disallowed_host_predicate and disallowed_host_predicate(policy_host):
         return None
 
+    strip_www = _should_strip_www_subdomain(host)
     normalized_netloc = parsed.netloc
     lower_netloc = parsed.netloc.lower()
-    if lower_netloc.startswith("www.") and _should_strip_www_subdomain(host):
+    if lower_netloc.startswith("www.") and strip_www:
         normalized_netloc = parsed.netloc[4:]
-    elif (
-        host
-        and lower_netloc.startswith(f"www.{host}")
-        and _should_strip_www_subdomain(host)
-    ):
+    elif host and lower_netloc.startswith(f"www.{host}") and strip_www:
         normalized_netloc = parsed.netloc.replace(parsed.netloc[:4], "", 1)
 
     parsed = parsed._replace(netloc=normalized_netloc)
     normalized = parsed.geturl().rstrip("/")
-    if normalized.startswith("https://www.") and _should_strip_www_subdomain(host):
+    if normalized.startswith("https://www.") and strip_www:
         normalized = normalized.replace("https://www.", "https://", 1)
-    elif normalized.startswith("http://www.") and _should_strip_www_subdomain(host):
+    elif normalized.startswith("http://www.") and strip_www:
         normalized = normalized.replace("http://www.", "http://", 1)
     return normalized
 

--- a/packages/shared/src/five08/crm_normalization.py
+++ b/packages/shared/src/five08/crm_normalization.py
@@ -105,6 +105,19 @@ _CANADA_PROVINCE_ABBREVIATIONS: dict[str, str] = {
 _CANADA_PROVINCE_NAMES: dict[str, str] = {
     value.casefold(): value for value in _CANADA_PROVINCE_ABBREVIATIONS.values()
 }
+_WWW_CANONICAL_HOST_SUFFIXES = frozenset(
+    {
+        "facebook.com",
+        "github.com",
+        "instagram.com",
+        "linkedin.com",
+        "threads.net",
+        "tiktok.com",
+        "twitter.com",
+        "x.com",
+        "youtube.com",
+    }
+)
 _LOCATION_STOPWORDS = frozenset(
     {
         "account",
@@ -896,26 +909,29 @@ def normalize_website_url(
         return None
 
     host = parsed.hostname or ""
-    if host.lower().startswith("www."):
-        host = host[4:]
     if not host:
         return None
 
-    if disallowed_host_predicate and disallowed_host_predicate(host):
+    policy_host = host[4:] if host.lower().startswith("www.") else host
+    if disallowed_host_predicate and disallowed_host_predicate(policy_host):
         return None
 
     normalized_netloc = parsed.netloc
     lower_netloc = parsed.netloc.lower()
-    if lower_netloc.startswith("www."):
+    if lower_netloc.startswith("www.") and _should_strip_www_subdomain(host):
         normalized_netloc = parsed.netloc[4:]
-    elif host and lower_netloc.startswith(f"www.{host}"):
+    elif (
+        host
+        and lower_netloc.startswith(f"www.{host}")
+        and _should_strip_www_subdomain(host)
+    ):
         normalized_netloc = parsed.netloc.replace(parsed.netloc[:4], "", 1)
 
     parsed = parsed._replace(netloc=normalized_netloc)
     normalized = parsed.geturl().rstrip("/")
-    if normalized.startswith("https://www."):
+    if normalized.startswith("https://www.") and _should_strip_www_subdomain(host):
         normalized = normalized.replace("https://www.", "https://", 1)
-    elif normalized.startswith("http://www."):
+    elif normalized.startswith("http://www.") and _should_strip_www_subdomain(host):
         normalized = normalized.replace("http://www.", "http://", 1)
     return normalized
 
@@ -927,7 +943,7 @@ def normalized_website_identity_key(normalized_url: str) -> str | None:
         return normalized_url.casefold()
 
     netloc = parsed.netloc.casefold()
-    if netloc.startswith("www."):
+    if netloc.startswith("www.") and _should_strip_www_subdomain(parsed.hostname or ""):
         netloc = netloc[4:]
     path = re.sub(r"/+", "/", parsed.path or "").rstrip("/").casefold()
     query = parsed.query.casefold()
@@ -951,3 +967,13 @@ def website_identity_key(
     if normalized is None:
         return None
     return normalized_website_identity_key(normalized)
+
+
+def _should_strip_www_subdomain(host: str) -> bool:
+    normalized_host = host.casefold()
+    if normalized_host.startswith("www."):
+        normalized_host = normalized_host[4:]
+    return any(
+        normalized_host == suffix or normalized_host.endswith(f".{suffix}")
+        for suffix in _WWW_CANONICAL_HOST_SUFFIXES
+    )

--- a/packages/shared/src/five08/crm_normalization.py
+++ b/packages/shared/src/five08/crm_normalization.py
@@ -107,15 +107,30 @@ _CANADA_PROVINCE_NAMES: dict[str, str] = {
 }
 _WWW_CANONICAL_HOST_SUFFIXES = frozenset(
     {
+        "bsky.app",
         "facebook.com",
+        "fb.com",
+        "fb.me",
+        "gitlab.com",
         "github.com",
+        "huggingface.co",
         "instagram.com",
+        "kaggle.com",
         "linkedin.com",
+        "mastodon.social",
+        "medium.com",
+        "pinterest.com",
+        "stackoverflow.com",
+        "substack.com",
+        "t.me",
+        "telegram.me",
         "threads.net",
         "tiktok.com",
+        "twitch.tv",
         "twitter.com",
         "x.com",
         "youtube.com",
+        "youtube-nocookie.com",
     }
 )
 _LOCATION_STOPWORDS = frozenset(

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -1089,27 +1089,36 @@ class ResumeProfileProcessor:
         if not proposed:
             return
 
-        if callable(is_blocked) and is_blocked(proposed):
+        normalized_proposed = proposed
+        normalized_current: str | None = (
+            str(current).strip() if current is not None else None
+        )
+        if crm_field == LINKEDIN_FIELD:
+            normalized_proposed = self._normalize_linkedin_profile_url(proposed) or ""
+            if not normalized_proposed:
+                return
+            normalized_current = self._normalize_linkedin_profile_url(current)
+
+        if callable(is_blocked) and is_blocked(normalized_proposed):
             skipped.append(
                 ResumeSkipReason(
                     field=crm_field,
-                    value=proposed,
+                    value=normalized_proposed,
                     reason=blocked_reason or "Update blocked by policy",
                 )
             )
             return
 
-        current_value = str(current).strip() if current is not None else None
-        if current_value and current_value == proposed:
+        if normalized_current and normalized_current == normalized_proposed:
             return
 
-        proposed_updates[crm_field] = proposed
+        proposed_updates[crm_field] = normalized_proposed
         proposed_changes.append(
             ResumeFieldChange(
                 field=crm_field,
                 label=label,
-                current=current_value,
-                proposed=proposed,
+                current=str(current).strip() if current is not None else None,
+                proposed=normalized_proposed,
                 reason="Extracted from uploaded resume",
             )
         )

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -1090,14 +1090,16 @@ class ResumeProfileProcessor:
             return
 
         normalized_proposed = proposed
-        normalized_current: str | None = (
+        display_current: str | None = (
             str(current).strip() if current is not None else None
         )
+        normalized_current: str | None = display_current
         if crm_field == LINKEDIN_FIELD:
             normalized_proposed = self._normalize_linkedin_profile_url(proposed) or ""
             if not normalized_proposed:
                 return
             normalized_current = self._normalize_linkedin_profile_url(current)
+            display_current = normalized_current
 
         if callable(is_blocked) and is_blocked(normalized_proposed):
             skipped.append(
@@ -1117,7 +1119,7 @@ class ResumeProfileProcessor:
             ResumeFieldChange(
                 field=crm_field,
                 label=label,
-                current=str(current).strip() if current is not None else None,
+                current=display_current,
                 proposed=normalized_proposed,
                 reason="Extracted from uploaded resume",
             )

--- a/tests/unit/test_crm_normalization.py
+++ b/tests/unit/test_crm_normalization.py
@@ -32,12 +32,24 @@ def test_normalize_role_and_roles_dedupe() -> None:
 
 
 def test_normalize_website_url_scheme_less_and_cleanup() -> None:
-    assert normalize_website_url("www.Example.com/path/") == "https://Example.com/path"
+    assert (
+        normalize_website_url("www.Example.com/path/") == "https://www.Example.com/path"
+    )
     assert (
         normalize_website_url("portfolio.example.com")
         == "https://portfolio.example.com"
     )
     assert normalize_website_url("mailto:test@example.com") is None
+
+
+def test_normalize_website_url_strips_www_for_known_social_hosts() -> None:
+    assert (
+        normalize_website_url("https://www.linkedin.com/in/wumichaelm/")
+        == "https://linkedin.com/in/wumichaelm"
+    )
+    assert (
+        normalize_website_url("www.github.com/octocat/") == "https://github.com/octocat"
+    )
 
 
 def test_normalize_website_url_respects_disallowed_host_predicate() -> None:
@@ -54,6 +66,18 @@ def test_website_identity_key_ignores_scheme_and_path_casing() -> None:
     assert website_identity_key("http://Example.com/About") == website_identity_key(
         "https://example.com/about/"
     )
+
+
+def test_website_identity_key_preserves_www_for_personal_sites() -> None:
+    assert website_identity_key(
+        "https://www.example.com/about"
+    ) != website_identity_key("https://example.com/about")
+
+
+def test_website_identity_key_ignores_www_for_known_social_hosts() -> None:
+    assert website_identity_key(
+        "https://www.linkedin.com/in/wumichaelm"
+    ) == website_identity_key("https://linkedin.com/in/wumichaelm/")
 
 
 def test_normalize_country_and_city() -> None:

--- a/tests/unit/test_resume_extractor.py
+++ b/tests/unit/test_resume_extractor.py
@@ -44,7 +44,7 @@ def test_extract_website_links_includes_scheme_less_domains() -> None:
     )
 
     assert "https://michaelwu.dev" in links
-    assert "https://example.org/about" in links
+    assert "https://www.example.org/about" in links
     assert "https://example.com" not in links
 
 

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -203,7 +203,7 @@ def test_extract_profile_proposal_merges_and_serializes_website_and_skill_attrs(
     assert result.success is True
     assert result.proposed_updates["cWebsiteLink"] == [
         "https://portfolio.example.com",
-        "https://blog.example.com",
+        "https://www.blog.example.com",
     ]
     assert result.proposed_updates["skills"] == ["typescript", "react native"]
     assert isinstance(result.proposed_updates["cSkillAttrs"], str)
@@ -211,6 +211,51 @@ def test_extract_profile_proposal_merges_and_serializes_website_and_skill_attrs(
         "react native": {"strength": 3},
         "typescript": {"strength": 4},
     }
+
+
+def test_extract_profile_proposal_skips_linkedin_www_only_change() -> None:
+    """LinkedIn compare should treat www-only normalization as unchanged."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = lambda v: (
+        str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+        "cLinkedIn": "https://www.linkedin.com/in/wumichaelm/",
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-linkedin-www"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url="https://linkedin.com/in/wumichaelm",
+        phone=None,
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=[],
+        skill_attrs={},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-linkedin-www",
+        attachment_id="att-linkedin-www",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert "cLinkedIn" not in result.proposed_updates
+    assert not any(item.field == "cLinkedIn" for item in result.proposed_changes)
 
 
 def test_extract_profile_proposal_merges_and_serializes_social_links() -> None:
@@ -723,7 +768,7 @@ def test_build_initial_external_source_candidates_preserves_www_host_from_crm() 
     assert len(candidates) == 1
     assert candidates[0].label == "Personal Website"
     assert candidates[0].url == "https://www.example.com/about"
-    assert candidates[0].source_key == "website:example.com/about"
+    assert candidates[0].source_key == "website:www.example.com/about"
 
 
 def test_build_initial_external_source_candidates_skips_duplicate_linkedin_website() -> (
@@ -2148,6 +2193,54 @@ def test_extract_profile_proposal_deduplicates_existing_and_extracted_websites_b
 
     assert result.success is True
     assert "cWebsiteLink" not in result.proposed_updates
+
+
+def test_extract_profile_proposal_keeps_www_distinct_for_personal_websites() -> None:
+    """Personal websites should not collapse www and apex hosts together."""
+    processor = ResumeProfileProcessor()
+    processor.crm = Mock()
+    processor.extractor = Mock()
+    processor.skills_extractor = Mock()
+    processor.document_processor = Mock()
+    processor._record_processing_run = Mock()
+    processor.skills_extractor.canonicalize_skill.side_effect = lambda v: (
+        str(v).strip().lower()
+    )
+
+    processor.crm.get_contact.return_value = {
+        "emailAddress": "member@example.com",
+        "cWebsiteLink": ["https://example.com"],
+    }
+    processor.crm.download_attachment.return_value = b"resume-bytes"
+    processor.document_processor.extract_text.return_value = "resume text"
+    processor.document_processor.get_content_hash.return_value = "hash-www-distinct"
+    processor.extractor.extract.return_value = ResumeExtractedProfile(
+        email=None,
+        github_username=None,
+        linkedin_url=None,
+        phone=None,
+        website_links=["https://www.example.com"],
+        confidence=0.9,
+        source="gpt-4o-mini",
+    )
+    processor.skills_extractor.extract_skills.return_value = ExtractedSkills(
+        skills=[],
+        skill_attrs={},
+        confidence=0.8,
+        source="gpt-4o-mini",
+    )
+
+    result = processor.extract_profile_proposal(
+        contact_id="contact-www-distinct",
+        attachment_id="att-www-distinct",
+        filename="resume.pdf",
+    )
+
+    assert result.success is True
+    assert result.proposed_updates["cWebsiteLink"] == [
+        "https://example.com",
+        "https://www.example.com",
+    ]
 
 
 def test_extract_profile_proposal_deduplicates_skills_in_confirmation() -> None:


### PR DESCRIPTION
## Description
Limit `www` canonicalization to known social hosts, preserve distinct personal website hosts during CRM merge/dedupe, and normalize LinkedIn comparisons so profile reprocesses do not show false-only URL changes.

## Related Issue
None.

## How Has This Been Tested?
`uv run pytest tests/unit/test_crm_normalization.py tests/unit/test_resume_profile_processor.py`
`uv run ruff check packages/shared/src/five08/crm_normalization.py packages/shared/src/five08/resume_profile_processor.py tests/unit/test_crm_normalization.py tests/unit/test_resume_profile_processor.py`