### PR TITLE
fix: normalize DocuSeal API base URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,8 @@ CRM_SYNC_PAGE_SIZE=200
 # If unset, Docuseal agreement processing is ignored.
 DOCUSEAL_MEMBER_AGREEMENT_TEMPLATE_ID=
 # Required for sending member agreement requests from Discord.
+# For DocuSeal Cloud use https://api.docuseal.com
+# For self-hosted DocuSeal, this is usually https://your-host/api
 DOCUSEAL_BASE_URL=
 DOCUSEAL_API_KEY=
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,15 +101,15 @@ jobs:
     - name: Install dependencies
       run: |
         uv sync --all-extras
-        uv add --dev bandit safety
 
     - name: Run bandit security linter
       run: |
-        uv run bandit -r apps/discord_bot/src/five08/ -r apps/worker/src/five08/ -r packages/shared/src/five08/ -f json -o bandit-report.json || true
+        uv run --with bandit bandit -r apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ -f json -o bandit-report.json || true
 
     - name: Run safety check
       run: |
-        uv run safety check --json --output safety-report.json || true
+        uv export --format requirements-txt --no-hashes > requirements-ci.txt
+        uv run --with safety safety check -r requirements-ci.txt --output json --save-json safety-report.json || true
 
     - name: Upload security reports
       uses: actions/upload-artifact@v7

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -70,7 +70,7 @@ This document captures Discord bot behavior, permissions, and slash command usag
 - `/send-member-agreement`
   - Description: Send the member agreement for signature through DocuSeal.
   - Required role: Steering Committee
-  - Prerequisites: `DOCUSEAL_BASE_URL`, `DOCUSEAL_API_KEY`, and `DOCUSEAL_MEMBER_AGREEMENT_TEMPLATE_ID` must be configured.
+  - Prerequisites: `DOCUSEAL_BASE_URL`, `DOCUSEAL_API_KEY`, and `DOCUSEAL_MEMBER_AGREEMENT_TEMPLATE_ID` must be configured. For DocuSeal Cloud, set `DOCUSEAL_BASE_URL=https://api.docuseal.com`. For self-hosted DocuSeal, this is usually `https://your-host/api`.
   - Args:
     - `search_term` (required): Email, 508 email, Discord username, name, or contact ID.
   - Guardrails:

--- a/packages/shared/src/five08/clients/docuseal.py
+++ b/packages/shared/src/five08/clients/docuseal.py
@@ -116,6 +116,10 @@ def normalize_docuseal_base_url(base_url: str) -> str:
     """Normalize DocuSeal Cloud URLs and self-hosted root URLs to the API base."""
     normalized = base_url.strip().rstrip("/")
     parts = urlsplit(normalized)
+    if not parts.scheme or not parts.netloc or not parts.hostname:
+        raise ValueError(
+            "DOCUSEAL_BASE_URL must be an absolute URL including scheme and host."
+        )
     cleaned = urlunsplit((parts.scheme, parts.netloc, parts.path, "", "")).rstrip("/")
     hostname = (parts.hostname or "").lower()
     if hostname in {"docuseal.com", "www.docuseal.com"}:

--- a/packages/shared/src/five08/clients/docuseal.py
+++ b/packages/shared/src/five08/clients/docuseal.py
@@ -116,17 +116,13 @@ def normalize_docuseal_base_url(base_url: str) -> str:
     """Normalize DocuSeal Cloud URLs and self-hosted root URLs to the API base."""
     normalized = base_url.strip().rstrip("/")
     parts = urlsplit(normalized)
+    cleaned = urlunsplit((parts.scheme, parts.netloc, parts.path, "", "")).rstrip("/")
     hostname = (parts.hostname or "").lower()
     if hostname in {"docuseal.com", "www.docuseal.com"}:
-        return urlunsplit(
-            (
-                "https",
-                "api.docuseal.com",
-                "",
-                parts.query,
-                parts.fragment,
-            )
-        ).rstrip("/")
+        return "https://api.docuseal.com"
+
+    if hostname == "api.docuseal.com":
+        return "https://api.docuseal.com"
 
     if parts.path in {"", "/"}:
         return urlunsplit(
@@ -134,12 +130,12 @@ def normalize_docuseal_base_url(base_url: str) -> str:
                 parts.scheme or "https",
                 parts.netloc,
                 "/api",
-                parts.query,
-                parts.fragment,
+                "",
+                "",
             )
         ).rstrip("/")
 
-    return normalized
+    return cleaned
 
 
 def create_member_agreement_submission(

--- a/packages/shared/src/five08/clients/docuseal.py
+++ b/packages/shared/src/five08/clients/docuseal.py
@@ -1,6 +1,7 @@
 """Shared DocuSeal client helpers."""
 
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
@@ -20,7 +21,7 @@ class DocusealClient:
         api_key: str,
         timeout_seconds: float = 20.0,
     ) -> None:
-        self.base_url = base_url.rstrip("/")
+        self.base_url = normalize_docuseal_base_url(base_url)
         self.api_key = api_key
         self.timeout_seconds = timeout_seconds
         self.status_code: int | None = None
@@ -38,23 +39,13 @@ class DocusealClient:
             "X-Auth-Token": self.api_key,
         }
 
-        try:
-            response = requests.request(
-                method.upper(),
-                url,
-                headers=headers,
-                json=payload,
-                timeout=self.timeout_seconds,
-                verify=default_ca_bundle_path(),
-            )
-        except requests.RequestException as exc:
-            raise DocusealAPIError(f"HTTP request failed: {exc}") from exc
-
+        response = self._send_request(method, url, headers, payload)
         self.status_code = response.status_code
         if not 200 <= response.status_code < 300:
             message = response.text.strip() or "Unknown Error"
             raise DocusealAPIError(
-                f"Wrong request, status code is {response.status_code}, reason is {message}"
+                f"DocuSeal request to {url} failed: "
+                f"status code is {response.status_code}, reason is {message}"
             )
 
         if not response.content:
@@ -99,6 +90,56 @@ class DocusealClient:
             "submitters": [submitter],
         }
         return self.request("POST", "submissions", payload)
+
+    def _send_request(
+        self,
+        method: str,
+        url: str,
+        headers: dict[str, str],
+        payload: dict[str, Any] | None,
+    ) -> requests.Response:
+        """Send one HTTP request to DocuSeal."""
+        try:
+            return requests.request(
+                method.upper(),
+                url,
+                headers=headers,
+                json=payload,
+                timeout=self.timeout_seconds,
+                verify=default_ca_bundle_path(),
+            )
+        except requests.RequestException as exc:
+            raise DocusealAPIError(f"HTTP request failed: {exc}") from exc
+
+
+def normalize_docuseal_base_url(base_url: str) -> str:
+    """Normalize DocuSeal Cloud URLs and self-hosted root URLs to the API base."""
+    normalized = base_url.strip().rstrip("/")
+    parts = urlsplit(normalized)
+    hostname = (parts.hostname or "").lower()
+    if hostname in {"docuseal.com", "www.docuseal.com"}:
+        return urlunsplit(
+            (
+                "https",
+                "api.docuseal.com",
+                "",
+                parts.query,
+                parts.fragment,
+            )
+        ).rstrip("/")
+
+    if parts.path in {"", "/"}:
+        return urlunsplit(
+            (
+                parts.scheme or "https",
+                parts.netloc,
+                "/api",
+                parts.query,
+                parts.fragment,
+            )
+        ).rstrip("/")
+
+    return normalized
 
 
 def create_member_agreement_submission(

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -155,6 +155,24 @@ def test_normalize_docuseal_base_url_strips_query_and_fragment() -> None:
     )
 
 
+def test_normalize_docuseal_base_url_rejects_empty_string() -> None:
+    """Empty DocuSeal base URLs should fail with a clear validation error."""
+    with pytest.raises(
+        ValueError,
+        match="DOCUSEAL_BASE_URL must be an absolute URL including scheme and host",
+    ):
+        normalize_docuseal_base_url("")
+
+
+def test_normalize_docuseal_base_url_rejects_scheme_less_url() -> None:
+    """Scheme-less DocuSeal base URLs should fail validation."""
+    with pytest.raises(
+        ValueError,
+        match="DOCUSEAL_BASE_URL must be an absolute URL including scheme and host",
+    ):
+        normalize_docuseal_base_url("docuseal.508.dev")
+
+
 def test_create_member_agreement_submission_raises_on_invalid_json_body() -> None:
     """2xx responses with invalid JSON should still raise DocusealAPIError."""
     mock_response = Mock()

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -4,7 +4,11 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from five08.clients.docuseal import DocusealAPIError, create_member_agreement_submission
+from five08.clients.docuseal import (
+    DocusealAPIError,
+    create_member_agreement_submission,
+    normalize_docuseal_base_url,
+)
 from five08.tls import default_ca_bundle_path
 
 
@@ -30,7 +34,7 @@ def test_create_member_agreement_submission_posts_expected_payload() -> None:
     assert result == {"id": 4200}
     mock_request.assert_called_once_with(
         "POST",
-        "https://docuseal.example.com/submissions",
+        "https://docuseal.example.com/api/submissions",
         headers={
             "Content-Type": "application/json",
             "X-Auth-Token": "secret",
@@ -49,6 +53,53 @@ def test_create_member_agreement_submission_posts_expected_payload() -> None:
         timeout=20.0,
         verify=default_ca_bundle_path(),
     )
+
+
+def test_create_member_agreement_submission_normalizes_docuseal_cloud_ui_url() -> None:
+    """Cloud UI URLs should be rewritten to the DocuSeal API host."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'{"id": 4200}'
+    mock_response.json.return_value = {"id": 4200}
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ) as mock_request:
+        create_member_agreement_submission(
+            base_url="https://docuseal.com/",
+            api_key="secret",
+            template_id=1000001,
+            submitter_name="Jane Doe",
+            submitter_email="jane@example.com",
+        )
+
+    mock_request.assert_called_once()
+    assert mock_request.call_args.args[1] == "https://api.docuseal.com/submissions"
+
+
+def test_create_member_agreement_submission_normalizes_self_hosted_root_url() -> None:
+    """Self-hosted root URLs should be rewritten to the `/api` base once."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'{"id": 4200}'
+    mock_response.json.return_value = {"id": 4200}
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ) as mock_request:
+        result = create_member_agreement_submission(
+            base_url="https://docuseal.508.dev",
+            api_key="secret",
+            template_id=1000001,
+            submitter_name="Jane Doe",
+            submitter_email="jane@example.com",
+        )
+
+    assert result == {"id": 4200}
+    mock_request.assert_called_once()
+    assert mock_request.call_args.args[1] == "https://docuseal.508.dev/api/submissions"
 
 
 def test_create_member_agreement_submission_raises_on_api_error() -> None:
@@ -70,6 +121,22 @@ def test_create_member_agreement_submission_raises_on_api_error() -> None:
                 submitter_name="Jane Doe",
                 submitter_email="jane@example.com",
             )
+
+
+def test_normalize_docuseal_base_url_leaves_self_hosted_url_unchanged() -> None:
+    """Self-hosted DocuSeal API URLs should keep their configured base URL."""
+    assert (
+        normalize_docuseal_base_url("https://docuseal.example.com/api")
+        == "https://docuseal.example.com/api"
+    )
+
+
+def test_normalize_docuseal_base_url_adds_api_to_self_hosted_root_url() -> None:
+    """Self-hosted root URLs should normalize to the API base URL."""
+    assert (
+        normalize_docuseal_base_url("https://docuseal.example.com/")
+        == "https://docuseal.example.com/api"
+    )
 
 
 def test_create_member_agreement_submission_raises_on_invalid_json_body() -> None:

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -139,6 +139,22 @@ def test_normalize_docuseal_base_url_adds_api_to_self_hosted_root_url() -> None:
     )
 
 
+def test_normalize_docuseal_base_url_leaves_docuseal_cloud_api_url_unchanged() -> None:
+    """DocuSeal Cloud API URLs should not have `/api` appended again."""
+    assert (
+        normalize_docuseal_base_url("https://api.docuseal.com")
+        == "https://api.docuseal.com"
+    )
+
+
+def test_normalize_docuseal_base_url_strips_query_and_fragment() -> None:
+    """Normalized base URLs should drop query strings and fragments."""
+    assert (
+        normalize_docuseal_base_url("https://docuseal.example.com/api?x=1#frag")
+        == "https://docuseal.example.com/api"
+    )
+
+
 def test_create_member_agreement_submission_raises_on_invalid_json_body() -> None:
     """2xx responses with invalid JSON should still raise DocusealAPIError."""
     mock_response = Mock()


### PR DESCRIPTION
## Description
Normalize `DOCUSEAL_BASE_URL` before building submission URLs so DocuSeal Cloud uses `https://api.docuseal.com` and self-hosted root URLs use `/api`. This fixes the `/send-member-agreement` 404 when prod is configured with `https://docuseal.508.dev/`, improves DocuSeal error messages to include the request URL, and documents the expected config values. It also adds regression tests covering cloud URLs, self-hosted root URLs, and already-correct API URLs.

## Related Issue
None found.

## How Has This Been Tested?
- `uv run pytest tests/unit/test_docuseal_client.py`
- `uv run pytest tests/unit/test_crm.py -k send_member_agreement`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Improved DocuSeal integration with automatic URL normalization, now correctly handling DocuSeal Cloud and self-hosted instances without manual configuration adjustments.

* **Documentation**
  * Enhanced environment setup and Discord bot command documentation with clearer examples for DocuSeal configuration.

* **Tests**
  * Added comprehensive unit tests for URL normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->