### PR TITLE
fix: retry transient CRM profile fetches

### DIFF
--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -92,6 +92,10 @@ PROFILE_SOURCE_BLOCKED_PATTERNS = (
     re.compile(r"unusual traffic", re.IGNORECASE),
     re.compile(r"verify you are human", re.IGNORECASE),
 )
+PROFILE_SOURCE_TRANSIENT_BROWSER_ERROR_MARKERS = (
+    "target page, context or browser has been closed",
+    "browser has been closed",
+)
 PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_CHARS = 250
 PROFILE_SOURCE_JS_SPARSE_TEXT_MAX_WORDS = 40
 PROFILE_SOURCE_JS_HTML_MIN_CHARS = 2000
@@ -1488,13 +1492,20 @@ class ResumeProfileProcessor:
                     allow_javascript_fallback=candidate.label == "Personal Website",
                 )
             except Exception as exc:
+                logger.warning(
+                    "External profile source fetch failed label=%s origin=%s url=%s error=%s",
+                    candidate.label,
+                    candidate.origin,
+                    candidate.url,
+                    exc,
+                )
                 enrichments.append(
                     ResumeSourceEnrichment(
                         label=candidate.label,
                         url=candidate.url,
                         origin=candidate.origin,
                         status="failed",
-                        detail=str(exc),
+                        detail=self._summarize_external_profile_source_error(exc),
                     )
                 )
                 continue
@@ -1527,6 +1538,20 @@ class ResumeProfileProcessor:
             )
 
         return extra_sources, enrichments
+
+    @staticmethod
+    def _summarize_external_profile_source_error(error: Exception) -> str:
+        detail = str(error).strip()
+        if not detail:
+            return "External source fetch failed"
+        if "Browser logs:" in detail:
+            detail = detail.split("Browser logs:", 1)[0].strip()
+        lines = [line.strip() for line in detail.splitlines() if line.strip()]
+        if lines:
+            detail = lines[0]
+        if len(detail) > 240:
+            detail = f"{detail[:237].rstrip()}..."
+        return detail
 
     def _fetch_external_profile_source_text(
         self,
@@ -1567,6 +1592,7 @@ class ResumeProfileProcessor:
                     break
                 except ValueError as exc:
                     last_fetch_error = exc
+                    retryable_browser_error = False
                     if (
                         allow_javascript_fallback
                         and self._should_reset_profile_source_session(str(exc))
@@ -1581,9 +1607,10 @@ class ResumeProfileProcessor:
                             )
                         except ValueError as browser_exc:
                             last_fetch_error = browser_exc
-                            if not self._is_retryable_profile_fetch_error(
-                                str(browser_exc)
-                            ):
+                            retryable_browser_error = (
+                                self._is_retryable_profile_fetch_error(str(browser_exc))
+                            )
+                            if not retryable_browser_error:
                                 raise browser_exc
                         else:
                             return ProfileSourceFetchDiagnostics(
@@ -1597,6 +1624,8 @@ class ResumeProfileProcessor:
                                 browser_text=direct_browser_text,
                                 error=None,
                             )
+                    if retryable_browser_error:
+                        continue
                     if not self._is_retryable_profile_fetch_error(str(exc)):
                         raise
 
@@ -1704,7 +1733,7 @@ class ResumeProfileProcessor:
     @staticmethod
     def _is_retryable_profile_fetch_error(error: str) -> bool:
         normalized = error.casefold()
-        return "profile fetch failed:" in normalized and any(
+        if "profile fetch failed:" in normalized and any(
             marker in normalized
             for marker in (
                 "tls connect error",
@@ -1712,6 +1741,11 @@ class ResumeProfileProcessor:
                 "tlsv1 alert internal error",
                 "ssl:",
             )
+        ):
+            return True
+        return "javascript profile fetch failed:" in normalized and any(
+            marker in normalized
+            for marker in PROFILE_SOURCE_TRANSIENT_BROWSER_ERROR_MARKERS
         )
 
     @staticmethod
@@ -2326,6 +2360,7 @@ class ResumeProfileProcessor:
                 "scraping block",
                 "timed out",
                 "timeout",
+                *PROFILE_SOURCE_TRANSIENT_BROWSER_ERROR_MARKERS,
             )
         )
 

--- a/tests/unit/test_resume_profile_processor.py
+++ b/tests/unit/test_resume_profile_processor.py
@@ -2,10 +2,11 @@
 
 import ipaddress
 import json
+import logging
 import sys
 from datetime import datetime
-from typing import Any
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from unittest.mock import ANY, MagicMock, Mock, call, patch
@@ -482,6 +483,45 @@ def test_extract_profile_proposal_fails_open_when_initial_enrichment_extract_err
     )
 
 
+def test_fetch_external_profile_sources_redacts_browser_logs_from_detail(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """User-facing enrichment details should omit embedded browser logs."""
+    processor = ResumeProfileProcessor()
+    processor._fetch_external_profile_source_text = Mock(
+        side_effect=ValueError(
+            "JavaScript profile fetch failed: BrowserType.launch: "
+            "Target page, context or browser has been closed "
+            "Browser logs:\n"
+            "  <launching> /app/.cloakbrowser/chromium/chrome --disable-extensions"
+        )
+    )
+
+    with caplog.at_level(logging.WARNING):
+        extra_sources, enrichments = processor._fetch_external_profile_sources(
+            [
+                _ExternalProfileSourceCandidate(
+                    label="Personal Website",
+                    url="https://example.com",
+                    origin="crm",
+                    source_key="website:example.com",
+                )
+            ],
+            seen_source_keys=set(),
+            source_label_counts={},
+        )
+
+    assert extra_sources == {}
+    assert [item.status for item in enrichments] == ["failed"]
+    assert enrichments[0].detail == (
+        "JavaScript profile fetch failed: BrowserType.launch: Target page, "
+        "context or browser has been closed"
+    )
+    assert "Browser logs:" not in (enrichments[0].detail or "")
+    assert "External profile source fetch failed" in caplog.text
+    assert "Browser logs:" in caplog.text
+
+
 def test_extract_profile_proposal_fetches_confirmed_website_and_github_together() -> (
     None
 ):
@@ -887,6 +927,47 @@ def test_inspect_profile_source_fetch_raises_non_retryable_direct_browser_error(
     processor._fetch_external_profile_source_response.assert_called_once_with(
         "https://candidate-one.example.com",
         session=ANY,
+    )
+
+
+def test_inspect_profile_source_fetch_retries_transient_direct_browser_error() -> None:
+    """Transient browser-launch closures should fall through to the next URL candidate."""
+    processor = ResumeProfileProcessor()
+    processor._fetch_external_profile_source_response = Mock(
+        side_effect=[
+            ValueError("Profile fetch hit a scraping block; reset session"),
+            ProfileSourceHttpResponse(
+                final_url="https://www.example.com/",
+                status_code=200,
+                headers={"content-type": "text/html"},
+                body=b"<html><body>stable fallback</body></html>",
+            ),
+        ]
+    )
+    processor._fetch_external_profile_source_text_with_browser_direct = Mock(
+        side_effect=ValueError(
+            "JavaScript profile fetch failed: BrowserType.launch: "
+            "Target page, context or browser has been closed"
+        )
+    )
+
+    diagnostics = processor.inspect_profile_source_fetch(
+        "https://example.com/",
+        allow_javascript_fallback=True,
+    )
+
+    assert diagnostics.final_url == "https://www.example.com/"
+    assert diagnostics.selected_text == "stable fallback"
+    assert diagnostics.browser_attempted is True
+    assert diagnostics.browser_used is False
+    processor._fetch_external_profile_source_response.assert_has_calls(
+        [
+            call("https://example.com/", session=ANY),
+            call("https://www.example.com/", session=ANY),
+        ]
+    )
+    processor._fetch_external_profile_source_text_with_browser_direct.assert_called_once_with(
+        "https://example.com/"
     )
 
 


### PR DESCRIPTION
## Description
- Retry transient CloakBrowser and Playwright closure errors during CRM personal website fetches so the processor can continue to alternate URL candidates instead of failing immediately.
- Redact embedded browser launch logs from CRM-facing external source errors while keeping the full raw exception in application logs.
- Add regression coverage for transient browser retries and browser log redaction.

## Related Issue
- None.

## How Has This Been Tested?
- `uv run pytest tests/unit/test_resume_profile_processor.py -k "redacts_browser_logs_from_detail or transient_direct_browser_error or direct_browser_error or fails_open_when_initial_enrichment_extract_errors or retries_with_fresh_session"`
