### PR TITLE
fix: simplify search-members skills flow

### DIFF
--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -80,13 +80,14 @@ This document captures Discord bot behavior, permissions, and slash command usag
 - `/search-members`
   - Description: Search for candidates/members in the CRM.
   - Args:
-    - `query` (required; accepts `skills:python,sql` for skills-only search, `john skills:python,sql` for combined search, and `me`/`self` to look up your own CRM profile)
+    - `query` (required; accepts `skills:python,sql` for skills-only search, `john skills:python,sql` for combined search, and `me`/`self`/`myself` to look up your own CRM profile)
     - `show_skills` (optional; explicit detailed skills output)
   - Notes:
-    - Use `query: me` or `query: self` to replace the old self-lookup flow from `/view-skills`.
+    - Use `query: me`, `query: self`, or `query: myself` to replace the old self-lookup flow from `/view-skills`.
     - Add `show_skills:true` to return the detailed skills embed for a single match.
   - Examples:
     - `/search-members query:me`
+    - `/search-members query:myself`
     - `/search-members query:me show_skills:true`
     - `/search-members query:john skills:python,sql`
 

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -89,7 +89,7 @@ This document captures Discord bot behavior, permissions, and slash command usag
     - `/search-members query:me`
     - `/search-members query:myself`
     - `/search-members query:me show_skills:true`
-    - `/search-members query:john skills:python,sql`
+    - `/search-members query:"john skills:python,sql"`
 
 - `/crm-status`
   - Description: Check CRM API accessibility.

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -80,8 +80,7 @@ This document captures Discord bot behavior, permissions, and slash command usag
 - `/search-members`
   - Description: Search for candidates/members in the CRM.
   - Args:
-    - `query` (required; also accepts `skills:python,sql` for skills-only search, and `me`/`self` to look up your own CRM profile)
-    - `skills` (optional, comma-separated AND filter; filtered results show member skills)
+    - `query` (required; accepts `skills:python,sql` for skills-only search, `john skills:python,sql` for combined search, and `me`/`self` to look up your own CRM profile)
     - `show_skills` (optional; explicit detailed skills output)
   - Notes:
     - Use `query: me` or `query: self` to replace the old self-lookup flow from `/view-skills`.
@@ -89,6 +88,7 @@ This document captures Discord bot behavior, permissions, and slash command usag
   - Examples:
     - `/search-members query:me`
     - `/search-members query:me show_skills:true`
+    - `/search-members query:john skills:python,sql`
 
 - `/crm-status`
   - Description: Check CRM API accessibility.

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -80,8 +80,9 @@ This document captures Discord bot behavior, permissions, and slash command usag
 - `/search-members`
   - Description: Search for candidates/members in the CRM.
   - Args:
-    - `query` (optional)
-    - `skills` (optional, comma-separated)
+    - `query` (required; also accepts `skills:python,sql` for skills-only search)
+    - `skills` (optional, comma-separated AND filter; filtered results show member skills)
+    - `show_skills` (optional; explicit detailed skills output)
 
 - `/crm-status`
   - Description: Check CRM API accessibility.
@@ -99,11 +100,6 @@ This document captures Discord bot behavior, permissions, and slash command usag
 
 - `/unlinked-discord-users`
   - Description: List Discord members with `Member` role not linked in CRM.
-
-- `/view-skills`
-  - Description: View structured skills for yourself or a specific member.
-  - Args:
-    - `search_term` (optional)
 
 - `/set-github-username`
   - Description: Set GitHub username on a CRM contact.

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -80,9 +80,15 @@ This document captures Discord bot behavior, permissions, and slash command usag
 - `/search-members`
   - Description: Search for candidates/members in the CRM.
   - Args:
-    - `query` (required; also accepts `skills:python,sql` for skills-only search)
+    - `query` (required; also accepts `skills:python,sql` for skills-only search, and `me`/`self` to look up your own CRM profile)
     - `skills` (optional, comma-separated AND filter; filtered results show member skills)
     - `show_skills` (optional; explicit detailed skills output)
+  - Notes:
+    - Use `query: me` or `query: self` to replace the old self-lookup flow from `/view-skills`.
+    - Add `show_skills:true` to return the detailed skills embed for a single match.
+  - Examples:
+    - `/search-members query:me`
+    - `/search-members query:me show_skills:true`
 
 - `/crm-status`
   - Description: Check CRM API accessibility.

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4833,7 +4833,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         name="search-members", description="Search for candidates / members in the CRM"
     )
     @app_commands.describe(
-        query=("Name/email/Discord/ID, `me`/`self`, or append `skills:python,sql`"),
+        query=(
+            "Name/email/Discord/ID, `me`/`self`/`myself`, or append `skills:python,sql`"
+        ),
         show_skills="Show skills for matches; replaces `/view-skills`",
     )
     @require_role("Member")
@@ -4908,7 +4910,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                 else:
                     contacts = [direct_contact]
-            elif query_value.casefold() in {"me", "self"}:
+            elif query_value.casefold() in {"me", "self", "myself"}:
                 target_contact = await self._find_contact_by_discord_user(
                     interaction.user,
                     select=select_fields,

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4818,7 +4818,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         query_value = (query or "").strip()
         raw_skills: list[str] = []
 
-        skills_match = re.search(r"(?i)(?:^|\s)skills?\s*:\s*(.+)$", query_value)
+        skills_match = re.search(r"(?i)(?:^|\s)skills?\s*:\s*(.*)$", query_value)
         if skills_match:
             query_value = query_value[: skills_match.start()].strip()
             raw_skills.extend(
@@ -4828,6 +4828,21 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
 
         return query_value, normalize_skill_list(raw_skills)
+
+    def _contact_matches_requested_skills(
+        self,
+        contact: dict[str, Any],
+        requested_skills: list[str],
+    ) -> bool:
+        """Return whether a contact satisfies all requested skills."""
+        if not requested_skills:
+            return True
+
+        available_skills = {
+            skill.casefold()
+            for skill, _ in self._extract_contact_skills_for_view(contact)[0]
+        }
+        return all(skill.casefold() in available_skills for skill in requested_skills)
 
     @app_commands.command(
         name="search-members", description="Search for candidates / members in the CRM"
@@ -4893,23 +4908,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     direct_contact = candidate
 
             if direct_contact is not None:
-                if skills_list:
-                    available_skills = {
-                        skill.casefold()
-                        for skill, _ in self._extract_contact_skills_for_view(
-                            direct_contact
-                        )[0]
-                    }
-                    contacts = (
-                        [direct_contact]
-                        if all(
-                            skill.casefold() in available_skills
-                            for skill in skills_list
-                        )
-                        else []
+                contacts = (
+                    [direct_contact]
+                    if self._contact_matches_requested_skills(
+                        direct_contact, skills_list
                     )
-                else:
-                    contacts = [direct_contact]
+                    else []
+                )
             elif query_value.casefold() in {"me", "self", "myself"}:
                 target_contact = await self._find_contact_by_discord_user(
                     interaction.user,
@@ -4933,23 +4938,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     return
 
-                if skills_list:
-                    available_skills = {
-                        skill.casefold()
-                        for skill, _ in self._extract_contact_skills_for_view(
-                            target_contact
-                        )[0]
-                    }
-                    contacts = (
-                        [target_contact]
-                        if all(
-                            skill.casefold() in available_skills
-                            for skill in skills_list
-                        )
-                        else []
+                contacts = (
+                    [target_contact]
+                    if self._contact_matches_requested_skills(
+                        target_contact, skills_list
                     )
-                else:
-                    contacts = [target_contact]
+                    else []
+                )
             else:
                 if query_value:
                     discord_user_id = self._extract_discord_id_from_mention(

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4813,25 +4813,18 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         return ", ".join(rendered)
 
-    def _parse_search_members_inputs(
-        self,
-        query: str | None,
-        skills: str | None,
-    ) -> tuple[str, list[str]]:
+    def _parse_search_members_inputs(self, query: str | None) -> tuple[str, list[str]]:
         """Normalize `/search-members` query text and skill filters."""
         query_value = (query or "").strip()
         raw_skills: list[str] = []
 
-        prefix, separator, remainder = query_value.partition(":")
-        if separator and prefix.strip().casefold() in {"skill", "skills"}:
-            query_value = ""
+        skills_match = re.search(r"(?i)(?:^|\s)skills?\s*:\s*(.+)$", query_value)
+        if skills_match:
+            query_value = query_value[: skills_match.start()].strip()
             raw_skills.extend(
-                item.strip() for item in remainder.split(",") if item.strip()
-            )
-
-        if skills:
-            raw_skills.extend(
-                item.strip() for item in skills.split(",") if item.strip()
+                item.strip()
+                for item in skills_match.group(1).split(",")
+                if item.strip()
             )
 
         return query_value, normalize_skill_list(raw_skills)
@@ -4840,11 +4833,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         name="search-members", description="Search for candidates / members in the CRM"
     )
     @app_commands.describe(
-        query=(
-            "Name/email/Discord/ID, `me`/`self` for yourself "
-            "(use with `show_skills`), or `skills:python,sql`"
-        ),
-        skills="Extra comma-separated skills (AND match)",
+        query=("Name/email/Discord/ID, `me`/`self`, or append `skills:python,sql`"),
         show_skills="Show skills for matches; replaces `/view-skills`",
     )
     @require_role("Member")
@@ -4852,14 +4841,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         self,
         interaction: discord.Interaction,
         query: str,
-        skills: str | None = None,
         show_skills: bool = False,
     ) -> None:
         """Search for contacts in the CRM."""
         try:
             await interaction.response.defer(ephemeral=True)
 
-            query_value, skills_list = self._parse_search_members_inputs(query, skills)
+            query_value, skills_list = self._parse_search_members_inputs(query)
             show_member_skills = show_skills or bool(skills_list)
 
             if not query_value and not skills_list:
@@ -4870,7 +4858,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"reason": "missing_query_and_skills"},
                 )
                 await interaction.followup.send(
-                    "❌ Please provide a search term or skills to search by."
+                    "❌ Please provide a search term or `skills:...` to search by."
                 )
                 return
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4840,7 +4840,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         name="search-members", description="Search for candidates / members in the CRM"
     )
     @app_commands.describe(
-        query="Name/email/Discord/ID, or `skills:python,sql`",
+        query=(
+            "Name/email/Discord/ID, `me`/`self` for yourself "
+            "(use with `show_skills`), or `skills:python,sql`"
+        ),
         skills="Extra comma-separated skills (AND match)",
         show_skills="Show skills for matches; replaces `/view-skills`",
     )
@@ -4889,8 +4892,35 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 "select": select_fields,
             }
             contacts: list[dict[str, Any]]
+            direct_contact: dict[str, Any] | None = None
 
-            if query_value.casefold() in {"me", "self"}:
+            if query_value and self._is_hex_string(query_value):
+                try:
+                    candidate = self.espo_api.request("GET", f"Contact/{query_value}")
+                except EspoAPIError:
+                    candidate = None
+                if isinstance(candidate, dict) and candidate.get("id"):
+                    direct_contact = candidate
+
+            if direct_contact is not None:
+                if skills_list:
+                    available_skills = {
+                        skill.casefold()
+                        for skill, _ in self._extract_contact_skills_for_view(
+                            direct_contact
+                        )[0]
+                    }
+                    contacts = (
+                        [direct_contact]
+                        if all(
+                            skill.casefold() in available_skills
+                            for skill in skills_list
+                        )
+                        else []
+                    )
+                else:
+                    contacts = [direct_contact]
+            elif query_value.casefold() in {"me", "self"}:
                 target_contact = await self._find_contact_by_discord_user(
                     interaction.user,
                     select=select_fields,
@@ -5011,7 +5041,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 target_contact = contacts[0]
                 contact_id = str(target_contact.get("id") or "").strip()
                 if not contact_id:
-                    self._audit_command(
+                    self._audit_command_safe(
                         interaction=interaction,
                         action="crm.search_members",
                         result="error",
@@ -5041,7 +5071,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 else:
                     await interaction.followup.send(embed=skill_embed)
 
-                self._audit_command(
+                self._audit_command_safe(
                     interaction=interaction,
                     action="crm.search_members",
                     result="success",
@@ -8355,7 +8385,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         if len(skills) > 25:
             skill_lines.append(f"...and {len(skills) - 25} more.")
         if skill_lines:
-            embed.add_field(name="Skills", value=", ".join(skill_lines), inline=False)
+            embed.add_field(
+                name="Skills",
+                value=ResumeUpdateConfirmationView._truncate_embed_field(
+                    ", ".join(skill_lines)
+                ),
+                inline=False,
+            )
 
         return embed, len(skills), source, contact_name
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4842,6 +4842,20 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             skill.casefold()
             for skill, _ in self._extract_contact_skills_for_view(contact)[0]
         }
+        raw_skills = contact.get("skills")
+        if isinstance(raw_skills, list):
+            normalized_skills = normalize_skill_list(
+                [str(item) for item in raw_skills if str(item).strip()]
+            )
+        else:
+            normalized_skills = normalize_skill_list(
+                [
+                    item.strip()
+                    for item in str(raw_skills or "").split(",")
+                    if item.strip()
+                ]
+            )
+        available_skills.update(skill.casefold() for skill in normalized_skills)
         return all(skill.casefold() in available_skills for skill in requested_skills)
 
     @app_commands.command(

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -4813,31 +4813,51 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         return ", ".join(rendered)
 
+    def _parse_search_members_inputs(
+        self,
+        query: str | None,
+        skills: str | None,
+    ) -> tuple[str, list[str]]:
+        """Normalize `/search-members` query text and skill filters."""
+        query_value = (query or "").strip()
+        raw_skills: list[str] = []
+
+        prefix, separator, remainder = query_value.partition(":")
+        if separator and prefix.strip().casefold() in {"skill", "skills"}:
+            query_value = ""
+            raw_skills.extend(
+                item.strip() for item in remainder.split(",") if item.strip()
+            )
+
+        if skills:
+            raw_skills.extend(
+                item.strip() for item in skills.split(",") if item.strip()
+            )
+
+        return query_value, normalize_skill_list(raw_skills)
+
     @app_commands.command(
         name="search-members", description="Search for candidates / members in the CRM"
     )
     @app_commands.describe(
-        query="Search term (name, Discord username, email, or 508 email)",
-        skills="Comma-separated skills (AND match)",
+        query="Name/email/Discord/ID, or `skills:python,sql`",
+        skills="Extra comma-separated skills (AND match)",
+        show_skills="Show skills for matches; replaces `/view-skills`",
     )
     @require_role("Member")
     async def search_members(
         self,
         interaction: discord.Interaction,
-        query: str | None = None,
+        query: str,
         skills: str | None = None,
+        show_skills: bool = False,
     ) -> None:
         """Search for contacts in the CRM."""
         try:
             await interaction.response.defer(ephemeral=True)
 
-            query_value = (query or "").strip()
-            raw_skills_list = (
-                [skill.strip() for skill in skills.split(",") if skill.strip()]
-                if skills
-                else []
-            )
-            skills_list = normalize_skill_list(raw_skills_list)
+            query_value, skills_list = self._parse_search_members_inputs(query, skills)
+            show_member_skills = show_skills or bool(skills_list)
 
             if not query_value and not skills_list:
                 self._audit_command(
@@ -4858,73 +4878,118 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 search_parts.append(f"skills: `{', '.join(skills_list)}`")
             search_summary = ", ".join(search_parts)
 
-            # Search contacts using EspoCRM API
-            where_filters = []
-            if query_value:
-                discord_user_id = self._extract_discord_id_from_mention(
-                    query_value
-                ) or (
-                    query_value
-                    if self._looks_like_discord_user_id(query_value)
-                    else None
-                )
-                query_filters = [
-                    {
-                        "type": "contains",
-                        "attribute": "name",
-                        "value": query_value,
-                    },
-                    {
-                        "type": "contains",
-                        "attribute": "emailAddress",
-                        "value": query_value,
-                    },
-                    {
-                        "type": "contains",
-                        "attribute": "c508Email",
-                        "value": query_value,
-                    },
-                ]
-                if discord_user_id:
-                    query_filters.append(
-                        {
-                            "type": "equals",
-                            "attribute": "cDiscordUserID",
-                            "value": discord_user_id,
-                        }
-                    )
-                else:
-                    query_filters.append(
-                        {
-                            "type": "contains",
-                            "attribute": "cDiscordUsername",
-                            "value": query_value,
-                        }
-                    )
-                where_filters.append(
-                    {
-                        "type": "or",
-                        "value": query_filters,
-                    }
-                )
-
-            if skills_list:
-                where_filters.append(
-                    {
-                        "type": "arrayAllOf",
-                        "attribute": "skills",
-                        "value": skills_list,
-                    }
-                )
-
-            search_params = {
+            select_fields = (
+                "id,name,emailAddress,c508Email,cDiscordUsername,cDiscordUserID,"
+                "phoneNumber,type,resumeIds,resumeNames,resumeTypes,skills,cSkillAttrs"
+            )
+            where_filters: list[dict[str, Any]] = []
+            search_params: dict[str, Any] = {
                 "where": where_filters,
                 "maxSize": 10,
-                "select": "id,name,emailAddress,c508Email,cDiscordUsername,cDiscordUserID,phoneNumber,type,resumeIds,resumeNames,resumeTypes,skills,cSkillAttrs",
+                "select": select_fields,
             }
+            contacts: list[dict[str, Any]]
 
-            response = self.espo_api.request("GET", "Contact", search_params)
-            contacts = response.get("list", [])
+            if query_value.casefold() in {"me", "self"}:
+                target_contact = await self._find_contact_by_discord_user(
+                    interaction.user,
+                    select=select_fields,
+                )
+                if not target_contact:
+                    self._audit_command(
+                        interaction=interaction,
+                        action="crm.search_members",
+                        result="denied",
+                        metadata={
+                            "query": query_value,
+                            "skills": skills_list,
+                            "show_skills": show_skills,
+                            "reason": "discord_not_linked",
+                        },
+                    )
+                    await interaction.followup.send(
+                        "❌ Your Discord account is not linked to a CRM contact. "
+                        "Please ask a Steering Committee member to link your account first."
+                    )
+                    return
+
+                if skills_list:
+                    available_skills = {
+                        skill.casefold()
+                        for skill, _ in self._extract_contact_skills_for_view(
+                            target_contact
+                        )[0]
+                    }
+                    contacts = (
+                        [target_contact]
+                        if all(
+                            skill.casefold() in available_skills
+                            for skill in skills_list
+                        )
+                        else []
+                    )
+                else:
+                    contacts = [target_contact]
+            else:
+                if query_value:
+                    discord_user_id = self._extract_discord_id_from_mention(
+                        query_value
+                    ) or (
+                        query_value
+                        if self._looks_like_discord_user_id(query_value)
+                        else None
+                    )
+                    query_filters = [
+                        {
+                            "type": "contains",
+                            "attribute": "name",
+                            "value": query_value,
+                        },
+                        {
+                            "type": "contains",
+                            "attribute": "emailAddress",
+                            "value": query_value,
+                        },
+                        {
+                            "type": "contains",
+                            "attribute": "c508Email",
+                            "value": query_value,
+                        },
+                    ]
+                    if discord_user_id:
+                        query_filters.append(
+                            {
+                                "type": "equals",
+                                "attribute": "cDiscordUserID",
+                                "value": discord_user_id,
+                            }
+                        )
+                    else:
+                        query_filters.append(
+                            {
+                                "type": "contains",
+                                "attribute": "cDiscordUsername",
+                                "value": query_value,
+                            }
+                        )
+                    search_params["where"].append(
+                        {
+                            "type": "or",
+                            "value": query_filters,
+                        }
+                    )
+
+                if skills_list:
+                    search_params["where"].append(
+                        {
+                            "type": "arrayAllOf",
+                            "attribute": "skills",
+                            "value": skills_list,
+                        }
+                    )
+
+                response = self.espo_api.request("GET", "Contact", search_params)
+                contacts = response.get("list", [])
 
             if not contacts:
                 self._audit_command(
@@ -4942,6 +5007,57 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
                 return
 
+            if show_skills and len(contacts) == 1:
+                target_contact = contacts[0]
+                contact_id = str(target_contact.get("id") or "").strip()
+                if not contact_id:
+                    self._audit_command(
+                        interaction=interaction,
+                        action="crm.search_members",
+                        result="error",
+                        metadata={
+                            "query": query_value or None,
+                            "skills": skills_list,
+                            "show_skills": True,
+                            "error": "missing_contact_id",
+                        },
+                    )
+                    await interaction.followup.send("❌ Contact ID not found.")
+                    return
+
+                full_contact = self.espo_api.request("GET", f"Contact/{contact_id}")
+                skill_embed, skills_count, source, contact_name = (
+                    self._build_contact_skills_embed(
+                        full_contact,
+                        target_contact=target_contact,
+                        interaction=interaction,
+                    )
+                )
+
+                if skills_count == 0:
+                    await interaction.followup.send(
+                        f"ℹ️ No skills found for **{contact_name}**."
+                    )
+                else:
+                    await interaction.followup.send(embed=skill_embed)
+
+                self._audit_command(
+                    interaction=interaction,
+                    action="crm.search_members",
+                    result="success",
+                    metadata={
+                        "query": query_value or None,
+                        "skills": skills_list,
+                        "show_skills": True,
+                        "contacts_found": 1,
+                        "skills_count": skills_count,
+                        "source": source,
+                    },
+                    resource_type="crm_contact",
+                    resource_id=contact_id,
+                )
+                return
+
             logger.info(f"Found {len(contacts)} contacts for: {search_summary}")
 
             # Create embed with results
@@ -4954,14 +5070,20 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             # Create view with resume download buttons
             view = ResumeButtonView()
 
-            for i, contact in enumerate(contacts):
+            for contact in contacts:
                 name = contact.get("name", "Unknown")
                 additional_fields: list[tuple[str, str]] = []
 
-                if skills_list:
-                    contact_skills = self._format_requested_skills(skills_list, contact)
+                if show_member_skills:
+                    contact_skills = self._format_contact_skill_preview(contact)
                     if contact_skills:
                         additional_fields.append(("🧠 Skills", contact_skills))
+                    elif skills_list:
+                        requested_skills = self._format_requested_skills(
+                            skills_list, contact
+                        )
+                        if requested_skills:
+                            additional_fields.append(("🧠 Skills", requested_skills))
 
                 contact_info = self._format_contact_card(
                     contact,
@@ -4999,6 +5121,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={
                     "query": query_value or None,
                     "skills": skills_list,
+                    "show_skills": show_skills,
+                    "skills_shown": show_member_skills,
                     "contacts_found": len(contacts),
                     "resume_button_count": len(view.children),
                 },
@@ -8180,12 +8304,60 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
         return [(skill, None) for skill in skills], "skills"
 
-    async def _search_contacts_for_view_skills(
-        self, search_term: str
-    ) -> list[dict[str, Any]]:
-        """Resolve search term for view-skills lookup."""
-        contacts = await self._search_contacts_for_lookup(search_term)
-        return contacts
+    def _format_contact_skill_preview(
+        self,
+        contact: dict[str, Any],
+        *,
+        limit: int = 8,
+    ) -> str:
+        """Build a compact skills preview for search results."""
+        skills, _ = self._extract_contact_skills_for_view(contact)
+        if not skills:
+            return ""
+
+        rendered: list[str] = []
+        for skill, strength in skills[:limit]:
+            if strength is None:
+                rendered.append(skill)
+            else:
+                rendered.append(f"{skill} ({strength})")
+        if len(skills) > limit:
+            rendered.append(f"...and {len(skills) - limit} more.")
+        return ", ".join(rendered)
+
+    def _build_contact_skills_embed(
+        self,
+        full_contact: dict[str, Any],
+        *,
+        target_contact: dict[str, Any],
+        interaction: discord.Interaction,
+    ) -> tuple[discord.Embed, int, str, str]:
+        """Build the detailed skills embed used by `/search-members show_skills`."""
+        contact_name = str(
+            full_contact.get("name") or target_contact.get("name") or "Unknown"
+        )
+        skills, source = self._extract_contact_skills_for_view(full_contact)
+
+        contact_card = self._format_contact_card(full_contact, interaction)
+        embed = discord.Embed(
+            title="🛠️ CRM Skills",
+            description=f"Skills for **{contact_name}**",
+            color=0x0099FF,
+        )
+        embed.add_field(name="👤 Profile", value=contact_card, inline=False)
+
+        skill_lines: list[str] = []
+        for skill, strength in skills[:25]:
+            if strength is None:
+                skill_lines.append(skill)
+            else:
+                skill_lines.append(f"{skill} ({strength})")
+        if len(skills) > 25:
+            skill_lines.append(f"...and {len(skills) - 25} more.")
+        if skill_lines:
+            embed.add_field(name="Skills", value=", ".join(skill_lines), inline=False)
+
+        return embed, len(skills), source, contact_name
 
     async def _search_contacts_for_reprocess_resume(
         self, search_term: str
@@ -8837,185 +9009,6 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             "one for this contact.",
             ephemeral=True,
         )
-
-    @app_commands.command(
-        name="view-skills",
-        description="View CRM skills for yourself or a specific member",
-    )
-    @app_commands.describe(
-        search_term="Optional: @mention, email, 508 username, name, or contact ID",
-    )
-    @require_role("Member")
-    async def view_skills(
-        self, interaction: discord.Interaction, search_term: str | None = None
-    ) -> None:
-        """View structured skills (with strengths) or fallback multi-enum skills."""
-        try:
-            await interaction.response.defer(ephemeral=True)
-
-            query = (search_term or "").strip()
-            target_scope = "other" if query else "self"
-
-            target_contact: dict[str, Any] | None = None
-            if not query:
-                target_contact = await self._find_contact_by_discord_user(
-                    interaction.user
-                )
-                if not target_contact:
-                    self._audit_command(
-                        interaction=interaction,
-                        action="crm.view_skills",
-                        result="denied",
-                        metadata={
-                            "target_scope": "self",
-                            "reason": "discord_not_linked",
-                        },
-                    )
-                    await interaction.followup.send(
-                        "❌ Your Discord account is not linked to a CRM contact. "
-                        "Please ask a Steering Committee member to link your account first."
-                    )
-                    return
-            else:
-                contacts = await self._search_contacts_for_view_skills(query)
-                if not contacts:
-                    self._audit_command(
-                        interaction=interaction,
-                        action="crm.view_skills",
-                        result="success",
-                        metadata={
-                            "search_term": query,
-                            "target_scope": target_scope,
-                            "contacts_found": 0,
-                        },
-                    )
-                    await interaction.followup.send(
-                        f"❌ No contact found for: `{query}`"
-                    )
-                    return
-
-                if len(contacts) > 1:
-                    lines: list[str] = []
-                    for contact in contacts[:5]:
-                        name = str(contact.get("name", "Unknown"))
-                        contact_id = str(contact.get("id", ""))
-                        lines.append(f"- **{name}** (`{contact_id}`)")
-                    suffix = (
-                        f"\n...and {len(contacts) - 5} more."
-                        if len(contacts) > 5
-                        else ""
-                    )
-                    self._audit_command(
-                        interaction=interaction,
-                        action="crm.view_skills",
-                        result="success",
-                        metadata={
-                            "search_term": query,
-                            "target_scope": target_scope,
-                            "contacts_found": len(contacts),
-                            "requires_selection": True,
-                        },
-                    )
-                    await interaction.followup.send(
-                        "⚠️ Multiple contacts found. Please refine your search:\n"
-                        + "\n".join(lines)
-                        + suffix
-                    )
-                    return
-
-                target_contact = contacts[0]
-
-            assert target_contact is not None
-            contact_id = str(target_contact.get("id") or "").strip()
-            if not contact_id:
-                self._audit_command(
-                    interaction=interaction,
-                    action="crm.view_skills",
-                    result="error",
-                    metadata={
-                        "search_term": query or None,
-                        "error": "missing_contact_id",
-                    },
-                )
-                await interaction.followup.send("❌ Contact ID not found.")
-                return
-
-            full_contact = self.espo_api.request("GET", f"Contact/{contact_id}")
-            contact_name = str(
-                full_contact.get("name") or target_contact.get("name") or "Unknown"
-            )
-            skills, source = self._extract_contact_skills_for_view(full_contact)
-
-            if not skills:
-                self._audit_command(
-                    interaction=interaction,
-                    action="crm.view_skills",
-                    result="success",
-                    metadata={
-                        "search_term": query or None,
-                        "target_scope": target_scope,
-                        "skills_count": 0,
-                        "source": source,
-                    },
-                    resource_type="crm_contact",
-                    resource_id=contact_id,
-                )
-                await interaction.followup.send(
-                    f"ℹ️ No skills found for **{contact_name}**."
-                )
-                return
-
-            contact_card = self._format_contact_card(full_contact, interaction)
-            embed = discord.Embed(
-                title="🛠️ CRM Skills",
-                description=f"Skills for **{contact_name}**",
-                color=0x0099FF,
-            )
-            embed.add_field(name="👤 Profile", value=contact_card, inline=False)
-            skill_lines: list[str] = []
-            for skill, strength in skills[:25]:
-                if strength is None:
-                    skill_lines.append(skill)
-                else:
-                    skill_lines.append(f"{skill} ({strength})")
-            if len(skills) > 25:
-                skill_lines.append(f"...and {len(skills) - 25} more.")
-            embed.add_field(name="Skills", value=", ".join(skill_lines), inline=False)
-
-            await interaction.followup.send(embed=embed)
-            self._audit_command(
-                interaction=interaction,
-                action="crm.view_skills",
-                result="success",
-                metadata={
-                    "search_term": query or None,
-                    "target_scope": target_scope,
-                    "skills_count": len(skills),
-                    "source": source,
-                },
-                resource_type="crm_contact",
-                resource_id=contact_id,
-            )
-        except EspoAPIError as e:
-            logger.error(f"EspoCRM API error in view_skills: {e}")
-            self._audit_command(
-                interaction=interaction,
-                action="crm.view_skills",
-                result="error",
-                metadata={"search_term": search_term, "error": str(e)},
-            )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
-        except Exception as e:
-            logger.error(f"Unexpected error in view_skills: {e}")
-            self._audit_command(
-                interaction=interaction,
-                action="crm.view_skills",
-                result="error",
-                metadata={"search_term": search_term, "error": str(e)},
-            )
-            await interaction.followup.send(
-                "❌ An unexpected error occurred while fetching skills."
-            )
 
     @app_commands.command(
         name="update-contact",

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2675,10 +2675,10 @@ class TestCRMCog:
         """Test contact search requires a query or skills."""
         mock_interaction.user.roles = [mock_member_role]
 
-        await crm_cog.search_members.callback(crm_cog, mock_interaction, "", None)
+        await crm_cog.search_members.callback(crm_cog, mock_interaction, "")
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ Please provide a search term or skills to search by."
+            "❌ Please provide a search term or `skills:...` to search by."
         )
         crm_cog.espo_api.request.assert_not_called()
 
@@ -2711,12 +2711,12 @@ class TestCRMCog:
     async def test_search_contacts_query_and_skills(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """Test contact search by query and skills."""
+        """Test contact search by combined inline query and skills."""
         mock_interaction.user.roles = [mock_member_role]
         crm_cog.espo_api.request.return_value = {"list": []}
 
         await crm_cog.search_members.callback(
-            crm_cog, mock_interaction, "john", "python,sql"
+            crm_cog, mock_interaction, "john skills:python,sql"
         )
 
         crm_cog.espo_api.request.assert_called_once()
@@ -3317,7 +3317,6 @@ class TestCRMCog:
                 crm_cog,
                 mock_interaction,
                 "me",
-                None,
                 True,
             )
 
@@ -3380,7 +3379,6 @@ class TestCRMCog:
             crm_cog,
             mock_interaction,
             "john",
-            None,
             True,
         )
 
@@ -3420,7 +3418,6 @@ class TestCRMCog:
             crm_cog,
             mock_interaction,
             "john",
-            None,
             True,
         )
 
@@ -3448,7 +3445,6 @@ class TestCRMCog:
                 crm_cog,
                 mock_interaction,
                 "me",
-                None,
                 True,
             )
 

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -3500,6 +3500,39 @@ class TestCRMCog:
         assert embed.title == "🛠️ CRM Skills"
 
     @pytest.mark.asyncio
+    async def test_search_contacts_self_skill_filter_matches_raw_skills_when_attrs_partial(
+        self, crm_cog, mock_interaction, mock_member_role
+    ):
+        """Self/direct skill filtering should match against both CRM skill sources."""
+        mock_interaction.user.roles = [mock_member_role]
+        mock_interaction.user.id = 123456789
+
+        with patch.object(
+            crm_cog,
+            "_find_contact_by_discord_user",
+            new=AsyncMock(
+                return_value={
+                    "id": "contact123",
+                    "name": "John Doe",
+                    "emailAddress": "john@example.com",
+                    "type": "Member",
+                    "cSkillAttrs": '{"python":{"strength":5}}',
+                    "skills": ["python", "sql"],
+                }
+            ),
+        ):
+            await crm_cog.search_members.callback(
+                crm_cog,
+                mock_interaction,
+                "me skills:sql",
+            )
+
+        crm_cog.espo_api.request.assert_not_called()
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.title == "🔍 CRM Contact Search Results"
+        assert "John Doe" in embed.fields[0].name
+
+    @pytest.mark.asyncio
     async def test_search_contacts_shows_skill_strengths(
         self, crm_cog, mock_interaction, mock_member_role
     ):

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2747,6 +2747,28 @@ class TestCRMCog:
         assert search_params["where"][0]["type"] == "arrayAllOf"
         assert search_params["where"][0]["value"] == ["python", "fastapi"]
 
+    @pytest.mark.asyncio
+    async def test_search_contacts_direct_contact_id_lookup(
+        self, crm_cog, mock_interaction, mock_member_role
+    ):
+        """Hex-like CRM contact IDs should use direct lookup before fallback search."""
+        mock_interaction.user.roles = [mock_member_role]
+        contact_id = "0123456789abcdef"
+        crm_cog.espo_api.request.return_value = {
+            "id": contact_id,
+            "name": "John Doe",
+            "emailAddress": "john@example.com",
+            "type": "Member",
+        }
+
+        await crm_cog.search_members.callback(crm_cog, mock_interaction, contact_id)
+
+        crm_cog.espo_api.request.assert_called_once_with("GET", f"Contact/{contact_id}")
+        mock_interaction.followup.send.assert_called_once()
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.title == "🔍 CRM Contact Search Results"
+        assert "John Doe" in embed.fields[0].name
+
     def test_parse_contact_skill_attrs_recovers_python_literal(self, crm_cog):
         """Malformed JSON-like skill attrs should recover via literal parsing."""
         parsed = crm_cog._parse_contact_skill_attrs(
@@ -3313,6 +3335,30 @@ class TestCRMCog:
         skills_field = embed.fields[1]
         assert "go (5)" in skills_field.value
         assert "python (4)" in skills_field.value
+
+    def test_build_contact_skills_embed_truncates_long_skill_field(self, crm_cog):
+        """Detailed skills embed should stay within Discord field limits."""
+        long_skill = "x" * 120
+        full_contact = {
+            "id": "contact123",
+            "name": "John Doe",
+            "emailAddress": "john@example.com",
+            "type": "Member",
+            "skills": [f"{long_skill}{index}" for index in range(25)],
+        }
+        interaction = Mock()
+        interaction.guild = None
+
+        embed, skills_count, source, contact_name = crm_cog._build_contact_skills_embed(
+            full_contact,
+            target_contact={"id": "contact123", "name": "John Doe"},
+            interaction=interaction,
+        )
+
+        assert skills_count == 25
+        assert source == "skills"
+        assert contact_name == "John Doe"
+        assert len(embed.fields[1].value) <= 1024
 
     @pytest.mark.asyncio
     async def test_search_contacts_show_skills_falls_back_to_multi_enum(

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -3454,6 +3454,38 @@ class TestCRMCog:
         assert "Discord account is not linked to a CRM contact" in message
 
     @pytest.mark.asyncio
+    async def test_search_contacts_show_skills_myself_alias_uses_self_lookup(
+        self, crm_cog, mock_interaction, mock_member_role
+    ):
+        """`myself` should behave the same as the existing self-lookup aliases."""
+        mock_interaction.user.roles = [mock_member_role]
+        mock_interaction.user.id = 123456789
+
+        with patch.object(
+            crm_cog,
+            "_find_contact_by_discord_user",
+            new=AsyncMock(return_value={"id": "contact123", "name": "John Doe"}),
+        ):
+            crm_cog.espo_api.request.return_value = {
+                "id": "contact123",
+                "name": "John Doe",
+                "emailAddress": "john@example.com",
+                "type": "Member",
+                "skills": ["python"],
+            }
+
+            await crm_cog.search_members.callback(
+                crm_cog,
+                mock_interaction,
+                "myself",
+                True,
+            )
+
+        crm_cog.espo_api.request.assert_called_once_with("GET", "Contact/contact123")
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.title == "🛠️ CRM Skills"
+
+    @pytest.mark.asyncio
     async def test_search_contacts_shows_skill_strengths(
         self, crm_cog, mock_interaction, mock_member_role
     ):

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2683,6 +2683,20 @@ class TestCRMCog:
         crm_cog.espo_api.request.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_search_contacts_rejects_empty_inline_skills_filter(
+        self, crm_cog, mock_interaction, mock_member_role
+    ):
+        """A bare `skills:` query should trigger the standard missing-input validation."""
+        mock_interaction.user.roles = [mock_member_role]
+
+        await crm_cog.search_members.callback(crm_cog, mock_interaction, "skills:")
+
+        mock_interaction.followup.send.assert_called_once_with(
+            "❌ Please provide a search term or `skills:...` to search by."
+        )
+        crm_cog.espo_api.request.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_search_contacts_skills_only(
         self, crm_cog, mock_interaction, mock_member_role
     ):

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2675,7 +2675,7 @@ class TestCRMCog:
         """Test contact search requires a query or skills."""
         mock_interaction.user.roles = [mock_member_role]
 
-        await crm_cog.search_members.callback(crm_cog, mock_interaction, None, None)
+        await crm_cog.search_members.callback(crm_cog, mock_interaction, "", None)
 
         mock_interaction.followup.send.assert_called_once_with(
             "❌ Please provide a search term or skills to search by."
@@ -2686,12 +2686,12 @@ class TestCRMCog:
     async def test_search_contacts_skills_only(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """Test contact search by skills only."""
+        """Test contact search by inline `skills:` query syntax."""
         mock_interaction.user.roles = [mock_member_role]
         crm_cog.espo_api.request.return_value = {"list": []}
 
         await crm_cog.search_members.callback(
-            crm_cog, mock_interaction, None, "python,  sql "
+            crm_cog, mock_interaction, "skills: python,  sql "
         )
 
         crm_cog.espo_api.request.assert_called_once()
@@ -2738,7 +2738,7 @@ class TestCRMCog:
         crm_cog.espo_api.request.return_value = {"list": []}
 
         await crm_cog.search_members.callback(
-            crm_cog, mock_interaction, None, "Python, FastAPI "
+            crm_cog, mock_interaction, "skills: Python, FastAPI "
         )
 
         crm_cog.espo_api.request.assert_called_once()
@@ -3269,16 +3269,19 @@ class TestCRMCog:
         )
 
     @pytest.mark.asyncio
-    async def test_view_skills_self_uses_structured_attrs(
+    async def test_search_contacts_show_skills_self_uses_structured_attrs(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """No search term should resolve self and display structured skill strengths."""
+        """`/search-members me show_skills:true` should display structured skill strengths."""
         mock_interaction.user.roles = [mock_member_role]
         mock_interaction.user.id = 123456789
 
-        crm_cog.espo_api.request.side_effect = [
-            {"list": [{"id": "contact123", "name": "John Doe"}]},
-            {
+        with patch.object(
+            crm_cog,
+            "_find_contact_by_discord_user",
+            new=AsyncMock(return_value={"id": "contact123", "name": "John Doe"}),
+        ):
+            crm_cog.espo_api.request.return_value = {
                 "id": "contact123",
                 "name": "John Doe",
                 "emailAddress": "john@example.com",
@@ -3286,36 +3289,37 @@ class TestCRMCog:
                 "c508Email": "john@508.dev",
                 "cSkillAttrs": '{"python":{"strength":4},"go":{"strength":5}}',
                 "skills": ["python", "go"],
-            },
-        ]
+            }
 
-        await crm_cog.view_skills.callback(crm_cog, mock_interaction, None)
+            await crm_cog.search_members.callback(
+                crm_cog,
+                mock_interaction,
+                "me",
+                None,
+                True,
+            )
 
-        assert crm_cog.espo_api.request.call_count == 2
+        crm_cog.espo_api.request.assert_called_once_with("GET", "Contact/contact123")
         mock_interaction.followup.send.assert_called_once()
         call_args = mock_interaction.followup.send.call_args
         embed = call_args[1]["embed"]
         assert embed.title == "🛠️ CRM Skills"
         assert "Skills for **John Doe**" in embed.description
-        # issue #61: profile field should show full contact info
         profile_field = embed.fields[0]
         assert profile_field.name == "👤 Profile"
         assert "john@example.com" in profile_field.value
         assert "Member" in profile_field.value
         assert "john@508.dev" in profile_field.value
-        # skills should still be present
         skills_field = embed.fields[1]
         assert "go (5)" in skills_field.value
         assert "python (4)" in skills_field.value
 
     @pytest.mark.asyncio
-    async def test_view_skills_falls_back_to_skills_when_attrs_unrecoverable(
+    async def test_search_contacts_show_skills_falls_back_to_multi_enum(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """If attrs cannot be recovered, command should display skills multi-enum."""
+        """`show_skills` should fall back to multi-enum skills when attrs are broken."""
         mock_interaction.user.roles = [mock_member_role]
-        mock_interaction.user.id = 123456789
-
         crm_cog.espo_api.request.side_effect = [
             {"list": [{"id": "contact123", "name": "John Doe"}]},
             {
@@ -3326,7 +3330,13 @@ class TestCRMCog:
             },
         ]
 
-        await crm_cog.view_skills.callback(crm_cog, mock_interaction, None)
+        await crm_cog.search_members.callback(
+            crm_cog,
+            mock_interaction,
+            "john",
+            None,
+            True,
+        )
 
         mock_interaction.followup.send.assert_called_once()
         call_args = mock_interaction.followup.send.call_args
@@ -3336,53 +3346,67 @@ class TestCRMCog:
         assert "/5" not in embed.fields[1].value
 
     @pytest.mark.asyncio
-    async def test_search_contacts_for_view_skills_delegates_to_linking(self, crm_cog):
-        """`_search_contacts_for_view_skills` should delegate to `_search_contacts_for_lookup`."""
-        expected = [{"id": "contact123"}]
-        with patch.object(
-            crm_cog,
-            "_search_contacts_for_lookup",
-            new=AsyncMock(return_value=expected),
-        ) as mock_search:
-            result = await crm_cog._search_contacts_for_view_skills("john")
-
-        assert result == expected
-        mock_search.assert_awaited_once_with("john")
-
-    @pytest.mark.asyncio
-    async def test_view_skills_multiple_contacts_requires_refine(
+    async def test_search_contacts_show_skills_multiple_contacts_adds_preview(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """Search term with multiple matches should ask caller to refine."""
+        """Multiple matches should keep search results and add compact skill previews."""
         mock_interaction.user.roles = [mock_member_role]
-
-        with patch.object(crm_cog, "_search_contacts_for_view_skills") as mock_search:
-            mock_search.return_value = [
-                {"id": "contact1", "name": "John Doe"},
-                {"id": "contact2", "name": "John Smith"},
+        crm_cog.espo_api.request.return_value = {
+            "list": [
+                {
+                    "id": "contact1",
+                    "name": "John Doe",
+                    "emailAddress": "john@example.com",
+                    "type": "Member",
+                    "cSkillAttrs": '{"python":{"strength":5},"go":{"strength":4}}',
+                },
+                {
+                    "id": "contact2",
+                    "name": "John Smith",
+                    "emailAddress": "jsmith@example.com",
+                    "type": "Member",
+                    "skills": ["react", "typescript"],
+                },
             ]
+        }
 
-            await crm_cog.view_skills.callback(crm_cog, mock_interaction, "john")
+        await crm_cog.search_members.callback(
+            crm_cog,
+            mock_interaction,
+            "john",
+            None,
+            True,
+        )
 
-        crm_cog.espo_api.request.assert_not_called()
         mock_interaction.followup.send.assert_called_once()
-        message = mock_interaction.followup.send.call_args[0][0]
-        assert "Multiple contacts found" in message
-        assert "John Doe" in message
-        assert "John Smith" in message
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert "John Doe" in embed.fields[0].name
+        assert "🧠 Skills: python (5), go (4)" in embed.fields[0].value
+        assert "John Smith" in embed.fields[1].name
+        assert "🧠 Skills: react, typescript" in embed.fields[1].value
 
     @pytest.mark.asyncio
-    async def test_view_skills_self_not_linked(
+    async def test_search_contacts_show_skills_self_not_linked(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """No search term should error when requester is not linked to CRM."""
+        """`me` should produce a direct linked-account error when no CRM contact exists."""
         mock_interaction.user.roles = [mock_member_role]
         mock_interaction.user.id = 123456789
-        crm_cog.espo_api.request.return_value = {"list": []}
 
-        await crm_cog.view_skills.callback(crm_cog, mock_interaction, None)
+        with patch.object(
+            crm_cog,
+            "_find_contact_by_discord_user",
+            new=AsyncMock(return_value=None),
+        ):
+            await crm_cog.search_members.callback(
+                crm_cog,
+                mock_interaction,
+                "me",
+                None,
+                True,
+            )
 
-        crm_cog.espo_api.request.assert_called_once()
+        crm_cog.espo_api.request.assert_not_called()
         mock_interaction.followup.send.assert_called_once()
         message = mock_interaction.followup.send.call_args[0][0]
         assert "Discord account is not linked to a CRM contact" in message
@@ -3391,7 +3415,7 @@ class TestCRMCog:
     async def test_search_contacts_shows_skill_strengths(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """Test contact search displays requested skills with strengths."""
+        """Skill-filtered search should show the found member's skills by default."""
         mock_interaction.user.roles = [mock_member_role]
         crm_cog.espo_api.request.return_value = {
             "list": [
@@ -3405,27 +3429,26 @@ class TestCRMCog:
                     "cSkillAttrs": {
                         "python": {"strength": 5},
                         "sql": {"strength": "4"},
-                        "aws": {"strength": "6"},
-                        "gcp": "1",
+                        "react": {"strength": 3},
                     },
                 }
             ]
         }
 
         await crm_cog.search_members.callback(
-            crm_cog, mock_interaction, None, "python,sql,aws"
+            crm_cog, mock_interaction, "skills: python,sql"
         )
 
         mock_interaction.followup.send.assert_called_once()
         embed = mock_interaction.followup.send.call_args.kwargs["embed"]
         field_value = embed.fields[0].value
-        assert "🧠 Skills: python (5), sql (4), amazon web services" in field_value
+        assert "🧠 Skills: python (5), sql (4), react (3)" in field_value
 
     @pytest.mark.asyncio
     async def test_search_contacts_ignores_broken_skill_attrs(
         self, crm_cog, mock_interaction, mock_member_role
     ):
-        """Test contact search ignores malformed cSkillAttrs payloads."""
+        """Broken skill attrs should fall back to requested skills when needed."""
         mock_interaction.user.roles = [mock_member_role]
         crm_cog.espo_api.request.return_value = {
             "list": [
@@ -3440,7 +3463,7 @@ class TestCRMCog:
         }
 
         await crm_cog.search_members.callback(
-            crm_cog, mock_interaction, None, "python,sql"
+            crm_cog, mock_interaction, "skills: python,sql"
         )
 
         mock_interaction.followup.send.assert_called_once()


### PR DESCRIPTION
## Description
Make `/search-members` take the default typed text as the query, support `skills:` inline syntax for skills-only searches, and show member skills automatically when a skills filter is used.
Fold the old `/view-skills` behavior into `/search-members` via `show_skills`, then remove the redundant standalone command.
Update CRM command tests and the Discord bot README to reflect the new command contract.

## Related Issue
#61

## How Has This Been Tested?
- `uv run ruff check apps/discord_bot/src/five08/discord_bot/cogs/crm.py tests/unit/test_crm.py apps/discord_bot/README.md`
- `uv run pytest tests/unit/test_crm.py tests/unit/test_discord_command_metadata.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `show_skills` to `/search-members` for a detailed skills view.
  * `query` now accepts inline `skills:...` filters and recognizes `me`/`self`/`myself` for self-profile lookup.

* **Changes**
  * `/search-members` `query` is required.
  * Skills-only and combined name+skills searches use the inline `skills:` syntax.

* **Removals**
  * Removed `/view-skills`; its behavior is now available via `/search-members show_skills`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->