### PR TITLE
docs: note BuildKit requirement for compose builds

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -91,6 +91,9 @@ Start full stack (discord_bot + api + worker + redis + postgres + minio):
 ./scripts/docker-compose.sh up --build
 ```
 
+Note: the service Dockerfiles use BuildKit cache mounts, so containerized builds
+require BuildKit-capable Docker / `docker compose build` support.
+
 Stop stack:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ For full containerized runs, including Coolify-style deployment parity:
 ./scripts/docker-compose.sh up --build
 ```
 
+Note: the service Dockerfiles use BuildKit cache mounts, so containerized builds
+require BuildKit-capable Docker / `docker compose build` support.
+
 Show the deterministic host ports for the current worktree:
 
 ```bash


### PR DESCRIPTION
## Description
Document that the containerized compose workflow requires BuildKit-capable Docker because the service Dockerfiles use BuildKit cache mounts.
This makes the merged deploy-build change explicit in the local and parity-run docs.

## Related Issue
N/A

## How Has This Been Tested?
Docs-only change; reviewed the updated `README.md` and `DEVELOPMENT.md` sections against the current Docker build workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Development documentation updated to clarify containerized build requirements. Containerized builds require a BuildKit-capable Docker setup and must use the `docker compose build` command for proper functionality. This ensures correct operation of all containerized services in development and deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->