### PR TITLE
fix: handle DocuSeal submitter list response

### DIFF
--- a/packages/shared/src/five08/clients/docuseal.py
+++ b/packages/shared/src/five08/clients/docuseal.py
@@ -31,7 +31,7 @@ class DocusealClient:
         method: str,
         path: str,
         payload: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
+    ) -> Any:
         """Send one JSON request to DocuSeal."""
         url = f"{self.base_url}/{path.lstrip('/')}"
         headers = {
@@ -63,8 +63,6 @@ class DocusealClient:
                 f"Failed to decode JSON response (status {response.status_code}). "
                 f"Body preview: {body_preview}"
             ) from exc
-        if not isinstance(json_data, dict):
-            raise DocusealAPIError("API response is not a JSON object")
         return json_data
 
     def create_submission(
@@ -89,7 +87,30 @@ class DocusealClient:
             "send_email": send_email,
             "submitters": [submitter],
         }
-        return self.request("POST", "submissions", payload)
+        response_payload = self.request("POST", "submissions", payload)
+        if isinstance(response_payload, dict):
+            return response_payload
+        if isinstance(response_payload, list):
+            return self._normalize_submission_submitters_response(response_payload)
+        raise DocusealAPIError("API response is not valid JSON for a submission")
+
+    @staticmethod
+    def _normalize_submission_submitters_response(
+        response_payload: list[Any],
+    ) -> dict[str, Any]:
+        """Convert DocuSeal's submitter list response into a stable submission object."""
+        if not response_payload:
+            raise DocusealAPIError("API response did not include any submitters")
+
+        first_submitter = response_payload[0]
+        if not isinstance(first_submitter, dict):
+            raise DocusealAPIError("API response submitter is not a JSON object")
+
+        submission_id = first_submitter.get("submission_id")
+        if submission_id is None:
+            raise DocusealAPIError("API response did not include a submission_id")
+
+        return {"id": submission_id}
 
     def _send_request(
         self,

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -130,6 +130,78 @@ def test_create_member_agreement_submission_normalizes_submitter_list_response()
     assert result == {"id": 4200}
 
 
+def test_create_member_agreement_submission_raises_on_empty_submitter_list() -> None:
+    """Create submission should reject empty submitter-array responses."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b"[]"
+    mock_response.json.return_value = []
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ):
+        with pytest.raises(
+            DocusealAPIError,
+            match="API response did not include any submitters",
+        ):
+            create_member_agreement_submission(
+                base_url="https://docuseal.example.com",
+                api_key="secret",
+                template_id=1000001,
+                submitter_name="Jane Doe",
+                submitter_email="jane@example.com",
+            )
+
+
+def test_create_member_agreement_submission_raises_on_non_object_submitter() -> None:
+    """Create submission should reject submitter arrays with non-object entries."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'["not-an-object"]'
+    mock_response.json.return_value = ["not-an-object"]
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ):
+        with pytest.raises(
+            DocusealAPIError,
+            match="API response submitter is not a JSON object",
+        ):
+            create_member_agreement_submission(
+                base_url="https://docuseal.example.com",
+                api_key="secret",
+                template_id=1000001,
+                submitter_name="Jane Doe",
+                submitter_email="jane@example.com",
+            )
+
+
+def test_create_member_agreement_submission_raises_on_missing_submission_id() -> None:
+    """Create submission should reject submitter arrays without a submission id."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'[{"id": 11, "role": "First Party"}]'
+    mock_response.json.return_value = [{"id": 11, "role": "First Party"}]
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ):
+        with pytest.raises(
+            DocusealAPIError,
+            match="API response did not include a submission_id",
+        ):
+            create_member_agreement_submission(
+                base_url="https://docuseal.example.com",
+                api_key="secret",
+                template_id=1000001,
+                submitter_name="Jane Doe",
+                submitter_email="jane@example.com",
+            )
+
+
 def test_create_member_agreement_submission_keeps_object_response() -> None:
     """Create submission should still accept object responses if returned."""
     mock_response = Mock()

--- a/tests/unit/test_docuseal_client.py
+++ b/tests/unit/test_docuseal_client.py
@@ -16,8 +16,8 @@ def test_create_member_agreement_submission_posts_expected_payload() -> None:
     """Shared helper should create a standard member agreement submission."""
     mock_response = Mock()
     mock_response.status_code = 201
-    mock_response.content = b'{"id": 4200}'
-    mock_response.json.return_value = {"id": 4200}
+    mock_response.content = b'[{"id": 1, "submission_id": 4200}]'
+    mock_response.json.return_value = [{"id": 1, "submission_id": 4200}]
 
     with patch(
         "five08.clients.docuseal.requests.request",
@@ -59,8 +59,8 @@ def test_create_member_agreement_submission_normalizes_docuseal_cloud_ui_url() -
     """Cloud UI URLs should be rewritten to the DocuSeal API host."""
     mock_response = Mock()
     mock_response.status_code = 201
-    mock_response.content = b'{"id": 4200}'
-    mock_response.json.return_value = {"id": 4200}
+    mock_response.content = b'[{"id": 1, "submission_id": 4200}]'
+    mock_response.json.return_value = [{"id": 1, "submission_id": 4200}]
 
     with patch(
         "five08.clients.docuseal.requests.request",
@@ -82,8 +82,8 @@ def test_create_member_agreement_submission_normalizes_self_hosted_root_url() ->
     """Self-hosted root URLs should be rewritten to the `/api` base once."""
     mock_response = Mock()
     mock_response.status_code = 201
-    mock_response.content = b'{"id": 4200}'
-    mock_response.json.return_value = {"id": 4200}
+    mock_response.content = b'[{"id": 1, "submission_id": 4200}]'
+    mock_response.json.return_value = [{"id": 1, "submission_id": 4200}]
 
     with patch(
         "five08.clients.docuseal.requests.request",
@@ -100,6 +100,56 @@ def test_create_member_agreement_submission_normalizes_self_hosted_root_url() ->
     assert result == {"id": 4200}
     mock_request.assert_called_once()
     assert mock_request.call_args.args[1] == "https://docuseal.508.dev/api/submissions"
+
+
+def test_create_member_agreement_submission_normalizes_submitter_list_response() -> (
+    None
+):
+    """Create submission should accept DocuSeal's submitter array response."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = (
+        b'[{"id": 11, "submission_id": 4200, "role": "First Party"}]'
+    )
+    mock_response.json.return_value = [
+        {"id": 11, "submission_id": 4200, "role": "First Party"}
+    ]
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ):
+        result = create_member_agreement_submission(
+            base_url="https://docuseal.example.com",
+            api_key="secret",
+            template_id=1000001,
+            submitter_name="Jane Doe",
+            submitter_email="jane@example.com",
+        )
+
+    assert result == {"id": 4200}
+
+
+def test_create_member_agreement_submission_keeps_object_response() -> None:
+    """Create submission should still accept object responses if returned."""
+    mock_response = Mock()
+    mock_response.status_code = 201
+    mock_response.content = b'{"id": 4200}'
+    mock_response.json.return_value = {"id": 4200}
+
+    with patch(
+        "five08.clients.docuseal.requests.request",
+        return_value=mock_response,
+    ):
+        result = create_member_agreement_submission(
+            base_url="https://docuseal.example.com",
+            api_key="secret",
+            template_id=1000001,
+            submitter_name="Jane Doe",
+            submitter_email="jane@example.com",
+        )
+
+    assert result == {"id": 4200}
 
 
 def test_create_member_agreement_submission_raises_on_api_error() -> None:


### PR DESCRIPTION
## Description
Handle DocuSeal submission create responses that return a submitter array instead of a JSON object. Normalize that response back to the submission ID shape expected by the Discord CRM flow, and add regression coverage for both array and object responses.

## Related Issue
No matching issue found.

## How Has This Been Tested?
- `uv run pytest tests/unit/test_docuseal_client.py`
- `uv run pytest tests/unit/test_crm.py -k send_member_agreement`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DocuSeal integration to accept both object and list JSON responses, normalize list responses to a stable submission object, and raise errors for invalid or unexpected response shapes.

* **Tests**
  * Expanded tests to cover normalization of submitter-list responses, acceptance of object responses, and error cases for empty, malformed, or incomplete responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->