### PR TITLE
feat: add bulk profile reprocess

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -8525,12 +8525,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
             lines.append(f"- {name} ({contact_id}) - {reason}; input: {input_label}")
 
-        def _truncate(value: str, limit: int) -> str:
-            if len(value) <= limit:
-                return value
-            return value[: limit - 3].rstrip() + "..."
-
-        class BulkResumeReprocessSelect(discord.ui.Select):
+        class BulkProfileReviewSelect(discord.ui.Select):
             def __init__(
                 self,
                 crm_cog: Any,
@@ -8545,10 +8540,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     if not item_id:
                         continue
                     label = str(item.get("name") or item_id)
-                    label = _truncate(label, 100)
-                    description = _truncate(
+                    label = _truncate_component_label(label, limit=100)
+                    description = _truncate_component_label(
                         self.crm_cog._bulk_resume_missing_summary(item),
-                        100,
+                        limit=100,
                     )
                     select_options.append(
                         discord.SelectOption(
@@ -8558,7 +8553,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         )
                     )
                 super().__init__(
-                    placeholder="Select a contact to review for enrichment",
+                    placeholder=_truncate_component_placeholder(
+                        "Select a contact to review for enrichment"
+                    ),
                     min_values=1,
                     max_values=1,
                     options=select_options,
@@ -8580,7 +8577,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     search_term="bulk_missing_fields",
                 )
 
-        class BulkResumeReprocessSelectView(discord.ui.View):
+        class BulkProfileReviewSelectView(discord.ui.View):
             def __init__(
                 self,
                 crm_cog: Any,
@@ -8588,7 +8585,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             ) -> None:
                 super().__init__(timeout=600)
                 self.add_item(
-                    BulkResumeReprocessSelect(
+                    BulkProfileReviewSelect(
                         crm_cog=crm_cog,
                         options=options,
                         contact_lookup=contact_lookup,
@@ -8610,6 +8607,23 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 f"{filter_label}, showing {len(contact_lookup)}:"
             )
 
+        message_parts = [summary, *lines]
+        messages: list[str] = []
+        current_message = ""
+        for part in message_parts:
+            candidate = part if not current_message else f"{current_message}\n{part}"
+            if len(candidate) <= 2000:
+                current_message = candidate
+                continue
+            if current_message:
+                messages.append(current_message)
+                current_message = part
+                continue
+            messages.append(_truncate_component_placeholder(part, limit=2000))
+            current_message = ""
+        if current_message:
+            messages.append(current_message)
+
         self._audit_command(
             interaction=interaction,
             action=action_name,
@@ -8621,11 +8635,18 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 "include_external_profile_sources": include_external_profile_sources,
             },
         )
-        await interaction.followup.send(
-            summary + "\n" + "\n".join(lines),
-            view=BulkResumeReprocessSelectView(self, contacts),
-            ephemeral=True,
-        )
+        for index, message in enumerate(messages):
+            if index == 0:
+                await interaction.followup.send(
+                    message,
+                    view=BulkProfileReviewSelectView(self, contacts),
+                    ephemeral=True,
+                )
+                continue
+            await interaction.followup.send(
+                message,
+                ephemeral=True,
+            )
 
     async def _get_latest_resume_attachment_for_contact(
         self, contact_id: str
@@ -10424,8 +10445,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
     @app_commands.command(
         name="bulk-reprocess-profiles",
         description=(
-            "Find contacts missing country/timezone, skills/roles, or seniority "
-            "and reprocess profiles from resumes or CRM profile sources"
+            "Review contacts missing key fields for resume or profile-source reprocessing"
         ),
     )
     @app_commands.describe(

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -8193,7 +8193,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         """Resolve search term for resume reprocessing lookup."""
         select_fields = (
             "id,name,emailAddress,c508Email,cDiscordUsername,resumeIds,resumeNames,"
-            "cWebsiteLink,cGitHubUsername"
+            f"cWebsiteLink,cGitHubUsername,{LINKEDIN_FIELD}"
         )
         mention_user_id = self._extract_discord_id_from_mention(search_term)
         if mention_user_id:
@@ -8254,6 +8254,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
     @staticmethod
     def _contact_has_external_profile_sources(contact: dict[str, Any]) -> bool:
+        if (
+            ResumeProfileProcessor._normalize_linkedin_profile_url(
+                contact.get(LINKEDIN_FIELD)
+            )
+            is not None
+        ):
+            return True
         website_links = (
             ResumeUpdateConfirmationView._normalize_website_links_for_reparse(
                 contact.get("cWebsiteLink")
@@ -8267,6 +8274,31 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             is not None
         )
+
+    def _contact_external_profile_source_summary(self, contact: dict[str, Any]) -> str:
+        sources: list[str] = []
+        if (
+            ResumeProfileProcessor._normalize_linkedin_profile_url(
+                contact.get(LINKEDIN_FIELD)
+            )
+            is not None
+        ):
+            sources.append("LinkedIn")
+        if (
+            ResumeProfileProcessor._normalize_github_username(
+                contact.get("cGitHubUsername")
+            )
+            is not None
+        ):
+            sources.append("GitHub")
+        website_links = (
+            ResumeUpdateConfirmationView._normalize_website_links_for_reparse(
+                contact.get("cWebsiteLink")
+            )
+        )
+        if website_links:
+            sources.append("Website")
+        return ", ".join(sources) if sources else "none"
 
     def _bulk_resume_missing_flags(self, contact: dict[str, Any]) -> dict[str, bool]:
         missing_country = self._is_blank_crm_field(contact.get("addressCountry"))
@@ -8325,10 +8357,23 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
     async def _search_contacts_for_bulk_resume_reprocess(
         self, *, limit: int, offset: int
     ) -> tuple[list[dict[str, Any]], int | None]:
-        """Fetch contacts missing key resume-derived fields and with a resume on file."""
+        return await self._search_contacts_for_bulk_profile_reprocess(
+            limit=limit,
+            offset=offset,
+            include_external_profile_sources=False,
+        )
+
+    async def _search_contacts_for_bulk_profile_reprocess(
+        self,
+        *,
+        limit: int,
+        offset: int,
+        include_external_profile_sources: bool,
+    ) -> tuple[list[dict[str, Any]], int | None]:
+        """Fetch contacts missing key profile fields and reprocessable inputs."""
         select_fields = (
             "id,name,emailAddress,addressCountry,cTimezone,skills,cRoles,cSeniority,"
-            "resumeIds,resumeNames"
+            f"resumeIds,resumeNames,cWebsiteLink,cGitHubUsername,{LINKEDIN_FIELD}"
         )
         where_filters = [
             {
@@ -8385,7 +8430,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         for contact in contacts:
             if not isinstance(contact, dict):
                 continue
-            if not self._contact_has_resume(contact):
+            if not self._contact_has_resume(contact) and not (
+                include_external_profile_sources
+                and self._contact_has_external_profile_sources(contact)
+            ):
                 continue
             if not self._matches_bulk_resume_reprocess_filters(contact):
                 continue
@@ -8394,6 +8442,190 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         total_raw = result.get("total")
         total = total_raw if isinstance(total_raw, int) else None
         return filtered, total
+
+    async def _run_bulk_profile_reprocess_command(
+        self,
+        interaction: discord.Interaction,
+        *,
+        action_name: str,
+        max_results: int,
+        offset: int,
+        include_external_profile_sources: bool,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        is_steering = hasattr(
+            interaction.user, "roles"
+        ) and check_user_roles_with_hierarchy(
+            interaction.user.roles, ["Steering Committee"]
+        )
+        if not is_steering:
+            self._audit_command(
+                interaction=interaction,
+                action=action_name,
+                result="denied",
+                metadata={
+                    "reason": "missing_required_role",
+                },
+            )
+            await interaction.followup.send(
+                "You must have Steering Committee role or higher to run this."
+            )
+            return
+
+        clamped_limit = max(1, min(int(max_results or 0), 25))
+        clamped_offset = max(0, int(offset or 0))
+        contacts, total = await self._search_contacts_for_bulk_profile_reprocess(
+            limit=clamped_limit,
+            offset=clamped_offset,
+            include_external_profile_sources=include_external_profile_sources,
+        )
+
+        if not contacts:
+            self._audit_command(
+                interaction=interaction,
+                action=action_name,
+                result="success",
+                metadata={
+                    "results": 0,
+                    "offset": clamped_offset,
+                    "limit": clamped_limit,
+                },
+            )
+            await interaction.followup.send(
+                "No contacts found with missing country/timezone, skills/roles, "
+                "or seniority and reprocessable profile inputs."
+            )
+            return
+
+        if len(contacts) == 1:
+            await self._prompt_reprocess_resume_confirmation(
+                interaction=interaction,
+                contact=contacts[0],
+                search_term="bulk_missing_fields",
+            )
+            return
+
+        contact_lookup: dict[str, dict[str, Any]] = {}
+        lines: list[str] = []
+        for contact in contacts:
+            contact_id = str(contact.get("id", "")).strip()
+            if not contact_id:
+                continue
+            contact_lookup[contact_id] = contact
+            name = str(contact.get("name") or "Unknown")
+            reason = self._bulk_resume_missing_summary(contact)
+            resume_name = self._extract_latest_resume_name_from_contact(contact)
+            if resume_name or self._contact_has_resume(contact):
+                input_label = resume_name or "latest resume"
+            else:
+                input_label = (
+                    "CRM profile sources: "
+                    + self._contact_external_profile_source_summary(contact)
+                )
+            lines.append(f"- {name} ({contact_id}) - {reason}; input: {input_label}")
+
+        def _truncate(value: str, limit: int) -> str:
+            if len(value) <= limit:
+                return value
+            return value[: limit - 3].rstrip() + "..."
+
+        class BulkResumeReprocessSelect(discord.ui.Select):
+            def __init__(
+                self,
+                crm_cog: Any,
+                options: list[dict[str, Any]],
+                contact_lookup: dict[str, dict[str, Any]],
+            ) -> None:
+                self.crm_cog = crm_cog
+                self.contact_lookup = contact_lookup
+                select_options: list[discord.SelectOption] = []
+                for item in options:
+                    item_id = str(item.get("id", "")).strip()
+                    if not item_id:
+                        continue
+                    label = str(item.get("name") or item_id)
+                    label = _truncate(label, 100)
+                    description = _truncate(
+                        self.crm_cog._bulk_resume_missing_summary(item),
+                        100,
+                    )
+                    select_options.append(
+                        discord.SelectOption(
+                            label=label,
+                            value=item_id,
+                            description=description,
+                        )
+                    )
+                super().__init__(
+                    placeholder="Select a contact to review for enrichment",
+                    min_values=1,
+                    max_values=1,
+                    options=select_options,
+                )
+
+            async def callback(self, interaction: discord.Interaction) -> None:
+                contact_id = self.values[0]
+                contact = self.contact_lookup.get(contact_id)
+                if not contact:
+                    await interaction.response.send_message(
+                        "Selected contact not found. Re-run the command.",
+                        ephemeral=True,
+                    )
+                    return
+                await interaction.response.defer(ephemeral=True)
+                await self.crm_cog._prompt_reprocess_resume_confirmation(
+                    interaction=interaction,
+                    contact=contact,
+                    search_term="bulk_missing_fields",
+                )
+
+        class BulkResumeReprocessSelectView(discord.ui.View):
+            def __init__(
+                self,
+                crm_cog: Any,
+                options: list[dict[str, Any]],
+            ) -> None:
+                super().__init__(timeout=600)
+                self.add_item(
+                    BulkResumeReprocessSelect(
+                        crm_cog=crm_cog,
+                        options=options,
+                        contact_lookup=contact_lookup,
+                    )
+                )
+
+        summary = (
+            f"Found {len(contact_lookup)} contacts with missing fields. "
+            "Select one to open its enrichment confirmation:"
+        )
+        if total is not None and total > len(contact_lookup):
+            filter_label = (
+                "profile-input checks"
+                if include_external_profile_sources
+                else "resume checks"
+            )
+            summary = (
+                f"Found {total} contacts in CRM matching the filters; after "
+                f"{filter_label}, showing {len(contact_lookup)}:"
+            )
+
+        self._audit_command(
+            interaction=interaction,
+            action=action_name,
+            result="success",
+            metadata={
+                "results": len(contact_lookup),
+                "offset": clamped_offset,
+                "limit": clamped_limit,
+                "include_external_profile_sources": include_external_profile_sources,
+            },
+        )
+        await interaction.followup.send(
+            summary + "\n" + "\n".join(lines),
+            view=BulkResumeReprocessSelectView(self, contacts),
+            ephemeral=True,
+        )
 
     async def _get_latest_resume_attachment_for_contact(
         self, contact_id: str
@@ -10168,168 +10400,12 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
     ) -> None:
         """List contacts missing key resume-derived fields for reprocessing."""
         try:
-            await interaction.response.defer(ephemeral=True)
-
-            is_steering = hasattr(
-                interaction.user, "roles"
-            ) and check_user_roles_with_hierarchy(
-                interaction.user.roles, ["Steering Committee"]
-            )
-            if not is_steering:
-                self._audit_command(
-                    interaction=interaction,
-                    action="crm.bulk_reprocess_resumes",
-                    result="denied",
-                    metadata={
-                        "reason": "missing_required_role",
-                    },
-                )
-                await interaction.followup.send(
-                    "You must have Steering Committee role or higher to run this."
-                )
-                return
-
-            clamped_limit = max(1, min(int(max_results or 0), 25))
-            clamped_offset = max(0, int(offset or 0))
-            contacts, total = await self._search_contacts_for_bulk_resume_reprocess(
-                limit=clamped_limit,
-                offset=clamped_offset,
-            )
-
-            if not contacts:
-                self._audit_command(
-                    interaction=interaction,
-                    action="crm.bulk_reprocess_resumes",
-                    result="success",
-                    metadata={
-                        "results": 0,
-                        "offset": clamped_offset,
-                        "limit": clamped_limit,
-                    },
-                )
-                await interaction.followup.send(
-                    "No contacts found with missing country/timezone or skills/roles "
-                    "and a resume on file."
-                )
-                return
-
-            if len(contacts) == 1:
-                await self._prompt_reprocess_resume_confirmation(
-                    interaction=interaction,
-                    contact=contacts[0],
-                    search_term="bulk_missing_fields",
-                )
-                return
-
-            contact_lookup: dict[str, dict[str, Any]] = {}
-            lines: list[str] = []
-            for contact in contacts:
-                contact_id = str(contact.get("id", "")).strip()
-                if not contact_id:
-                    continue
-                contact_lookup[contact_id] = contact
-                name = str(contact.get("name") or "Unknown")
-                reason = self._bulk_resume_missing_summary(contact)
-                resume_name = self._extract_latest_resume_name_from_contact(contact)
-                resume_label = resume_name or "latest resume"
-                lines.append(
-                    f"- {name} ({contact_id}) - {reason}; resume: {resume_label}"
-                )
-
-            def _truncate(value: str, limit: int) -> str:
-                if len(value) <= limit:
-                    return value
-                return value[: limit - 3].rstrip() + "..."
-
-            class BulkResumeReprocessSelect(discord.ui.Select):
-                def __init__(
-                    self,
-                    crm_cog: Any,
-                    options: list[dict[str, Any]],
-                    contact_lookup: dict[str, dict[str, Any]],
-                ) -> None:
-                    self.crm_cog = crm_cog
-                    self.contact_lookup = contact_lookup
-                    select_options: list[discord.SelectOption] = []
-                    for item in options:
-                        item_id = str(item.get("id", "")).strip()
-                        if not item_id:
-                            continue
-                        label = str(item.get("name") or item_id)
-                        label = _truncate(label, 100)
-                        description = _truncate(
-                            self.crm_cog._bulk_resume_missing_summary(item),
-                            100,
-                        )
-                        select_options.append(
-                            discord.SelectOption(
-                                label=label,
-                                value=item_id,
-                                description=description,
-                            )
-                        )
-                    super().__init__(
-                        placeholder="Select a contact to reprocess",
-                        min_values=1,
-                        max_values=1,
-                        options=select_options,
-                    )
-
-                async def callback(self, interaction: discord.Interaction) -> None:
-                    contact_id = self.values[0]
-                    contact = self.contact_lookup.get(contact_id)
-                    if not contact:
-                        await interaction.response.send_message(
-                            "Selected contact not found. Re-run the command.",
-                            ephemeral=True,
-                        )
-                        return
-                    await interaction.response.defer(ephemeral=True)
-                    await self.crm_cog._start_resume_reprocess_from_contact(
-                        interaction=interaction,
-                        contact=contact,
-                        search_term="bulk_missing_fields",
-                    )
-
-            class BulkResumeReprocessSelectView(discord.ui.View):
-                def __init__(
-                    self,
-                    crm_cog: Any,
-                    options: list[dict[str, Any]],
-                ) -> None:
-                    super().__init__(timeout=600)
-                    self.add_item(
-                        BulkResumeReprocessSelect(
-                            crm_cog=crm_cog,
-                            options=options,
-                            contact_lookup=contact_lookup,
-                        )
-                    )
-
-            summary = (
-                f"Found {len(contact_lookup)} contacts with missing fields. "
-                "Select one to reprocess:"
-            )
-            if total is not None and total > len(contact_lookup):
-                summary = (
-                    f"Found {total} contacts in CRM matching the filters; after "
-                    f"resume checks, showing {len(contact_lookup)}:"
-                )
-
-            self._audit_command(
+            await self._run_bulk_profile_reprocess_command(
                 interaction=interaction,
-                action="crm.bulk_reprocess_resumes",
-                result="success",
-                metadata={
-                    "results": len(contact_lookup),
-                    "offset": clamped_offset,
-                    "limit": clamped_limit,
-                },
-            )
-            await interaction.followup.send(
-                summary + "\n" + "\n".join(lines),
-                view=BulkResumeReprocessSelectView(self, contacts),
-                ephemeral=True,
+                action_name="crm.bulk_reprocess_resumes",
+                max_results=max_results,
+                offset=offset,
+                include_external_profile_sources=False,
             )
         except Exception as exc:
             logger.error("Unexpected error in bulk_reprocess_resumes: %s", exc)
@@ -10343,6 +10419,46 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 "An unexpected error occurred while loading bulk resume results."
+            )
+
+    @app_commands.command(
+        name="bulk-reprocess-profiles",
+        description=(
+            "Find contacts missing country/timezone, skills/roles, or seniority "
+            "and reprocess profiles from resumes or CRM profile sources"
+        ),
+    )
+    @app_commands.describe(
+        max_results="Max results to list (1-25)",
+        offset="Skip this many matching contacts",
+    )
+    async def bulk_reprocess_profiles(
+        self,
+        interaction: discord.Interaction,
+        max_results: int = 25,
+        offset: int = 0,
+    ) -> None:
+        """List contacts missing key profile fields with reprocessable inputs."""
+        try:
+            await self._run_bulk_profile_reprocess_command(
+                interaction=interaction,
+                action_name="crm.bulk_reprocess_profiles",
+                max_results=max_results,
+                offset=offset,
+                include_external_profile_sources=True,
+            )
+        except Exception as exc:
+            logger.error("Unexpected error in bulk_reprocess_profiles: %s", exc)
+            self._audit_command(
+                interaction=interaction,
+                action="crm.bulk_reprocess_profiles",
+                result="error",
+                metadata={
+                    "error": str(exc),
+                },
+            )
+            await interaction.followup.send(
+                "An unexpected error occurred while loading bulk profile results."
             )
 
 

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -6358,6 +6358,52 @@ class TestCRMCog:
         crm_cog._start_resume_reprocess_from_contact.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_bulk_reprocess_profiles_splits_long_followup_messages(
+        self, crm_cog, mock_interaction
+    ):
+        """Bulk profile results should split across messages before hitting Discord's limit."""
+        contacts = [
+            {
+                "id": f"contact{i}",
+                "name": "Candidate User " + ("X" * 70) + str(i),
+                "resumeIds": [],
+                "resumeNames": {},
+                "cWebsiteLink": [f"https://portfolio{i}.example.com/" + ("p" * 40)],
+                "cGitHubUsername": "",
+                "cLinkedIn": "",
+                "addressCountry": "",
+                "cTimezone": "",
+                "skills": [],
+                "cRoles": [],
+                "cSeniority": "unknown",
+            }
+            for i in range(25)
+        ]
+
+        with (
+            patch(
+                "five08.discord_bot.cogs.crm.check_user_roles_with_hierarchy",
+                return_value=True,
+            ),
+            patch.object(
+                crm_cog,
+                "_search_contacts_for_bulk_profile_reprocess",
+                new=AsyncMock(return_value=(contacts, len(contacts))),
+            ),
+        ):
+            await crm_cog.bulk_reprocess_profiles.callback(
+                crm_cog, mock_interaction, 25, 0
+            )
+
+        assert mock_interaction.followup.send.await_count > 1
+        first_call = mock_interaction.followup.send.await_args_list[0]
+        second_call = mock_interaction.followup.send.await_args_list[1]
+        assert first_call.kwargs["view"] is not None
+        assert "view" not in second_call.kwargs
+        assert len(first_call.args[0]) <= 2000
+        assert len(second_call.args[0]) <= 2000
+
+    @pytest.mark.asyncio
     async def test_reprocess_profile_shows_no_contact_message(
         self, crm_cog, mock_interaction
     ):

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -6140,6 +6140,224 @@ class TestCRMCog:
         assert view.has_resume is False
 
     @pytest.mark.asyncio
+    async def test_reprocess_profile_without_resume_uses_linkedin_source(
+        self, crm_cog, mock_interaction
+    ):
+        """LinkedIn-only contacts should still reprocess from CRM profile sources."""
+        mock_interaction.user.id = 101
+
+        with (
+            patch(
+                "five08.discord_bot.cogs.crm.settings.api_shared_secret",
+                "test-shared-secret",
+            ),
+            patch(
+                "five08.discord_bot.cogs.crm.check_user_roles_with_hierarchy",
+                return_value=True,
+            ),
+            patch.object(
+                crm_cog,
+                "_search_contacts_for_reprocess_resume",
+                new=AsyncMock(
+                    return_value=[
+                        {
+                            "id": "contact123",
+                            "name": "Candidate User",
+                            "resumeIds": [],
+                            "resumeNames": {},
+                            "cWebsiteLink": [],
+                            "cGitHubUsername": "",
+                            "cLinkedIn": "https://www.linkedin.com/in/candidate-user/",
+                        },
+                    ]
+                ),
+            ),
+        ):
+            await crm_cog.reprocess_profile.callback(
+                crm_cog, mock_interaction, "candidate"
+            )
+
+        confirmation_message = mock_interaction.followup.send.call_args.args[0]
+        followup_kwargs = mock_interaction.followup.send.call_args.kwargs
+        assert "CRM profile sources" in confirmation_message
+        view = followup_kwargs["view"]
+        assert view.attachment_id == ""
+        assert view.filename == "CRM profile sources"
+        assert view.has_resume is False
+
+    def test_contact_has_external_profile_sources_accepts_linkedin(self, crm_cog):
+        """LinkedIn profiles count as external profile sources."""
+        assert crm_cog._contact_has_external_profile_sources(
+            {"cLinkedIn": "https://linkedin.com/in/candidate-user/"}
+        )
+
+    @pytest.mark.asyncio
+    async def test_bulk_profile_reprocess_search_includes_linkedin_only_contact(
+        self, crm_cog, mock_espo_api
+    ):
+        """Profile-aware bulk search should include LinkedIn-only contacts."""
+        linkedin_only_contact = {
+            "id": "contact123",
+            "name": "Candidate User",
+            "addressCountry": "",
+            "cTimezone": "",
+            "skills": [],
+            "cRoles": [],
+            "cSeniority": "unknown",
+            "resumeIds": [],
+            "resumeNames": {},
+            "cWebsiteLink": [],
+            "cGitHubUsername": "",
+            "cLinkedIn": "https://linkedin.com/in/candidate-user/",
+        }
+        mock_espo_api.request.return_value = {
+            "list": [linkedin_only_contact],
+            "total": 1,
+        }
+
+        (
+            resume_only_contacts,
+            _,
+        ) = await crm_cog._search_contacts_for_bulk_resume_reprocess(
+            limit=25,
+            offset=0,
+        )
+        (
+            profile_contacts,
+            total,
+        ) = await crm_cog._search_contacts_for_bulk_profile_reprocess(
+            limit=25,
+            offset=0,
+            include_external_profile_sources=True,
+        )
+
+        assert resume_only_contacts == []
+        assert profile_contacts == [linkedin_only_contact]
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_bulk_reprocess_profiles_uses_profile_sources_without_resume(
+        self, crm_cog, mock_interaction
+    ):
+        """The bulk profile command should route profile-only contacts into reprocess."""
+        crm_cog._prompt_reprocess_resume_confirmation = AsyncMock()
+
+        with (
+            patch(
+                "five08.discord_bot.cogs.crm.check_user_roles_with_hierarchy",
+                return_value=True,
+            ),
+            patch.object(
+                crm_cog,
+                "_search_contacts_for_bulk_profile_reprocess",
+                new=AsyncMock(
+                    return_value=(
+                        [
+                            {
+                                "id": "contact123",
+                                "name": "Candidate User",
+                                "resumeIds": [],
+                                "resumeNames": {},
+                                "cWebsiteLink": [],
+                                "cGitHubUsername": "",
+                                "cLinkedIn": "https://linkedin.com/in/candidate-user/",
+                                "addressCountry": "",
+                                "cTimezone": "",
+                                "skills": [],
+                                "cRoles": [],
+                                "cSeniority": "unknown",
+                            }
+                        ],
+                        1,
+                    )
+                ),
+            ),
+        ):
+            await crm_cog.bulk_reprocess_profiles.callback(
+                crm_cog, mock_interaction, 25, 0
+            )
+
+        crm_cog._prompt_reprocess_resume_confirmation.assert_awaited_once()
+        kwargs = crm_cog._prompt_reprocess_resume_confirmation.await_args.kwargs
+        assert kwargs["interaction"] is mock_interaction
+        assert kwargs["contact"]["id"] == "contact123"
+        assert kwargs["search_term"] == "bulk_missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_bulk_reprocess_profiles_selection_opens_confirmation(
+        self, crm_cog, mock_interaction
+    ):
+        """Bulk selection should open confirmation instead of starting enrichment."""
+        crm_cog._prompt_reprocess_resume_confirmation = AsyncMock()
+        crm_cog._start_resume_reprocess_from_contact = AsyncMock()
+
+        with (
+            patch(
+                "five08.discord_bot.cogs.crm.check_user_roles_with_hierarchy",
+                return_value=True,
+            ),
+            patch.object(
+                crm_cog,
+                "_search_contacts_for_bulk_profile_reprocess",
+                new=AsyncMock(
+                    return_value=(
+                        [
+                            {
+                                "id": "contact123",
+                                "name": "Candidate User",
+                                "resumeIds": [],
+                                "resumeNames": {},
+                                "cWebsiteLink": [],
+                                "cGitHubUsername": "",
+                                "cLinkedIn": "https://linkedin.com/in/candidate-user/",
+                                "addressCountry": "",
+                                "cTimezone": "",
+                                "skills": [],
+                                "cRoles": [],
+                                "cSeniority": "unknown",
+                            },
+                            {
+                                "id": "contact456",
+                                "name": "Other User",
+                                "resumeIds": [],
+                                "resumeNames": {},
+                                "cWebsiteLink": ["https://other.example.com"],
+                                "cGitHubUsername": "",
+                                "cLinkedIn": "",
+                                "addressCountry": "",
+                                "cTimezone": "",
+                                "skills": [],
+                                "cRoles": [],
+                                "cSeniority": "unknown",
+                            },
+                        ],
+                        2,
+                    )
+                ),
+            ),
+        ):
+            await crm_cog.bulk_reprocess_profiles.callback(
+                crm_cog, mock_interaction, 25, 0
+            )
+
+        view = mock_interaction.followup.send.call_args.kwargs["view"]
+        select = next(
+            child for child in view.children if isinstance(child, discord.ui.Select)
+        )
+
+        select_interaction = AsyncMock()
+        select_interaction.user = Mock()
+        select_interaction.user.id = 101
+        select_interaction.response = AsyncMock()
+        select_interaction.response.defer = AsyncMock()
+        select._values = ["contact123"]
+
+        await select.callback(select_interaction)
+
+        crm_cog._prompt_reprocess_resume_confirmation.assert_awaited_once()
+        crm_cog._start_resume_reprocess_from_contact.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_reprocess_profile_shows_no_contact_message(
         self, crm_cog, mock_interaction
     ):


### PR DESCRIPTION
## Description
- Add `/bulk-reprocess-profiles` for contacts missing derived profile fields, including contacts that can be enriched from LinkedIn, GitHub, or website sources without a resume.
- Refactor the CRM bulk reprocess flow into a shared helper and keep the bulk selection review-first by opening confirmation before enrichment starts.
- Extend CRM cog tests to cover LinkedIn-only source detection, profile-aware bulk filtering, and the bulk confirmation flow.

## Related Issue
- N/A

## How Has This Been Tested?
- `uv run pytest tests/unit/test_crm.py -k "linkedin_source or external_profile_sources_accepts_linkedin or bulk_profile_reprocess_search_includes_linkedin_only_contact or bulk_reprocess_profiles_uses_profile_sources_without_resume or bulk_reprocess_profiles_selection_opens_confirmation or reprocess_profile_without_resume_uses_crm_sources"`