### PR TITLE
[codex] Guard worktree ports against browser-unsafe values

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,8 +51,10 @@ MINIO_HOST_BIND=127.0.0.1
 
 # API (optional defaults; API_SHARED_SECRET required to accept ingest calls)
 WEBHOOK_INGEST_HOST=0.0.0.0
-# Host-run API processes use this port directly. docker-compose.yml pins the
-# API container to 8090 internally and varies only the published host port.
+# Host-run API processes launched through `./scripts/dev.sh api` ignore this
+# `.env` value and compute a deterministic per-worktree port unless you export
+# WEBHOOK_INGEST_PORT in your shell. docker-compose.yml pins the API container
+# to 8090 internally and varies only the published host port.
 WEBHOOK_INGEST_PORT=8090
 WEBHOOK_INGEST_HOST_BIND=127.0.0.1
 # Optional: expose ingest API on a fixed host port for local debugging.
@@ -131,9 +133,10 @@ DOCUSEAL_API_KEY=
 
 # Discord bot (required for bot runtime)
 DISCORD_BOT_TOKEN=your_bot_token_here
+# Host-run bot processes launched through `./scripts/dev.sh discord-bot` ignore
+# this `.env` value and compute a deterministic per-worktree port unless you
+# export HEALTHCHECK_PORT in your shell.
 HEALTHCHECK_PORT=3000
-# Host-run bot processes launched through `./scripts/dev.sh discord-bot` override
-# `HEALTHCHECK_PORT` with a deterministic per-worktree port automatically.
 BACKEND_API_BASE_URL=http://127.0.0.1:8090
 AUDIT_API_BASE_URL=
 AUDIT_API_TIMEOUT_SECONDS=2.0

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -59,7 +59,7 @@ Use `.env.example` as the source of defaults.
 
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default when unset: deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060` because Chrome blocks them)
+- `Optional`: `WEBHOOK_INGEST_PORT` (host-run `./scripts/dev.sh` ignores `.env` for this key and defaults to a deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; export it in your shell only when you intentionally want a fixed port, and avoid browser-unsafe ports such as `5060`)
 - `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, and pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 - `Required`: `API_SHARED_SECRET` (global shared secret for protected endpoints and webhooks)
 
@@ -122,7 +122,7 @@ Use `.env.example` as the source of defaults.
 ## Discord Bot Core
 
 - `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
-- `Optional`: `HEALTHCHECK_PORT` (default when unset: deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`)
+- `Optional`: `HEALTHCHECK_PORT` (host-run `./scripts/dev.sh` ignores `.env` for this key and defaults to a deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; export it in your shell only when you intentionally want a fixed port, and avoid browser-unsafe ports such as `5060`)
 - Note: bot message chunking follows Discord's 2000 character limit in code.
 
 ## Migadu Mailbox Automation

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -47,8 +47,8 @@ Use `.env.example` as the source of defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; set `MINIO_API_HOST_PORT=9000` to pin it to `9000`; see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; set `MINIO_CONSOLE_HOST_PORT=9001` to pin it to `9001`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 
 ### Notes
 
@@ -59,8 +59,8 @@ Use `.env.example` as the source of defaults.
 
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; host-run API listen port. Compose pins the container listen port to `8090` and varies only the published host port)
-- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default when unset: deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060` because Chrome blocks them)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, and pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 - `Required`: `API_SHARED_SECRET` (global shared secret for protected endpoints and webhooks)
 
 ## Backend API OIDC Session Auth
@@ -122,7 +122,7 @@ Use `.env.example` as the source of defaults.
 ## Discord Bot Core
 
 - `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
-- `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
+- `Optional`: `HEALTHCHECK_PORT` (default when unset: deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`)
 - Note: bot message chunking follows Discord's 2000 character limit in code.
 
 ## Migadu Mailbox Automation

--- a/README.md
+++ b/README.md
@@ -193,8 +193,8 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `MINIO_INTERNAL_BUCKET` (default: `internal-transfers`)
 - `Optional`: `MINIO_ROOT_USER` (default: `internal`)
 - `Optional`: `MINIO_HOST_BIND` (default: `127.0.0.1`; set `0.0.0.0` to expose externally)
-- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; set `MINIO_API_HOST_PORT=9000` to pin it to `9000`; see `./scripts/docker-compose.sh print-ports`)
-- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; set `MINIO_CONSOLE_HOST_PORT=9001` to pin it to `9001`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_API_HOST_PORT` (default when unset: deterministic per-worktree value `24000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `MINIO_CONSOLE_HOST_PORT` (default when unset: deterministic per-worktree value `28000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 - Note: `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` are `SharedSettings` alias properties (`minio_access_key`, `minio_secret_key`) and are not env-loaded fields.
 - Note: use `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` as the actual env vars.
 
@@ -203,8 +203,8 @@ Use `.env.example` as the source of truth for defaults.
 - `Required` for protected endpoints: `API_SHARED_SECRET` (ingest requests are rejected when unset)
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default: `8090`; host-run API listen port. Compose pins the container listen port to `8090` and only varies the published host port.)
-- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, see `./scripts/docker-compose.sh print-ports`)
+- `Optional`: `WEBHOOK_INGEST_PORT` (default when unset: deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060` because Chrome blocks them)
+- `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, and pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 
 ### Backend API OIDC Session Auth
 
@@ -262,7 +262,7 @@ Use `.env.example` as the source of truth for defaults.
 
 - `Required`: `DISCORD_BOT_TOKEN`
 - `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
-- `Optional`: `HEALTHCHECK_PORT` (default: `3000`)
+- `Optional`: `HEALTHCHECK_PORT` (default when unset: deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`)
 - Note: bot message chunking uses Discord's 2000 character limit in code.
 
 ### Discord CRM Audit Logging (Best Effort)

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Required` for protected endpoints: `API_SHARED_SECRET` (ingest requests are rejected when unset)
 - `Optional`: `WEBHOOK_INGEST_HOST` (default: `0.0.0.0`)
 - `Optional`: `WEBHOOK_INGEST_HOST_BIND` (default: `127.0.0.1`; Compose host bind for local exposure)
-- `Optional`: `WEBHOOK_INGEST_PORT` (default when unset: deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060` because Chrome blocks them)
+- `Optional`: `WEBHOOK_INGEST_PORT` (host-run `./scripts/dev.sh` ignores `.env` for this key and defaults to a deterministic per-worktree value near `18080 + WORKTREE_ENV_SLOT`; export it in your shell only when you intentionally want a fixed port, and avoid browser-unsafe ports such as `5060`)
 - `Optional`: `WEBHOOK_INGEST_HOST_PORT` (default: `8090` when running `docker compose` directly; `./scripts/docker-compose.sh` computes a deterministic per-worktree value when unset, and pinned values must avoid browser-unsafe ports such as `5060`; see `./scripts/docker-compose.sh print-ports`)
 
 ### Backend API OIDC Session Auth
@@ -262,7 +262,7 @@ Use `.env.example` as the source of truth for defaults.
 
 - `Required`: `DISCORD_BOT_TOKEN`
 - `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
-- `Optional`: `HEALTHCHECK_PORT` (default when unset: deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; pinned values must avoid browser-unsafe ports such as `5060`)
+- `Optional`: `HEALTHCHECK_PORT` (host-run `./scripts/dev.sh` ignores `.env` for this key and defaults to a deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; export it in your shell only when you intentionally want a fixed port, and avoid browser-unsafe ports such as `5060`)
 - Note: bot message chunking uses Discord's 2000 character limit in code.
 
 ### Discord CRM Audit Logging (Best Effort)

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -87,6 +87,70 @@ worktree_env_resolve_shell_or_default() {
   printf '%s' "$default_value"
 }
 
+worktree_env_validate_port_number() {
+  port_value=$1
+  port_label=$2
+
+  case $port_value in
+    ''|*[!0-9]*)
+      echo "$port_label must be a numeric TCP port, got '$port_value'." >&2
+      return 1
+      ;;
+  esac
+
+  if [ "$port_value" -lt 1 ] || [ "$port_value" -gt 65535 ]; then
+    echo "$port_label must be between 1 and 65535, got '$port_value'." >&2
+    return 1
+  fi
+}
+
+worktree_env_is_browser_unsafe_port() {
+  case " $1 " in
+    *" 1 "*|*" 7 "*|*" 9 "*|*" 11 "*|*" 13 "*|*" 15 "*|*" 17 "*|*" 19 "*|*" 20 "*|*" 21 "*|*" 22 "*|*" 23 "*|*" 25 "*|*" 37 "*|*" 42 "*|*" 43 "*|*" 53 "*|*" 69 "*|*" 77 "*|*" 79 "*|*" 87 "*|*" 95 "*|*" 101 "*|*" 102 "*|*" 103 "*|*" 104 "*|*" 109 "*|*" 110 "*|*" 111 "*|*" 113 "*|*" 115 "*|*" 117 "*|*" 119 "*|*" 123 "*|*" 135 "*|*" 137 "*|*" 139 "*|*" 143 "*|*" 161 "*|*" 179 "*|*" 389 "*|*" 427 "*|*" 465 "*|*" 512 "*|*" 513 "*|*" 514 "*|*" 515 "*|*" 526 "*|*" 530 "*|*" 531 "*|*" 532 "*|*" 540 "*|*" 548 "*|*" 554 "*|*" 556 "*|*" 563 "*|*" 587 "*|*" 601 "*|*" 636 "*|*" 989 "*|*" 990 "*|*" 993 "*|*" 995 "*|*" 1719 "*|*" 1720 "*|*" 1723 "*|*" 2049 "*|*" 3659 "*|*" 4045 "*|*" 5060 "*|*" 5061 "*|*" 6000 "*|*" 6566 "*|*" 6665 "*|*" 6666 "*|*" 6667 "*|*" 6668 "*|*" 6669 "*|*" 6697 "*|*" 10080 "*)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
+worktree_env_next_browser_safe_port() {
+  port_value=$1
+  while worktree_env_is_browser_unsafe_port "$port_value"; do
+    port_value=$((port_value + 1))
+  done
+  printf '%s' "$port_value"
+}
+
+worktree_env_resolve_browser_safe_port() {
+  key=$1
+  default_value=$2
+  env_file=$3
+  port_label=$4
+  source_label=default
+  eval "shell_value=\${$key-}"
+
+  if [ -n "$shell_value" ]; then
+    resolved_value=$shell_value
+    source_label=environment
+  elif file_value=$(worktree_env_get_env_file_value "$key" "$env_file" 2>/dev/null); then
+    resolved_value=$file_value
+    source_label=.env
+  else
+    resolved_value=$default_value
+  fi
+
+  worktree_env_validate_port_number "$resolved_value" "$port_label" || return 1
+
+  if [ "$source_label" = "default" ]; then
+    resolved_value=$(worktree_env_next_browser_safe_port "$resolved_value")
+  elif worktree_env_is_browser_unsafe_port "$resolved_value"; then
+    echo "$port_label cannot use browser-unsafe port '$resolved_value'; pick a different port." >&2
+    return 1
+  fi
+
+  printf '%s' "$resolved_value"
+}
+
 worktree_env_load() {
   script_dir=$1
   mode=${2:-host}
@@ -108,9 +172,9 @@ worktree_env_load() {
   POSTGRES_USER=$(worktree_env_resolve_value POSTGRES_USER "postgres" "$WORKTREE_ENV_FILE")
   POSTGRES_PASSWORD=$(worktree_env_resolve_value POSTGRES_PASSWORD "postgres" "$WORKTREE_ENV_FILE")
   POSTGRES_DB=$(worktree_env_resolve_value POSTGRES_DB "workflows" "$WORKTREE_ENV_FILE")
-  WEBHOOK_INGEST_HOST_PORT=$(worktree_env_resolve_value WEBHOOK_INGEST_HOST_PORT "$((20080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
-  MINIO_API_HOST_PORT=$(worktree_env_resolve_value MINIO_API_HOST_PORT "$((24000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
-  MINIO_CONSOLE_HOST_PORT=$(worktree_env_resolve_value MINIO_CONSOLE_HOST_PORT "$((28000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE")
+  WEBHOOK_INGEST_HOST_PORT=$(worktree_env_resolve_browser_safe_port WEBHOOK_INGEST_HOST_PORT "$((20080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "WEBHOOK_INGEST_HOST_PORT")
+  MINIO_API_HOST_PORT=$(worktree_env_resolve_browser_safe_port MINIO_API_HOST_PORT "$((24000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "MINIO_API_HOST_PORT")
+  MINIO_CONSOLE_HOST_PORT=$(worktree_env_resolve_browser_safe_port MINIO_CONSOLE_HOST_PORT "$((28000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "MINIO_CONSOLE_HOST_PORT")
 
   export WORKTREE_ENV_REPO_ROOT
   export WORKTREE_ENV_FILE
@@ -128,8 +192,8 @@ worktree_env_load() {
   if [ "$mode" = "host" ]; then
     # Keep host-run app ports below the Linux default ephemeral range
     # (32768-60999) to avoid rare EADDRINUSE races with outbound sockets.
-    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_shell_or_default WEBHOOK_INGEST_PORT "$((18080 + WORKTREE_ENV_SLOT))")
-    HEALTHCHECK_PORT=$(worktree_env_resolve_shell_or_default HEALTHCHECK_PORT "$((30000 + WORKTREE_ENV_SLOT))")
+    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_browser_safe_port WEBHOOK_INGEST_PORT "$((18080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "WEBHOOK_INGEST_PORT")
+    HEALTHCHECK_PORT=$(worktree_env_resolve_browser_safe_port HEALTHCHECK_PORT "$((30000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "HEALTHCHECK_PORT")
     export WEBHOOK_INGEST_PORT
     export HEALTHCHECK_PORT
   else

--- a/scripts/worktree-env.sh
+++ b/scripts/worktree-env.sh
@@ -121,6 +121,23 @@ worktree_env_next_browser_safe_port() {
   printf '%s' "$port_value"
 }
 
+worktree_env_finalize_browser_safe_port() {
+  resolved_value=$1
+  source_label=$2
+  port_label=$3
+
+  worktree_env_validate_port_number "$resolved_value" "$port_label" || return 1
+
+  if [ "$source_label" = "default" ]; then
+    resolved_value=$(worktree_env_next_browser_safe_port "$resolved_value")
+  elif worktree_env_is_browser_unsafe_port "$resolved_value"; then
+    echo "$port_label cannot use browser-unsafe port '$resolved_value'; pick a different port." >&2
+    return 1
+  fi
+
+  printf '%s' "$resolved_value"
+}
+
 worktree_env_resolve_browser_safe_port() {
   key=$1
   default_value=$2
@@ -139,16 +156,30 @@ worktree_env_resolve_browser_safe_port() {
     resolved_value=$default_value
   fi
 
-  worktree_env_validate_port_number "$resolved_value" "$port_label" || return 1
+  worktree_env_finalize_browser_safe_port \
+    "$resolved_value" \
+    "$source_label" \
+    "$port_label"
+}
 
-  if [ "$source_label" = "default" ]; then
-    resolved_value=$(worktree_env_next_browser_safe_port "$resolved_value")
-  elif worktree_env_is_browser_unsafe_port "$resolved_value"; then
-    echo "$port_label cannot use browser-unsafe port '$resolved_value'; pick a different port." >&2
-    return 1
+worktree_env_resolve_browser_safe_shell_or_default() {
+  key=$1
+  default_value=$2
+  port_label=$3
+  source_label=default
+  eval "shell_value=\${$key-}"
+
+  if [ -n "$shell_value" ]; then
+    resolved_value=$shell_value
+    source_label=environment
+  else
+    resolved_value=$default_value
   fi
 
-  printf '%s' "$resolved_value"
+  worktree_env_finalize_browser_safe_port \
+    "$resolved_value" \
+    "$source_label" \
+    "$port_label"
 }
 
 worktree_env_load() {
@@ -192,8 +223,8 @@ worktree_env_load() {
   if [ "$mode" = "host" ]; then
     # Keep host-run app ports below the Linux default ephemeral range
     # (32768-60999) to avoid rare EADDRINUSE races with outbound sockets.
-    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_browser_safe_port WEBHOOK_INGEST_PORT "$((18080 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "WEBHOOK_INGEST_PORT")
-    HEALTHCHECK_PORT=$(worktree_env_resolve_browser_safe_port HEALTHCHECK_PORT "$((30000 + WORKTREE_ENV_SLOT))" "$WORKTREE_ENV_FILE" "HEALTHCHECK_PORT")
+    WEBHOOK_INGEST_PORT=$(worktree_env_resolve_browser_safe_shell_or_default WEBHOOK_INGEST_PORT "$((18080 + WORKTREE_ENV_SLOT))" "WEBHOOK_INGEST_PORT")
+    HEALTHCHECK_PORT=$(worktree_env_resolve_browser_safe_shell_or_default HEALTHCHECK_PORT "$((30000 + WORKTREE_ENV_SLOT))" "HEALTHCHECK_PORT")
     export WEBHOOK_INGEST_PORT
     export HEALTHCHECK_PORT
   else

--- a/tests/unit/test_worktree_env.py
+++ b/tests/unit/test_worktree_env.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -73,3 +74,46 @@ def test_worktree_env_load_rejects_unsafe_compose_http_port_override() -> None:
         "WEBHOOK_INGEST_HOST_PORT cannot use browser-unsafe port '5060'; "
         "pick a different port." in result.stderr
     )
+
+
+def test_worktree_env_load_host_mode_ignores_dotenv_host_port_pins() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        repo_root = Path(tmp_dir)
+        scripts_dir = repo_root / "scripts"
+        scripts_dir.mkdir()
+        env = os.environ.copy()
+        env.pop("WEBHOOK_INGEST_PORT", None)
+        env.pop("HEALTHCHECK_PORT", None)
+        (repo_root / ".env").write_text(
+            "WEBHOOK_INGEST_PORT=8090\nHEALTHCHECK_PORT=3000\n",
+            encoding="utf-8",
+        )
+
+        result = _run_shell(
+            f"""
+            set -eu
+            . {SCRIPT_PATH}
+            worktree_env_load {scripts_dir} host
+            printf '%s\\n%s\\n' "$WEBHOOK_INGEST_PORT" "$HEALTHCHECK_PORT"
+            """,
+            env=env,
+        )
+
+        assert result.returncode == 0
+
+        hash_value = subprocess.run(
+            [
+                "/bin/sh",
+                "-c",
+                f"printf '%s' '{repo_root}' | cksum | awk '{{print $1}}'",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        slot = int(hash_value) % 2000
+
+        assert result.stdout.splitlines() == [
+            str(18080 + slot),
+            str(30000 + slot),
+        ]

--- a/tests/unit/test_worktree_env.py
+++ b/tests/unit/test_worktree_env.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "worktree-env.sh"
+
+
+def _run_shell(
+    script: str, *, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["zsh", "-c", script],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_resolve_browser_safe_port_skips_chrome_unsafe_defaults() -> None:
+    result = _run_shell(
+        f"""
+        set -eu
+        . {SCRIPT_PATH}
+        worktree_env_resolve_browser_safe_port TEST_PORT 5060 /dev/null TEST_PORT
+        """
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == "5062"
+
+
+def test_resolve_browser_safe_port_rejects_explicit_unsafe_override() -> None:
+    env = os.environ.copy()
+    env["TEST_PORT"] = "5060"
+
+    result = _run_shell(
+        f"""
+        set -eu
+        . {SCRIPT_PATH}
+        worktree_env_resolve_browser_safe_port TEST_PORT 3000 /dev/null TEST_PORT
+        """,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "TEST_PORT cannot use browser-unsafe port '5060'; pick a different port."
+        in result.stderr
+    )
+
+
+def test_worktree_env_load_rejects_unsafe_compose_http_port_override() -> None:
+    env = os.environ.copy()
+    env["WEBHOOK_INGEST_HOST_PORT"] = "5060"
+
+    result = _run_shell(
+        f"""
+        set -eu
+        . {SCRIPT_PATH}
+        worktree_env_load {REPO_ROOT / "scripts"} compose
+        """,
+        env=env,
+    )
+
+    assert result.returncode != 0
+    assert (
+        "WEBHOOK_INGEST_HOST_PORT cannot use browser-unsafe port '5060'; "
+        "pick a different port." in result.stderr
+    )

--- a/tests/unit/test_worktree_env.py
+++ b/tests/unit/test_worktree_env.py
@@ -13,7 +13,7 @@ def _run_shell(
     script: str, *, env: dict[str, str] | None = None
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["zsh", "-c", script],
+        ["/bin/sh", "-c", script],
         cwd=REPO_ROOT,
         env=env,
         check=False,


### PR DESCRIPTION
## Description
Guard worktree-resolved localhost ports against Chrome's unsafe-port blocklist so admin and other local HTTP surfaces do not land on unusable ports like `5060`. The shell resolver now skips unsafe defaults, rejects explicitly pinned unsafe overrides for both host-run and Compose-published HTTP ports, and the docs/tests were updated to cover the new behavior.

## Related Issue
#13

## How Has This Been Tested?
- `uv run pytest tests/unit/test_worktree_env.py tests/unit/test_dev_mux.py`
- `WEBHOOK_INGEST_PORT=5060 ./scripts/dev.sh ports`
- `WEBHOOK_INGEST_HOST_PORT=5060 ./scripts/docker-compose.sh print-ports`
