### PR TITLE
fix: reuse uv layer in Coolify deploy builds

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
 FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
 
@@ -9,11 +10,13 @@ COPY apps/discord_bot/pyproject.toml apps/discord_bot/pyproject.toml
 COPY apps/worker/pyproject.toml apps/worker/pyproject.toml
 COPY apps/api/pyproject.toml apps/api/pyproject.toml
 COPY packages/shared/pyproject.toml packages/shared/pyproject.toml
+COPY apps/discord_bot/src apps/discord_bot/src
 COPY apps/api/src apps/api/src
 COPY apps/worker/src apps/worker/src
 COPY packages/shared/src packages/shared/src
 
-RUN uv sync --frozen --no-dev --package api
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
+    uv sync --frozen --no-dev --all-packages
 RUN groupadd -r appgroup && useradd -r -g appgroup -d /app -s /usr/sbin/nologin appuser
 RUN chown -R appuser:appgroup /app
 

--- a/apps/discord_bot/Dockerfile
+++ b/apps/discord_bot/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
 FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
 
@@ -10,9 +11,12 @@ COPY apps/worker/pyproject.toml apps/worker/pyproject.toml
 COPY apps/api/pyproject.toml apps/api/pyproject.toml
 COPY packages/shared/pyproject.toml packages/shared/pyproject.toml
 COPY apps/discord_bot/src apps/discord_bot/src
+COPY apps/api/src apps/api/src
+COPY apps/worker/src apps/worker/src
 COPY packages/shared/src packages/shared/src
 
-RUN uv sync --frozen --no-dev --package discord_bot
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
+    uv sync --frozen --no-dev --all-packages
 RUN groupadd -r appgroup && useradd -r -g appgroup -d /app -s /usr/sbin/nologin appuser
 RUN chown -R appuser:appgroup /app
 

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
 FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
 
@@ -9,10 +10,13 @@ COPY apps/discord_bot/pyproject.toml apps/discord_bot/pyproject.toml
 COPY apps/worker/pyproject.toml apps/worker/pyproject.toml
 COPY apps/api/pyproject.toml apps/api/pyproject.toml
 COPY packages/shared/pyproject.toml packages/shared/pyproject.toml
+COPY apps/discord_bot/src apps/discord_bot/src
+COPY apps/api/src apps/api/src
 COPY apps/worker/src apps/worker/src
 COPY packages/shared/src packages/shared/src
 
-RUN uv sync --frozen --no-dev --package worker
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv,sharing=locked \
+    uv sync --frozen --no-dev --all-packages
 RUN groupadd -r appgroup && useradd -r -g appgroup -d /app -s /usr/sbin/nologin appuser
 RUN chown -R appuser:appgroup /app
 


### PR DESCRIPTION
## Description
This updates the `api`, `worker`, and `discord_bot` Dockerfiles to use a shared BuildKit `uv` cache mount and the same `uv sync --frozen --no-dev --all-packages` install layer.
It also copies the full workspace sources needed to make that dependency layer identical across all three service images, reducing duplicate extraction during Coolify builds.

## Related Issue
N/A

## How Has This Been Tested?
`docker compose build api worker discord_bot`
Reviewed the April 19, 2026 Coolify deployment log and confirmed the failure was build-time disk exhaustion during repeated `uv sync` extraction.