### PR TITLE
[codex] Add Outline account provisioning commands

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,12 @@ AUTHENTIK_API_TOKEN=
 AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
+# Outline wiki invitations (required for /create-user-accounts)
+# For Outline Cloud, keep the default https://app.getoutline.com/api.
+# For self-hosted Outline, use https://your-outline-host/api.
+OUTLINE_API_BASE_URL=https://app.getoutline.com/api
+OUTLINE_API_TIMEOUT_SECONDS=20.0
+OUTLINE_API_KEY=
 # Optional: Discord logs webhook for operator-visible logs from commands/jobs
 DISCORD_LOGS_WEBHOOK_URL=
 # Optional: wait for Discord server confirmation before returning from webhook call

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ WEBHOOK_INGEST_HOST_BIND=127.0.0.1
 # `WEBHOOK_INGEST_PORT` with a deterministic per-worktree port automatically.
 # Required: ingest requests are rejected when unset
 API_SHARED_SECRET=
-# Authentik admin API (required for /create-sso-user)
+# Authentik admin API (required for /create-sso-user and /create-user-accounts)
 # Base URL can omit /api/v3; the client adds it automatically.
 AUTHENTIK_API_BASE_URL=
 AUTHENTIK_API_TIMEOUT_SECONDS=20.0
@@ -73,7 +73,8 @@ AUTHENTIK_API_TOKEN=
 AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
-# Outline wiki invitations (required for /create-user-accounts and /invite-outline-user)
+# Outline wiki invitations (also requires Migadu + Authentik for /create-user-accounts)
+# Required for /create-user-accounts and /invite-outline-user.
 # For Outline Cloud, keep the default https://app.getoutline.com.
 # For self-hosted Outline, use https://your-outline-host.
 OUTLINE_BASE_URL=https://app.getoutline.com

--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ AUTHENTIK_API_TOKEN=
 AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
-# Outline wiki invitations (required for /create-user-accounts)
+# Outline wiki invitations (required for /create-user-accounts and /invite-outline-user)
 # For Outline Cloud, keep the default https://app.getoutline.com.
 # For self-hosted Outline, use https://your-outline-host.
 OUTLINE_BASE_URL=https://app.getoutline.com

--- a/.env.example
+++ b/.env.example
@@ -74,9 +74,9 @@ AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
 # Outline wiki invitations (required for /create-user-accounts)
-# For Outline Cloud, keep the default https://app.getoutline.com/api.
-# For self-hosted Outline, use https://your-outline-host/api.
-OUTLINE_API_BASE_URL=https://app.getoutline.com/api
+# For Outline Cloud, keep the default https://app.getoutline.com.
+# For self-hosted Outline, use https://your-outline-host.
+OUTLINE_BASE_URL=https://app.getoutline.com
 OUTLINE_API_TIMEOUT_SECONDS=20.0
 OUTLINE_API_KEY=
 # Optional: Discord logs webhook for operator-visible logs from commands/jobs

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -127,12 +127,20 @@ Use `.env.example` as the source of defaults.
 
 ## Migadu Mailbox Automation
 
-- `Required for /create-mailbox`: `MIGADU_API_USER`, `MIGADU_API_KEY`
+- `Required for /create-mailbox and /create-user-accounts`: `MIGADU_API_USER`, `MIGADU_API_KEY`
 - `Optional`: `MIGADU_MAILBOX_DOMAIN` (default: `508.dev`)
+
+## Authentik SSO Provisioning
+
+- `Required for /create-sso-user and /create-user-accounts`: `AUTHENTIK_API_BASE_URL`, `AUTHENTIK_API_TOKEN`
+- `Optional`: `AUTHENTIK_API_TIMEOUT_SECONDS` (default: `20.0`)
+- `Optional`: `AUTHENTIK_RECOVERY_EMAIL_STAGE_ID` (when unset, the bot resolves by name)
+- `Optional`: `AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME` (default: `default-recovery-email`)
 
 ## Outline Invitations
 
 - `Required for /create-user-accounts and /invite-outline-user`: `OUTLINE_API_KEY`
+- Note: `/create-user-accounts` also requires the Migadu and Authentik settings above.
 - `Optional`: `OUTLINE_BASE_URL` (default: `https://app.getoutline.com`; root and `/api` URLs are both accepted)
 - `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -130,6 +130,12 @@ Use `.env.example` as the source of defaults.
 - `Required for /create-mailbox`: `MIGADU_API_USER`, `MIGADU_API_KEY`
 - `Optional`: `MIGADU_MAILBOX_DOMAIN` (default: `508.dev`)
 
+## Outline Invitations
+
+- `Required for /create-user-accounts`: `OUTLINE_API_KEY`
+- `Optional`: `OUTLINE_API_BASE_URL` (default: `https://app.getoutline.com/api`)
+- `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
+
 ## Discord CRM Audit Logging (Best Effort)
 
 - `Optional`: `AUDIT_API_BASE_URL` (when set with `API_SHARED_SECRET`, CRM commands emit best-effort audit events)

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -132,7 +132,7 @@ Use `.env.example` as the source of defaults.
 
 ## Outline Invitations
 
-- `Required for /create-user-accounts`: `OUTLINE_API_KEY`
+- `Required for /create-user-accounts and /invite-outline-user`: `OUTLINE_API_KEY`
 - `Optional`: `OUTLINE_BASE_URL` (default: `https://app.getoutline.com`; root and `/api` URLs are both accepted)
 - `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -133,7 +133,7 @@ Use `.env.example` as the source of defaults.
 ## Outline Invitations
 
 - `Required for /create-user-accounts`: `OUTLINE_API_KEY`
-- `Optional`: `OUTLINE_API_BASE_URL` (default: `https://app.getoutline.com/api`)
+- `Optional`: `OUTLINE_BASE_URL` (default: `https://app.getoutline.com`; root and `/api` URLs are both accepted)
 - `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
 
 ## Discord CRM Audit Logging (Best Effort)

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -10,6 +10,7 @@ import ast
 import io
 import json
 import logging
+from dataclasses import dataclass
 from datetime import date, datetime
 import re
 from typing import Any, Literal
@@ -26,6 +27,13 @@ from five08.clients.docuseal import (
     DocusealAPIError,
     create_member_agreement_submission,
 )
+from five08.clients.migadu import (
+    MigaduAPIError,
+    MigaduClient,
+    MigaduMailboxCreateRequest,
+    normalize_migadu_mailbox_domain,
+)
+from five08.clients.outline import OutlineAPIError, OutlineClient
 from five08.document_text import document_file_extension, extract_document_text
 from five08.crm_normalization import (
     format_seniority_label as shared_format_seniority_label,
@@ -82,6 +90,59 @@ LINKEDIN_FIELD = "cLinkedIn"
 EspoClient = espo.EspoClient
 EspoAPI = EspoClient
 EspoAPIError = espo.EspoAPIError
+
+
+@dataclass(frozen=True, slots=True)
+class SSOProvisioningResult:
+    """Result from creating or linking one Authentik SSO user."""
+
+    contact_id: str
+    contact_name: str
+    username: str
+    email: str
+    user_id: int
+    created: bool
+    freshly_created: bool
+    recovered_existing_after_create_error: bool
+    crm_updated: bool
+    recovery_email_error: str | None
+
+
+class SSOProvisioningPartialError(RuntimeError):
+    """Raised when Authentik succeeded but a later local/CRM step failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        partial_user_id: int | None,
+        partial_success: str,
+    ) -> None:
+        super().__init__(message)
+        self.partial_user_id = partial_user_id
+        self.partial_success = partial_success
+
+
+@dataclass(frozen=True, slots=True)
+class MailboxProvisioningResult:
+    """Result from creating or reusing one 508 mailbox."""
+
+    email: str
+    created: bool
+    crm_updated: bool
+    backup_email: str
+
+
+@dataclass(frozen=True, slots=True)
+class UserAccountsProvisioningResult:
+    """Combined account provisioning result for Discord output."""
+
+    contact_id: str
+    contact_name: str
+    email: str
+    mailbox: MailboxProvisioningResult
+    sso: SSOProvisioningResult
+    outline_invited: bool
 
 
 def _format_seniority_label(value: str | None) -> str:
@@ -421,6 +482,215 @@ class CreateSSOUserSelectionView(discord.ui.View):
             except discord.HTTPException as exc:
                 logger.warning(
                     "Failed to disable create_sso_user selection view: %s", exc
+                )
+
+
+class CreateUserAccountsSelectionButton(
+    discord.ui.Button["CreateUserAccountsSelectionView"]
+):
+    """Button for selecting a contact to continue all-in-one provisioning."""
+
+    def __init__(self, contact: dict[str, Any], requester_id: int) -> None:
+        contact_name = str(contact.get("name", "Unknown"))
+        label = contact_name[:80] if len(contact_name) > 80 else contact_name
+        super().__init__(style=discord.ButtonStyle.primary, label=label, emoji="👤")
+        self.contact = contact
+        self.requester_id = requester_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Handle contact selection and continue account provisioning."""
+        try:
+            if not self.view:
+                await interaction.response.send_message(
+                    "❌ View not found.",
+                    ephemeral=True,
+                )
+                return
+            if interaction.user.id != self.requester_id:
+                await interaction.response.send_message(
+                    "❌ Only the command requester can confirm this action.",
+                    ephemeral=True,
+                )
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            await self.view.crm_cog._create_user_accounts_for_contact(
+                interaction=interaction,
+                contact=self.contact,
+                search_term=self.view.search_term,
+                mailbox_username=self.view.mailbox_username,
+            )
+
+            for item in self.view.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+
+            if interaction.message:
+                try:
+                    await interaction.message.edit(view=self.view)
+                except discord.NotFound:
+                    pass
+                except discord.HTTPException as exc:
+                    logger.warning(
+                        "Failed to update create_user_accounts selection view: %s",
+                        exc,
+                    )
+        except Exception as exc:
+            logger.error("Error in create_user_accounts selection callback: %s", exc)
+            await interaction.followup.send(
+                "❌ An error occurred while handling the selection.",
+                ephemeral=True,
+            )
+
+
+class CreateUserAccountsSelectionView(discord.ui.View):
+    """View containing contact selection buttons for combined account provisioning."""
+
+    def __init__(
+        self,
+        crm_cog: "CRMCog",
+        requester_id: int,
+        search_term: str,
+        mailbox_username: str,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.crm_cog = crm_cog
+        self.requester_id = requester_id
+        self.search_term = search_term
+        self.mailbox_username = mailbox_username
+        self._message: discord.Message | None = None
+
+    def add_contact_button(self, contact: dict[str, Any]) -> None:
+        """Add a contact selection button."""
+        if len(self.children) >= 5:
+            return
+        self.add_item(
+            CreateUserAccountsSelectionButton(
+                contact=contact,
+                requester_id=self.requester_id,
+            )
+        )
+
+    def set_message(self, message: discord.Message | None) -> None:
+        """Store the sent message so timeout can disable its controls."""
+        self._message = message
+
+    async def on_timeout(self) -> None:
+        """Disable controls when the selection times out and update the message."""
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+        if self._message:
+            try:
+                await self._message.edit(view=self)
+            except discord.NotFound:
+                pass
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "Failed to disable create_user_accounts selection view: %s",
+                    exc,
+                )
+
+
+class OutlineInviteSelectionButton(discord.ui.Button["OutlineInviteSelectionView"]):
+    """Button for selecting a contact to invite to Outline."""
+
+    def __init__(self, contact: dict[str, Any], requester_id: int) -> None:
+        contact_name = str(contact.get("name", "Unknown"))
+        label = contact_name[:80] if len(contact_name) > 80 else contact_name
+        super().__init__(style=discord.ButtonStyle.primary, label=label, emoji="📨")
+        self.contact = contact
+        self.requester_id = requester_id
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        """Handle contact selection and send the Outline invite."""
+        try:
+            if not self.view:
+                await interaction.response.send_message(
+                    "❌ View not found.",
+                    ephemeral=True,
+                )
+                return
+            if interaction.user.id != self.requester_id:
+                await interaction.response.send_message(
+                    "❌ Only the command requester can confirm this action.",
+                    ephemeral=True,
+                )
+                return
+
+            await interaction.response.defer(ephemeral=True)
+            await self.view.crm_cog._invite_outline_user_for_contact_flow(
+                interaction=interaction,
+                contact=self.contact,
+                search_term=self.view.search_term,
+            )
+
+            for item in self.view.children:
+                if isinstance(item, discord.ui.Button):
+                    item.disabled = True
+
+            if interaction.message:
+                try:
+                    await interaction.message.edit(view=self.view)
+                except discord.NotFound:
+                    pass
+                except discord.HTTPException as exc:
+                    logger.warning(
+                        "Failed to update invite_outline_user selection view: %s",
+                        exc,
+                    )
+        except Exception as exc:
+            logger.error("Error in invite_outline_user selection callback: %s", exc)
+            await interaction.followup.send(
+                "❌ An error occurred while handling the selection.",
+                ephemeral=True,
+            )
+
+
+class OutlineInviteSelectionView(discord.ui.View):
+    """View containing contact selection buttons for Outline invitations."""
+
+    def __init__(
+        self,
+        crm_cog: "CRMCog",
+        requester_id: int,
+        search_term: str,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.crm_cog = crm_cog
+        self.requester_id = requester_id
+        self.search_term = search_term
+        self._message: discord.Message | None = None
+
+    def add_contact_button(self, contact: dict[str, Any]) -> None:
+        """Add a contact selection button."""
+        if len(self.children) >= 5:
+            return
+        self.add_item(
+            OutlineInviteSelectionButton(
+                contact=contact,
+                requester_id=self.requester_id,
+            )
+        )
+
+    def set_message(self, message: discord.Message | None) -> None:
+        """Store the sent message so timeout can disable its controls."""
+        self._message = message
+
+    async def on_timeout(self) -> None:
+        """Disable controls when the selection times out and update the message."""
+        for item in self.children:
+            if isinstance(item, discord.ui.Button):
+                item.disabled = True
+        if self._message:
+            try:
+                await self._message.edit(view=self)
+            except discord.NotFound:
+                pass
+            except discord.HTTPException as exc:
+                logger.warning(
+                    "Failed to disable invite_outline_user selection view: %s",
+                    exc,
                 )
 
 
@@ -3330,6 +3600,79 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             api_token=api_token,
             timeout_seconds=max(1.0, float(settings.authentik_api_timeout_seconds)),
         )
+
+    def _outline_client(self) -> OutlineClient:
+        """Build an Outline API client from shared settings."""
+        api_key = self._contact_text_value(settings.outline_api_key)
+        if not api_key:
+            raise ValueError("OUTLINE_API_KEY is not configured.")
+
+        base_url = (
+            self._contact_text_value(settings.outline_api_base_url)
+            or "https://app.getoutline.com/api"
+        )
+        return OutlineClient(
+            api_key=api_key,
+            base_url=base_url,
+            timeout_seconds=max(1.0, float(settings.outline_api_timeout_seconds)),
+        )
+
+    def _migadu_mailbox_domain(self) -> str:
+        """Resolve the mailbox domain configured for new 508 addresses."""
+        return normalize_migadu_mailbox_domain(settings.migadu_mailbox_domain)
+
+    def _migadu_client(self) -> MigaduClient:
+        """Build a Migadu client from the current runtime settings."""
+        username = self._contact_text_value(settings.migadu_api_user)
+        if not username:
+            raise ValueError("MIGADU_API_USER is required to create Migadu mailboxes.")
+
+        api_key = self._contact_text_value(settings.migadu_api_key)
+        if not api_key:
+            raise ValueError("MIGADU_API_KEY is required to create Migadu mailboxes.")
+
+        return MigaduClient(
+            username=username,
+            api_key=api_key,
+            domain=self._migadu_mailbox_domain(),
+        )
+
+    def _normalize_mailbox_request(self, mailbox_username: str) -> tuple[str, str]:
+        """Normalize a bare or full 508 mailbox request to email and local-part."""
+        normalized = mailbox_username.strip().lower()
+        if not normalized:
+            raise ValueError("Please provide a mailbox username like `jane`.")
+        if " " in normalized:
+            raise ValueError("Mailbox username cannot include spaces.")
+
+        configured_domain = self._migadu_mailbox_domain()
+        if "@" not in normalized:
+            local_part = normalized
+        else:
+            if normalized.count("@") != 1:
+                raise ValueError(
+                    "Mailbox username must be in the format `name@domain`."
+                )
+            local_part, username_domain = normalized.split("@", 1)
+            if username_domain != configured_domain:
+                raise ValueError(
+                    f"Mailbox username must be omitted or use the @{configured_domain} domain."
+                )
+
+        if not local_part:
+            raise ValueError("Mailbox username is missing a local part.")
+
+        return f"{local_part}@{configured_domain}", local_part
+
+    @staticmethod
+    def _normalize_full_email(value: Any, *, field_label: str) -> str:
+        """Normalize a required full email address."""
+        normalized = str(value or "").strip().lower()
+        if not normalized:
+            raise ValueError(f"{field_label} is required.")
+        if " " in normalized or normalized.count("@") != 1:
+            raise ValueError(f"{field_label} must be a full email address.")
+        return normalized
 
     @staticmethod
     def _normalize_508_email(value: Any) -> str | None:
@@ -7299,6 +7642,188 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
+    async def _execute_sso_user_provisioning(
+        self,
+        *,
+        contact: dict[str, Any],
+    ) -> SSOProvisioningResult:
+        """Create or link one Authentik SSO user for one CRM contact."""
+        contact_id = str(contact.get("id") or "")
+        if not contact_id:
+            raise ValueError("Selected contact is missing a CRM ID.")
+
+        contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
+        username, email = self._resolve_sso_identity_for_contact(contact)
+        client = self._authentik_client()
+
+        created_user: dict[str, Any] | None = None
+        user: dict[str, Any]
+        user_id: int
+        crm_updated = False
+        created = False
+        freshly_created = False
+        recovered_existing_after_create_error = False
+        recovery_email_error: str | None = None
+
+        linked_sso_id = self._crm_sso_id(contact)
+        if linked_sso_id is not None:
+            user = await asyncio.to_thread(client.get_user, linked_sso_id)
+            user_id = self._validate_authentik_user_for_contact(
+                user,
+                expected_username=username,
+                expected_email=email,
+            )
+        else:
+            matches = await asyncio.to_thread(
+                client.find_users_by_username_or_email,
+                username=username,
+                email=email,
+            )
+            if len(matches) > 1:
+                raise ValueError(
+                    "Multiple Authentik users matched this CRM contact. "
+                    "Resolve the duplicate manually before linking."
+                )
+
+            if matches:
+                user = matches[0]
+                user_id = self._validate_authentik_user_for_contact(
+                    user,
+                    expected_username=username,
+                    expected_email=email,
+                )
+            else:
+                configured_stage_id = self._contact_text_value(
+                    settings.authentik_recovery_email_stage_id
+                )
+                configured_stage_name = (
+                    self._contact_text_value(
+                        settings.authentik_recovery_email_stage_name
+                    )
+                    or "default-recovery-email"
+                )
+                logger.debug(
+                    "create_sso_user resolving recovery stage contact_id=%s username=%s override_present=%s stage_name=%s",
+                    contact_id,
+                    username,
+                    bool(configured_stage_id),
+                    configured_stage_name,
+                )
+                recovery_email_stage_id = await asyncio.to_thread(
+                    client.resolve_email_stage_id,
+                    stage_id=configured_stage_id,
+                    stage_name=configured_stage_name,
+                )
+                logger.debug(
+                    "create_sso_user resolved recovery stage contact_id=%s username=%s stage_id=%s",
+                    contact_id,
+                    username,
+                    recovery_email_stage_id,
+                )
+                try:
+                    created_user = await asyncio.to_thread(
+                        client.create_user,
+                        username=username,
+                        name=contact_name,
+                        email=email,
+                    )
+                    created = True
+                    freshly_created = True
+                except AuthentikAPIError as exc:
+                    logger.warning(
+                        "create_sso_user create_user failed contact_id=%s username=%s status=%s error=%s; checking for reconciled user",
+                        contact_id,
+                        username,
+                        client.status_code,
+                        exc,
+                    )
+                    reconciled_matches = await asyncio.to_thread(
+                        client.find_users_by_username_or_email,
+                        username=username,
+                        email=email,
+                    )
+                    if len(reconciled_matches) > 1:
+                        raise ValueError(
+                            "Multiple Authentik users matched this CRM contact after "
+                            "the create attempt. Resolve the duplicate manually "
+                            "before linking."
+                        ) from exc
+                    if not reconciled_matches:
+                        raise
+                    created_user = reconciled_matches[0]
+                    recovered_existing_after_create_error = True
+
+                user = created_user
+                try:
+                    user_id = self._validate_authentik_user_for_contact(
+                        user,
+                        expected_username=username,
+                        expected_email=email,
+                    )
+                except ValueError as exc:
+                    if freshly_created:
+                        try:
+                            partial_user_id = self._authentik_user_pk(user)
+                        except ValueError:
+                            partial_user_id = None
+                        raise SSOProvisioningPartialError(
+                            str(exc),
+                            partial_user_id=partial_user_id,
+                            partial_success="sso_created_validation_failed",
+                        ) from exc
+                    raise
+
+                if freshly_created:
+                    try:
+                        await asyncio.to_thread(
+                            client.send_recovery_email,
+                            user_id=user_id,
+                            email_stage=recovery_email_stage_id,
+                        )
+                    except AuthentikAPIError as exc:
+                        logger.warning(
+                            "create_sso_user recovery email failed contact_id=%s username=%s user_id=%s stage_id=%s error=%s",
+                            contact_id,
+                            username,
+                            user_id,
+                            recovery_email_stage_id,
+                            exc,
+                        )
+                        recovery_email_error = self._sanitize_error_message_for_discord(
+                            exc
+                        )
+
+            try:
+                await asyncio.to_thread(
+                    self.espo_api.request,
+                    "PUT",
+                    f"Contact/{contact_id}",
+                    {SSO_ID_FIELD: str(user_id)},
+                )
+            except EspoAPIError as exc:
+                if freshly_created:
+                    raise SSOProvisioningPartialError(
+                        str(exc),
+                        partial_user_id=user_id,
+                        partial_success="sso_created_crm_update_failed",
+                    ) from exc
+                raise
+            crm_updated = True
+            contact[SSO_ID_FIELD] = str(user_id)
+
+        return SSOProvisioningResult(
+            contact_id=contact_id,
+            contact_name=contact_name,
+            username=username,
+            email=email,
+            user_id=user_id,
+            created=created,
+            freshly_created=freshly_created,
+            recovered_existing_after_create_error=recovered_existing_after_create_error,
+            crm_updated=crm_updated,
+            recovery_email_error=recovery_email_error,
+        )
+
     async def _create_or_link_sso_user_for_contact(
         self,
         *,
@@ -7307,180 +7832,31 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         search_term: str,
     ) -> None:
         """Create or link one Authentik SSO user for one CRM contact."""
-        created_user: dict[str, Any] | None = None
         try:
-            contact_id = str(contact.get("id") or "")
-            if not contact_id:
-                self._audit_command_safe(
-                    interaction=interaction,
-                    action="crm.create_sso_user",
-                    result="error",
-                    metadata={
-                        "search_term": search_term,
-                        "reason": "contact_id_missing",
-                    },
-                )
-                await interaction.followup.send(
-                    "❌ Selected contact is missing a CRM ID.",
-                    ephemeral=True,
-                )
-                return
-
-            contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
-            username, email = self._resolve_sso_identity_for_contact(contact)
-            client = self._authentik_client()
-
-            user: dict[str, Any]
-            user_id: int
-            crm_updated = False
-            created = False
-            freshly_created = False
-            recovered_existing_after_create_error = False
-            recovery_email_error: str | None = None
-
-            linked_sso_id = self._crm_sso_id(contact)
-            if linked_sso_id is not None:
-                user = await asyncio.to_thread(client.get_user, linked_sso_id)
-                user_id = self._validate_authentik_user_for_contact(
-                    user,
-                    expected_username=username,
-                    expected_email=email,
-                )
-            else:
-                matches = await asyncio.to_thread(
-                    client.find_users_by_username_or_email,
-                    username=username,
-                    email=email,
-                )
-                if len(matches) > 1:
-                    raise ValueError(
-                        "Multiple Authentik users matched this CRM contact. "
-                        "Resolve the duplicate manually before linking."
-                    )
-
-                if matches:
-                    user = matches[0]
-                    user_id = self._validate_authentik_user_for_contact(
-                        user,
-                        expected_username=username,
-                        expected_email=email,
-                    )
-                else:
-                    configured_stage_id = self._contact_text_value(
-                        settings.authentik_recovery_email_stage_id
-                    )
-                    configured_stage_name = (
-                        self._contact_text_value(
-                            settings.authentik_recovery_email_stage_name
-                        )
-                        or "default-recovery-email"
-                    )
-                    logger.debug(
-                        "create_sso_user resolving recovery stage contact_id=%s username=%s override_present=%s stage_name=%s",
-                        contact_id,
-                        username,
-                        bool(configured_stage_id),
-                        configured_stage_name,
-                    )
-                    recovery_email_stage_id = await asyncio.to_thread(
-                        client.resolve_email_stage_id,
-                        stage_id=configured_stage_id,
-                        stage_name=configured_stage_name,
-                    )
-                    logger.debug(
-                        "create_sso_user resolved recovery stage contact_id=%s username=%s stage_id=%s",
-                        contact_id,
-                        username,
-                        recovery_email_stage_id,
-                    )
-                    try:
-                        created_user = await asyncio.to_thread(
-                            client.create_user,
-                            username=username,
-                            name=contact_name,
-                            email=email,
-                        )
-                        created = True
-                        freshly_created = True
-                    except AuthentikAPIError as exc:
-                        logger.warning(
-                            "create_sso_user create_user failed contact_id=%s username=%s status=%s error=%s; checking for reconciled user",
-                            contact_id,
-                            username,
-                            client.status_code,
-                            exc,
-                        )
-                        reconciled_matches = await asyncio.to_thread(
-                            client.find_users_by_username_or_email,
-                            username=username,
-                            email=email,
-                        )
-                        if len(reconciled_matches) > 1:
-                            raise ValueError(
-                                "Multiple Authentik users matched this CRM contact after "
-                                "the create attempt. Resolve the duplicate manually "
-                                "before linking."
-                            ) from exc
-                        if not reconciled_matches:
-                            raise
-                        created_user = reconciled_matches[0]
-                        recovered_existing_after_create_error = True
-                    user = created_user
-                    user_id = self._validate_authentik_user_for_contact(
-                        user,
-                        expected_username=username,
-                        expected_email=email,
-                    )
-                    if freshly_created:
-                        try:
-                            await asyncio.to_thread(
-                                client.send_recovery_email,
-                                user_id=user_id,
-                                email_stage=recovery_email_stage_id,
-                            )
-                        except AuthentikAPIError as exc:
-                            logger.warning(
-                                "create_sso_user recovery email failed contact_id=%s username=%s user_id=%s stage_id=%s error=%s",
-                                contact_id,
-                                username,
-                                user_id,
-                                recovery_email_stage_id,
-                                exc,
-                            )
-                            recovery_email_error = (
-                                self._sanitize_error_message_for_discord(exc)
-                            )
-
-                await asyncio.to_thread(
-                    self.espo_api.request,
-                    "PUT",
-                    f"Contact/{contact_id}",
-                    {SSO_ID_FIELD: str(user_id)},
-                )
-                crm_updated = True
+            result = await self._execute_sso_user_provisioning(contact=contact)
 
             message_lines = [
                 (
                     "✅ Created SSO user and linked the CRM contact."
-                    if created
+                    if result.created
                     else (
                         "✅ Linked the existing SSO user to the CRM contact."
-                        if crm_updated
+                        if result.crm_updated
                         else "✅ CRM contact is already linked to the matching SSO user."
                     )
                 ),
-                f"Contact: `{contact_name}`",
-                f"CRM ID: `{contact_id}`",
-                f"SSO user ID: `{user_id}`",
-                f"Username: `{username}`",
-                f"Email: `{email}`",
+                f"Contact: `{result.contact_name}`",
+                f"CRM ID: `{result.contact_id}`",
+                f"SSO user ID: `{result.user_id}`",
+                f"Username: `{result.username}`",
+                f"Email: `{result.email}`",
             ]
-            if created:
-                if recovery_email_error is None:
+            if result.created:
+                if result.recovery_email_error is None:
                     message_lines.append("Recovery email: sent.")
                 else:
                     message_lines.append(
-                        f"Recovery email failed: `{recovery_email_error}`"
+                        f"Recovery email failed: `{result.recovery_email_error}`"
                     )
             else:
                 message_lines.append(
@@ -7493,44 +7869,49 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="success",
                 metadata={
                     "search_term": search_term,
-                    "contact_id": contact_id,
-                    "username": username,
-                    "email": email,
-                    "sso_user_id": user_id,
-                    "created": created,
-                    "freshly_created": freshly_created,
-                    "recovered_existing_after_create_error": recovered_existing_after_create_error,
-                    "crm_updated": crm_updated,
-                    "recovery_email_error": recovery_email_error,
+                    "contact_id": result.contact_id,
+                    "username": result.username,
+                    "email": result.email,
+                    "sso_user_id": result.user_id,
+                    "created": result.created,
+                    "freshly_created": result.freshly_created,
+                    "recovered_existing_after_create_error": (
+                        result.recovered_existing_after_create_error
+                    ),
+                    "crm_updated": result.crm_updated,
+                    "recovery_email_error": result.recovery_email_error,
                 },
                 resource_type="crm_contact",
-                resource_id=contact_id,
+                resource_id=result.contact_id,
             )
             await interaction.followup.send(
                 "\n".join(message_lines),
                 ephemeral=True,
             )
-        except ValueError as exc:
+        except SSOProvisioningPartialError as exc:
             message = self._sanitize_error_message_for_discord(exc)
-            if freshly_created and created_user is not None:
-                try:
-                    partial_user_id = self._authentik_user_pk(created_user)
-                except ValueError:
-                    partial_user_id = None
-                self._audit_command_safe(
-                    interaction=interaction,
-                    action="crm.create_sso_user",
-                    result="error",
-                    metadata={
-                        "search_term": search_term,
-                        "partial_user_id": partial_user_id,
-                        "error": message,
-                        "partial_success": "sso_created_validation_failed",
-                    },
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_sso_user",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "partial_user_id": exc.partial_user_id,
+                    "error": message,
+                    "partial_success": exc.partial_success,
+                },
+            )
+            if exc.partial_success == "sso_created_crm_update_failed":
+                await interaction.followup.send(
+                    "⚠️ Created the SSO user, but failed to update CRM "
+                    f"`{SSO_ID_FIELD}`.\nSSO user ID: `{exc.partial_user_id}`\n"
+                    f"Error: `{message}`",
+                    ephemeral=True,
                 )
+            else:
                 partial_id_line = (
-                    f"\nSSO user ID: `{partial_user_id}`"
-                    if partial_user_id is not None
+                    f"\nSSO user ID: `{exc.partial_user_id}`"
+                    if exc.partial_user_id is not None
                     else ""
                 )
                 await interaction.followup.send(
@@ -7538,7 +7919,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     f"response locally.{partial_id_line}\nError: `{message}`",
                     ephemeral=True,
                 )
-                return
+        except ValueError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.create_sso_user",
@@ -7551,27 +7933,6 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
         except EspoAPIError as exc:
             message = self._sanitize_error_message_for_discord(exc)
-            if freshly_created and created_user is not None:
-                partial_user_id = self._authentik_user_pk(created_user)
-                self._audit_command_safe(
-                    interaction=interaction,
-                    action="crm.create_sso_user",
-                    result="error",
-                    metadata={
-                        "search_term": search_term,
-                        "partial_user_id": partial_user_id,
-                        "error": message,
-                        "partial_success": "sso_created_crm_update_failed",
-                    },
-                )
-                await interaction.followup.send(
-                    "⚠️ Created the SSO user, but failed to update CRM "
-                    f"`{SSO_ID_FIELD}`.\nSSO user ID: `{partial_user_id}`\n"
-                    f"Error: `{message}`",
-                    ephemeral=True,
-                )
-                return
-
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.create_sso_user",
@@ -7606,6 +7967,504 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 "❌ An unexpected error occurred while creating the SSO user.",
                 ephemeral=True,
             )
+
+    async def _create_migadu_mailbox_for_contact(
+        self,
+        *,
+        contact: dict[str, Any],
+        mailbox_username: str,
+    ) -> MailboxProvisioningResult:
+        """Create or reuse the contact's 508 mailbox and sync CRM."""
+        contact_id = str(contact.get("id") or "")
+        if not contact_id:
+            raise ValueError("Selected contact is missing a CRM ID.")
+
+        target_email, local_part = self._normalize_mailbox_request(mailbox_username)
+        existing_email = self._contact_508_email(contact)
+        backup_email = self._normalize_full_email(
+            contact.get("emailAddress"),
+            field_label="CRM primary email",
+        )
+
+        if existing_email is not None:
+            if existing_email != target_email:
+                raise ValueError(
+                    "CRM contact already has a different 508 email: "
+                    f"`{existing_email}`."
+                )
+            return MailboxProvisioningResult(
+                email=existing_email,
+                created=False,
+                crm_updated=False,
+                backup_email=backup_email,
+            )
+
+        contact_name = self._contact_text_value(contact.get("name")) or local_part
+        request = MigaduMailboxCreateRequest(
+            local_part=local_part,
+            backup_email=backup_email,
+            name=contact_name,
+        )
+        mailbox = await asyncio.to_thread(self._migadu_client().create_mailbox, request)
+        created_address = str(mailbox.get("address") or target_email).strip().lower()
+        if created_address != target_email:
+            logger.warning(
+                "Migadu returned address=%s for requested target_email=%s",
+                created_address,
+                target_email,
+            )
+
+        await asyncio.to_thread(
+            self.espo_api.request,
+            "PUT",
+            f"Contact/{contact_id}",
+            {"c508Email": target_email},
+        )
+        contact["c508Email"] = target_email
+
+        return MailboxProvisioningResult(
+            email=target_email,
+            created=True,
+            crm_updated=True,
+            backup_email=backup_email,
+        )
+
+    async def _invite_outline_user_for_contact(
+        self,
+        *,
+        contact: dict[str, Any],
+        email: str,
+    ) -> bool:
+        """Invite the contact to Outline using the provided 508 email."""
+        contact_name = self._contact_text_value(contact.get("name"))
+        await asyncio.to_thread(
+            self._outline_client().invite_user,
+            email=email,
+            name=contact_name,
+        )
+        return True
+
+    def _outline_invite_email_for_contact(self, contact: dict[str, Any]) -> str:
+        """Resolve the email address to invite to Outline for a CRM contact."""
+        email = self._contact_508_email(contact) or self._contact_text_value(
+            contact.get("emailAddress")
+        )
+        return self._normalize_full_email(email, field_label="Outline invite email")
+
+    async def _invite_outline_user(
+        self,
+        *,
+        email: str,
+        name: str | None = None,
+    ) -> None:
+        """Invite one email address to Outline."""
+        await asyncio.to_thread(
+            self._outline_client().invite_user,
+            email=email,
+            name=name,
+        )
+
+    async def _invite_outline_user_for_contact_flow(
+        self,
+        *,
+        interaction: discord.Interaction,
+        contact: dict[str, Any],
+        search_term: str,
+    ) -> None:
+        """Invite one CRM contact to Outline and report the result."""
+        try:
+            contact_id = str(contact.get("id") or "")
+            if not contact_id:
+                raise ValueError("Selected contact is missing a CRM ID.")
+
+            contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
+            email = self._outline_invite_email_for_contact(contact)
+            await self._invite_outline_user(email=email, name=contact_name)
+
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="success",
+                metadata={
+                    "search_term": search_term,
+                    "contact_id": contact_id,
+                    "email": email,
+                },
+                resource_type="crm_contact",
+                resource_id=contact_id,
+            )
+            await interaction.followup.send(
+                "✅ Outline invite sent.\n"
+                f"Contact: `{contact_name}`\n"
+                f"CRM ID: `{contact_id}`\n"
+                f"Email: `{email}`",
+                ephemeral=True,
+            )
+        except OutlineAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="error",
+                metadata={"search_term": search_term, "error": message},
+            )
+            await interaction.followup.send(
+                f"❌ Outline invite failed: {message}",
+                ephemeral=True,
+            )
+        except ValueError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="denied",
+                metadata={"search_term": search_term, "reason": message},
+            )
+            await interaction.followup.send(f"❌ {message}", ephemeral=True)
+
+    async def _invite_outline_user_for_email_flow(
+        self,
+        *,
+        interaction: discord.Interaction,
+        email: str,
+        search_term: str,
+    ) -> None:
+        """Invite one direct email address to Outline and report the result."""
+        try:
+            normalized_email = self._normalize_full_email(
+                email,
+                field_label="Outline invite email",
+            )
+            await self._invite_outline_user(email=normalized_email)
+
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="success",
+                metadata={
+                    "search_term": search_term,
+                    "email": normalized_email,
+                    "direct_email": True,
+                },
+            )
+            await interaction.followup.send(
+                f"✅ Outline invite sent.\nEmail: `{normalized_email}`",
+                ephemeral=True,
+            )
+        except OutlineAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "email": email,
+                    "direct_email": True,
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(
+                f"❌ Outline invite failed: {message}",
+                ephemeral=True,
+            )
+        except ValueError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="denied",
+                metadata={
+                    "search_term": search_term,
+                    "email": email,
+                    "direct_email": True,
+                    "reason": message,
+                },
+            )
+            await interaction.followup.send(f"❌ {message}", ephemeral=True)
+
+    async def _execute_user_accounts_provisioning(
+        self,
+        *,
+        contact: dict[str, Any],
+        mailbox_username: str,
+    ) -> UserAccountsProvisioningResult:
+        """Create mailbox, SSO user, and Outline invite for one contact."""
+        contact_id = str(contact.get("id") or "")
+        if not contact_id:
+            raise ValueError("Selected contact is missing a CRM ID.")
+
+        contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
+        mailbox = await self._create_migadu_mailbox_for_contact(
+            contact=contact,
+            mailbox_username=mailbox_username,
+        )
+        sso = await self._execute_sso_user_provisioning(contact=contact)
+        outline_invited = await self._invite_outline_user_for_contact(
+            contact=contact,
+            email=mailbox.email,
+        )
+
+        return UserAccountsProvisioningResult(
+            contact_id=contact_id,
+            contact_name=contact_name,
+            email=mailbox.email,
+            mailbox=mailbox,
+            sso=sso,
+            outline_invited=outline_invited,
+        )
+
+    @staticmethod
+    def _created_or_reused_label(created: bool) -> str:
+        return "created" if created else "already existed/reused"
+
+    async def _create_user_accounts_for_contact(
+        self,
+        *,
+        interaction: discord.Interaction,
+        contact: dict[str, Any],
+        search_term: str,
+        mailbox_username: str,
+    ) -> None:
+        """Create all user accounts for a selected CRM contact."""
+        try:
+            result = await self._execute_user_accounts_provisioning(
+                contact=contact,
+                mailbox_username=mailbox_username,
+            )
+        except SSOProvisioningPartialError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "partial_user_id": exc.partial_user_id,
+                    "partial_success": exc.partial_success,
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(
+                "⚠️ Created the mailbox and started SSO provisioning, but the SSO "
+                f"flow partially failed.\nSSO user ID: `{exc.partial_user_id}`\n"
+                f"Error: `{message}`\nOutline invite was not sent.",
+                ephemeral=True,
+            )
+        except MigaduAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "stage": "mailbox",
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(
+                f"❌ Migadu mailbox creation failed: {message}",
+                ephemeral=True,
+            )
+        except AuthentikAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "stage": "sso",
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(
+                f"⚠️ Mailbox is ready, but Authentik SSO provisioning failed: {message}",
+                ephemeral=True,
+            )
+        except OutlineAPIError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "stage": "outline",
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(
+                "⚠️ Mailbox and SSO are ready, but the Outline invite failed: "
+                f"{message}",
+                ephemeral=True,
+            )
+        except (ValueError, EspoAPIError) as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "error": message,
+                },
+            )
+            await interaction.followup.send(f"❌ {message}", ephemeral=True)
+        except Exception as exc:
+            logger.error("Unexpected error in create_user_accounts: %s", exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "error": str(exc),
+                },
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while creating user accounts.",
+                ephemeral=True,
+            )
+        else:
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="success",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "contact_id": result.contact_id,
+                    "email": result.email,
+                    "mailbox_created": result.mailbox.created,
+                    "mailbox_crm_updated": result.mailbox.crm_updated,
+                    "sso_user_id": result.sso.user_id,
+                    "sso_created": result.sso.created,
+                    "sso_crm_updated": result.sso.crm_updated,
+                    "outline_invited": result.outline_invited,
+                    "recovery_email_error": result.sso.recovery_email_error,
+                },
+                resource_type="crm_contact",
+                resource_id=result.contact_id,
+            )
+            message_lines = [
+                "✅ User accounts are ready.",
+                f"Contact: `{result.contact_name}`",
+                f"CRM ID: `{result.contact_id}`",
+                f"Email: `{result.email}`",
+                f"Mailbox: {self._created_or_reused_label(result.mailbox.created)}.",
+                "SSO: "
+                f"{self._created_or_reused_label(result.sso.created)} "
+                f"(user ID `{result.sso.user_id}`).",
+                "Outline invite: sent.",
+            ]
+            if result.sso.created:
+                if result.sso.recovery_email_error is None:
+                    message_lines.append("SSO recovery email: sent.")
+                else:
+                    message_lines.append(
+                        "SSO recovery email failed: "
+                        f"`{result.sso.recovery_email_error}`"
+                    )
+            else:
+                message_lines.append(
+                    "SSO recovery email not sent because the user already existed."
+                )
+            await interaction.followup.send(
+                "\n".join(message_lines),
+                ephemeral=True,
+            )
+
+    async def _show_create_user_accounts_contact_choices(
+        self,
+        interaction: discord.Interaction,
+        *,
+        search_term: str,
+        mailbox_username: str,
+        contacts: list[dict[str, Any]],
+    ) -> None:
+        """Show contact choices for the combined account provisioning command."""
+        embed = discord.Embed(
+            title="🔍 Multiple Contacts Found",
+            description=(
+                f"Found {len(contacts)} contacts for `{search_term}`. "
+                "Select the correct person to create their user accounts."
+            ),
+            color=0xFFA500,
+        )
+        view = CreateUserAccountsSelectionView(
+            crm_cog=self,
+            requester_id=interaction.user.id,
+            search_term=search_term,
+            mailbox_username=mailbox_username,
+        )
+
+        for i, contact in enumerate(contacts[:5], 1):
+            name = contact.get("name", "Unknown")
+            email = self._contact_preferred_email(contact) or "No email"
+            email_508 = contact.get("c508Email", "No 508 email")
+            contact_id = contact.get("id", "")
+            contact_info = (
+                f"📧 {email}\n🏢 508 Email: {email_508}\n🆔 ID: `{contact_id}`"
+            )
+            embed.add_field(name=f"{i}. {name}", value=contact_info, inline=True)
+            view.add_contact_button(contact)
+
+        message = await interaction.followup.send(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+            wait=True,
+        )
+        view.set_message(message)
+
+    async def _show_invite_outline_user_contact_choices(
+        self,
+        interaction: discord.Interaction,
+        *,
+        search_term: str,
+        contacts: list[dict[str, Any]],
+    ) -> None:
+        """Show contact choices for the Outline invite command."""
+        embed = discord.Embed(
+            title="🔍 Multiple Contacts Found",
+            description=(
+                f"Found {len(contacts)} contacts for `{search_term}`. "
+                "Select the correct person to invite to Outline."
+            ),
+            color=0xFFA500,
+        )
+        view = OutlineInviteSelectionView(
+            crm_cog=self,
+            requester_id=interaction.user.id,
+            search_term=search_term,
+        )
+
+        for i, contact in enumerate(contacts[:5], 1):
+            name = contact.get("name", "Unknown")
+            email = self._contact_preferred_email(contact) or "No email"
+            email_508 = contact.get("c508Email", "No 508 email")
+            contact_id = contact.get("id", "")
+            contact_info = (
+                f"📧 {email}\n🏢 508 Email: {email_508}\n🆔 ID: `{contact_id}`"
+            )
+            embed.add_field(name=f"{i}. {name}", value=contact_info, inline=True)
+            view.add_contact_button(contact)
+
+        message = await interaction.followup.send(
+            embed=embed,
+            view=view,
+            ephemeral=True,
+            wait=True,
+        )
+        view.set_message(message)
 
     @app_commands.command(
         name="mark-id-verified",
@@ -7806,6 +8665,141 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 "❌ An unexpected error occurred while preparing the SSO user flow.",
+                ephemeral=True,
+            )
+
+    @app_commands.command(
+        name="create-user-accounts",
+        description="Create 508 email, Authentik SSO, and Outline invite.",
+    )
+    @app_commands.describe(
+        search_term="Discord mention, email, 508 username, or contact ID.",
+        mailbox_username="508 mailbox username to create, like jane or jane@508.dev.",
+    )
+    @require_role("Admin")
+    async def create_user_accounts(
+        self,
+        interaction: discord.Interaction,
+        search_term: str,
+        mailbox_username: str,
+    ) -> None:
+        """Create a mailbox, SSO user, and Outline invite for a CRM contact."""
+        try:
+            await interaction.response.defer(ephemeral=True)
+
+            contacts = await self._search_contacts_for_lookup(
+                search_term,
+                max_size=5,
+                select=(
+                    f"id,name,emailAddress,c508Email,cDiscordUsername,{SSO_ID_FIELD}"
+                ),
+            )
+            if not contacts:
+                await interaction.followup.send(
+                    f"❌ No contact found for: `{search_term}`",
+                    ephemeral=True,
+                )
+                return
+
+            if len(contacts) > 1:
+                await self._show_create_user_accounts_contact_choices(
+                    interaction,
+                    search_term=search_term,
+                    mailbox_username=mailbox_username,
+                    contacts=contacts,
+                )
+                return
+
+            await self._create_user_accounts_for_contact(
+                interaction=interaction,
+                contact=contacts[0],
+                search_term=search_term,
+                mailbox_username=mailbox_username,
+            )
+        except Exception as exc:
+            logger.error(
+                "Unexpected error in create_user_accounts lookup flow: %s", exc
+            )
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "error": str(exc),
+                },
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while preparing account creation.",
+                ephemeral=True,
+            )
+
+    @app_commands.command(
+        name="invite-outline-user",
+        description="Invite a CRM contact or direct email address to Outline.",
+    )
+    @app_commands.describe(
+        search_term="Discord mention, email, 508 username, contact ID, or direct email."
+    )
+    @require_role("Admin")
+    async def invite_outline_user(
+        self,
+        interaction: discord.Interaction,
+        search_term: str,
+    ) -> None:
+        """Invite a CRM contact or direct email address to Outline."""
+        try:
+            await interaction.response.defer(ephemeral=True)
+
+            contacts = await self._search_contacts_for_lookup(
+                search_term,
+                max_size=5,
+                select="id,name,emailAddress,c508Email,cDiscordUsername",
+            )
+            if not contacts:
+                try:
+                    direct_email = self._normalize_full_email(
+                        search_term,
+                        field_label="Outline invite email",
+                    )
+                except ValueError:
+                    await interaction.followup.send(
+                        f"❌ No contact found for: `{search_term}`",
+                        ephemeral=True,
+                    )
+                    return
+
+                await self._invite_outline_user_for_email_flow(
+                    interaction=interaction,
+                    email=direct_email,
+                    search_term=search_term,
+                )
+                return
+
+            if len(contacts) > 1:
+                await self._show_invite_outline_user_contact_choices(
+                    interaction,
+                    search_term=search_term,
+                    contacts=contacts,
+                )
+                return
+
+            await self._invite_outline_user_for_contact_flow(
+                interaction=interaction,
+                contact=contacts[0],
+                search_term=search_term,
+            )
+        except Exception as exc:
+            logger.error("Unexpected error in invite_outline_user lookup flow: %s", exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.invite_outline_user",
+                result="error",
+                metadata={"search_term": search_term, "error": str(exc)},
+            )
+            await interaction.followup.send(
+                "❌ An unexpected error occurred while preparing the Outline invite.",
                 ephemeral=True,
             )
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -6056,8 +6056,12 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         if has_at:
             local_part, _, domain = normalized.partition("@")
-            if local_part and (not domain or domain.lower() in {"", "508", "508.dev"}):
-                normalized = f"{local_part}@508.dev"
+            configured_domain = self._migadu_mailbox_domain()
+            domain_aliases = {"", configured_domain}
+            if "." in configured_domain:
+                domain_aliases.add(configured_domain.split(".", 1)[0])
+            if local_part and domain.lower() in domain_aliases:
+                normalized = f"{local_part}@{configured_domain}"
 
             search_filters.extend(
                 [
@@ -6080,7 +6084,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 {
                     "type": "equals",
                     "attribute": "c508Email",
-                    "value": f"{normalized}@508.dev",
+                    "value": f"{normalized}@{self._migadu_mailbox_domain()}",
                 }
             )
         return search_filters
@@ -8221,6 +8225,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         if not contact_id:
             raise ValueError("Selected contact is missing a CRM ID.")
 
+        self._validate_user_accounts_provisioning_config(
+            contact=contact,
+            mailbox_username=mailbox_username,
+        )
         contact_name = self._contact_text_value(contact.get("name")) or "Unknown"
         mailbox = await self._create_migadu_mailbox_for_contact(
             contact=contact,
@@ -8240,6 +8248,25 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             sso=sso,
             outline_invited=outline_invited,
         )
+
+    def _validate_user_accounts_provisioning_config(
+        self,
+        *,
+        contact: dict[str, Any],
+        mailbox_username: str,
+    ) -> None:
+        """Validate required account clients before creating any resources."""
+        self._authentik_client()
+        self._outline_client()
+
+        target_email, _local_part = self._normalize_mailbox_request(mailbox_username)
+        existing_email = self._normalize_508_email(contact.get("c508Email"))
+        if existing_email is None:
+            self._migadu_client()
+        elif existing_email != target_email:
+            raise ValueError(
+                f"CRM contact already has a different 508 email: `{existing_email}`."
+            )
 
     @staticmethod
     def _created_or_reused_label(created: bool) -> str:

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -8000,11 +8000,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             raise ValueError("Selected contact is missing a CRM ID.")
 
         target_email, local_part = self._normalize_mailbox_request(mailbox_username)
-        existing_email = self._contact_508_email(contact)
-        backup_email = self._normalize_full_email(
-            contact.get("emailAddress"),
-            field_label="CRM primary email",
-        )
+        existing_email = self._normalize_508_email(contact.get("c508Email"))
 
         if existing_email is not None:
             if existing_email != target_email:
@@ -8016,9 +8012,13 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 email=existing_email,
                 created=False,
                 crm_updated=False,
-                backup_email=backup_email,
+                backup_email="",
             )
 
+        backup_email = self._normalize_full_email(
+            contact.get("emailAddress"),
+            field_label="CRM primary email",
+        )
         contact_name = self._contact_text_value(contact.get("name")) or local_part
         request = MigaduMailboxCreateRequest(
             local_part=local_part,
@@ -8292,6 +8292,11 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
         except SSOProvisioningPartialError as exc:
             message = self._sanitize_error_message_for_discord(exc)
+            partial_id_line = (
+                f"\nSSO user ID: `{exc.partial_user_id}`"
+                if exc.partial_user_id is not None
+                else ""
+            )
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.create_user_accounts",
@@ -8306,7 +8311,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 "⚠️ Created the mailbox and started SSO provisioning, but the SSO "
-                f"flow partially failed.\nSSO user ID: `{exc.partial_user_id}`\n"
+                f"flow partially failed.{partial_id_line}\n"
                 f"Error: `{message}`\nOutline invite was not sent.",
                 ephemeral=True,
             )
@@ -8732,7 +8737,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
     )
     @app_commands.describe(
         search_term="Discord mention, email, 508 username, or contact ID.",
-        mailbox_username="508 mailbox username to create, like jane or jane@508.dev.",
+        mailbox_username="Mailbox username to create, like jane or jane@domain.",
     )
     @require_role("Admin")
     async def create_user_accounts(

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -3608,8 +3608,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             raise ValueError("OUTLINE_API_KEY is not configured.")
 
         base_url = (
-            self._contact_text_value(settings.outline_api_base_url)
-            or "https://app.getoutline.com/api"
+            self._contact_text_value(settings.outline_base_url)
+            or "https://app.getoutline.com"
         )
         return OutlineClient(
             api_key=api_key,

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -7825,11 +7825,16 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     {SSO_ID_FIELD: str(user_id)},
                 )
             except EspoAPIError as exc:
-                if freshly_created:
+                if freshly_created or recovered_existing_after_create_error:
+                    partial_success = (
+                        "sso_created_crm_update_failed"
+                        if freshly_created
+                        else "sso_reconciled_crm_update_failed"
+                    )
                     raise SSOProvisioningPartialError(
                         str(exc),
                         partial_user_id=user_id,
-                        partial_success="sso_created_crm_update_failed",
+                        partial_success=partial_success,
                     ) from exc
                 raise
             crm_updated = True
@@ -7929,6 +7934,14 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 await interaction.followup.send(
                     "⚠️ Created the SSO user, but failed to update CRM "
                     f"`{SSO_ID_FIELD}`.\nSSO user ID: `{exc.partial_user_id}`\n"
+                    f"Error: `{message}`",
+                    ephemeral=True,
+                )
+            elif exc.partial_success == "sso_reconciled_crm_update_failed":
+                await interaction.followup.send(
+                    "⚠️ Recovered the SSO user after the create request failed, "
+                    f"but failed to update CRM `{SSO_ID_FIELD}`.\n"
+                    f"SSO user ID: `{exc.partial_user_id}`\n"
                     f"Error: `{message}`",
                     ephemeral=True,
                 )

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -123,6 +123,21 @@ class SSOProvisioningPartialError(RuntimeError):
         self.partial_success = partial_success
 
 
+class MailboxProvisioningPartialError(RuntimeError):
+    """Raised when Migadu created a mailbox but a later local/CRM step failed."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        mailbox_email: str,
+        partial_success: str,
+    ) -> None:
+        super().__init__(message)
+        self.mailbox_email = mailbox_email
+        self.partial_success = partial_success
+
+
 @dataclass(frozen=True, slots=True)
 class MailboxProvisioningResult:
     """Result from creating or reusing one 508 mailbox."""
@@ -3674,10 +3689,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             raise ValueError(f"{field_label} must be a full email address.")
         return normalized
 
-    @staticmethod
-    def _normalize_508_email(value: Any) -> str | None:
+    def _normalize_508_email(self, value: Any) -> str | None:
         text = str(value or "").strip().lower()
-        if not text or not text.endswith("@508.dev"):
+        configured_domain = self._migadu_mailbox_domain()
+        if not text or not text.endswith(f"@{configured_domain}"):
             return None
         return text
 
@@ -3694,7 +3709,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         """Derive the Authentik username and email from CRM's 508 email."""
         email = self._contact_508_email(contact)
         if not email:
-            raise ValueError("Selected contact does not have a @508.dev email in CRM.")
+            configured_domain = self._migadu_mailbox_domain()
+            raise ValueError(
+                f"Selected contact does not have a @{configured_domain} email in CRM."
+            )
 
         username = self._normalize_508_username(email)
         if not username:
@@ -3737,8 +3755,10 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         actual_email = self._normalize_508_email(user.get("email"))
         if actual_email != expected_email:
+            configured_domain = self._migadu_mailbox_domain()
             raise ValueError(
-                "Matched Authentik email does not match the CRM-derived @508.dev email."
+                "Matched Authentik email does not match the CRM-derived "
+                f"@{configured_domain} email."
             )
 
         return self._authentik_user_pk(user)
@@ -8008,18 +8028,27 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         mailbox = await asyncio.to_thread(self._migadu_client().create_mailbox, request)
         created_address = str(mailbox.get("address") or target_email).strip().lower()
         if created_address != target_email:
-            logger.warning(
-                "Migadu returned address=%s for requested target_email=%s",
-                created_address,
-                target_email,
+            raise MailboxProvisioningPartialError(
+                "Migadu created a mailbox but returned a different address "
+                f"`{created_address}` than requested `{target_email}`. "
+                "CRM, SSO, and Outline were not updated.",
+                mailbox_email=created_address,
+                partial_success="mailbox_created_address_mismatch",
             )
 
-        await asyncio.to_thread(
-            self.espo_api.request,
-            "PUT",
-            f"Contact/{contact_id}",
-            {"c508Email": target_email},
-        )
+        try:
+            await asyncio.to_thread(
+                self.espo_api.request,
+                "PUT",
+                f"Contact/{contact_id}",
+                {"c508Email": target_email},
+            )
+        except EspoAPIError as exc:
+            raise MailboxProvisioningPartialError(
+                str(exc),
+                mailbox_email=target_email,
+                partial_success="mailbox_created_crm_update_failed",
+            ) from exc
         contact["c508Email"] = target_email
 
         return MailboxProvisioningResult(
@@ -8232,6 +8261,35 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 contact=contact,
                 mailbox_username=mailbox_username,
             )
+        except MailboxProvisioningPartialError as exc:
+            message = self._sanitize_error_message_for_discord(exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="crm.create_user_accounts",
+                result="error",
+                metadata={
+                    "search_term": search_term,
+                    "mailbox_username": mailbox_username,
+                    "mailbox_email": exc.mailbox_email,
+                    "partial_success": exc.partial_success,
+                    "error": message,
+                },
+            )
+            if exc.partial_success == "mailbox_created_crm_update_failed":
+                await interaction.followup.send(
+                    "⚠️ Created the mailbox, but failed to update CRM `c508Email`.\n"
+                    f"Email: `{exc.mailbox_email}`\n"
+                    f"Error: `{message}`\n"
+                    "SSO provisioning and Outline invite were not started.",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.followup.send(
+                    f"⚠️ {message}\n"
+                    f"Created mailbox: `{exc.mailbox_email}`\n"
+                    "SSO provisioning and Outline invite were not started.",
+                    ephemeral=True,
+                )
         except SSOProvisioningPartialError as exc:
             message = self._sanitize_error_message_for_discord(exc)
             self._audit_command_safe(

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -8066,11 +8066,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
     ) -> bool:
         """Invite the contact to Outline using the provided 508 email."""
         contact_name = self._contact_text_value(contact.get("name"))
-        await asyncio.to_thread(
-            self._outline_client().invite_user,
-            email=email,
-            name=contact_name,
-        )
+        await self._invite_outline_user(email=email, name=contact_name)
         return True
 
     def _outline_invite_email_for_contact(self, contact: dict[str, Any]) -> str:
@@ -8087,10 +8083,12 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
         name: str | None = None,
     ) -> None:
         """Invite one email address to Outline."""
+        invite_name = name or email.partition("@")[0]
         await asyncio.to_thread(
             self._outline_client().invite_user,
             email=email,
-            name=name,
+            name=invite_name,
+            role="member",
         )
 
     async def _invite_outline_user_for_contact_flow(

--- a/packages/shared/src/five08/clients/outline.py
+++ b/packages/shared/src/five08/clients/outline.py
@@ -3,15 +3,35 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import requests
 
 
-OUTLINE_API_BASE_URL = "https://app.getoutline.com/api"
+OUTLINE_BASE_URL = "https://app.getoutline.com"
 
 
 class OutlineAPIError(RuntimeError):
     """Raised when the Outline API request fails or returns invalid data."""
+
+
+def normalize_outline_api_base_url(base_url: str) -> str:
+    """Normalize an Outline root or API URL to the RPC API base."""
+    normalized = base_url.strip().rstrip("/")
+    if not normalized:
+        raise OutlineAPIError("Outline base URL must not be empty.")
+
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise OutlineAPIError("Outline base URL must be an absolute HTTP(S) URL.")
+
+    path = parsed.path.rstrip("/")
+    if path.endswith("/api"):
+        api_path = path
+    else:
+        api_path = f"{path}/api" if path else "/api"
+
+    return urlunsplit((parsed.scheme, parsed.netloc, api_path, "", ""))
 
 
 class OutlineClient:
@@ -21,11 +41,11 @@ class OutlineClient:
         self,
         *,
         api_key: str,
-        base_url: str = OUTLINE_API_BASE_URL,
+        base_url: str = OUTLINE_BASE_URL,
         timeout_seconds: float = 20.0,
     ) -> None:
         self.api_key = api_key
-        self.base_url = base_url.rstrip("/")
+        self.base_url = normalize_outline_api_base_url(base_url)
         self.timeout_seconds = timeout_seconds
 
     def _headers(self) -> dict[str, str]:

--- a/packages/shared/src/five08/clients/outline.py
+++ b/packages/shared/src/five08/clients/outline.py
@@ -1,0 +1,93 @@
+"""Outline API client helpers shared across services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+
+OUTLINE_API_BASE_URL = "https://app.getoutline.com/api"
+
+
+class OutlineAPIError(RuntimeError):
+    """Raised when the Outline API request fails or returns invalid data."""
+
+
+class OutlineClient:
+    """Small Outline RPC API wrapper for user invitations."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        base_url: str = OUTLINE_API_BASE_URL,
+        timeout_seconds: float = 20.0,
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout_seconds = timeout_seconds
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+    def request(self, method: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Call one Outline RPC method and return the JSON response."""
+        try:
+            response = requests.post(
+                f"{self.base_url}/{method.lstrip('/')}",
+                headers=self._headers(),
+                json=payload,
+                timeout=self.timeout_seconds,
+            )
+        except requests.RequestException as exc:
+            raise OutlineAPIError(f"Outline API request failed: {exc}") from exc
+
+        if not 200 <= response.status_code < 300:
+            raise OutlineAPIError(
+                "Outline API request failed: "
+                f"status={response.status_code}, body={response.text}"
+            )
+
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise OutlineAPIError(
+                "Outline response payload must be valid JSON."
+            ) from exc
+
+        if not isinstance(data, dict):
+            raise OutlineAPIError("Outline response payload must be a JSON object.")
+
+        if data.get("ok") is False:
+            error = str(data.get("error") or "unknown error")
+            raise OutlineAPIError(f"Outline API returned an error: {error}")
+
+        return data
+
+    def invite_user(
+        self,
+        *,
+        email: str,
+        name: str | None = None,
+        role: str | None = None,
+        suppress_email: bool = False,
+    ) -> dict[str, Any]:
+        """Invite one user to Outline and return the response payload."""
+        invite: dict[str, Any] = {"email": email}
+        if name:
+            invite["name"] = name
+        if role:
+            invite["role"] = role
+
+        return self.request(
+            "users.invite",
+            {
+                "invites": [invite],
+                "suppressEmail": suppress_email,
+            },
+        )

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -55,7 +55,7 @@ class SharedSettings(BaseSettings):
     authentik_api_timeout_seconds: float = 20.0
     authentik_recovery_email_stage_id: str | None = None
     authentik_recovery_email_stage_name: str = "default-recovery-email"
-    outline_api_base_url: str = "https://app.getoutline.com/api"
+    outline_base_url: str = "https://app.getoutline.com"
     outline_api_key: str | None = None
     outline_api_timeout_seconds: float = 20.0
 

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -55,6 +55,9 @@ class SharedSettings(BaseSettings):
     authentik_api_timeout_seconds: float = 20.0
     authentik_recovery_email_stage_id: str | None = None
     authentik_recovery_email_stage_name: str = "default-recovery-email"
+    outline_api_base_url: str = "https://app.getoutline.com/api"
+    outline_api_key: str | None = None
+    outline_api_timeout_seconds: float = 20.0
 
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -13,6 +13,7 @@ from five08.discord_bot.cogs.crm import (
 )
 from five08.clients.authentik import AuthentikAPIError
 from five08.clients.espo import EspoAPIError
+from five08.clients.outline import OutlineAPIError
 
 
 @pytest.fixture
@@ -576,6 +577,21 @@ async def test_create_user_accounts_uses_configured_mailbox_domain_for_sso(
     assert "Email: `jane@example.org`" in message
 
 
+def test_contact_lookup_bare_username_uses_configured_mailbox_domain(
+    cog: CRMCog,
+) -> None:
+    with patch(
+        "five08.discord_bot.cogs.crm.settings.migadu_mailbox_domain", "example.org"
+    ):
+        filters = cog._build_contact_search_filters("jane")
+
+    assert {
+        "type": "equals",
+        "attribute": "c508Email",
+        "value": "jane@example.org",
+    } in filters
+
+
 @pytest.mark.asyncio
 async def test_create_user_accounts_reuses_existing_mailbox(
     cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
@@ -731,6 +747,45 @@ async def test_create_user_accounts_primary_508_email_does_not_skip_mailbox_crea
 
 
 @pytest.mark.asyncio
+async def test_create_user_accounts_validates_outline_before_mailbox_creation(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_authentik_client", return_value=Mock()),
+        patch.object(
+            cog,
+            "_outline_client",
+            side_effect=ValueError("OUTLINE_API_KEY is not configured."),
+        ),
+        patch.object(cog, "_migadu_client") as migadu_client,
+        patch.object(cog, "_audit_command_safe"),
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    migadu_client.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "OUTLINE_API_KEY is not configured" in message
+
+
+@pytest.mark.asyncio
 async def test_create_user_accounts_reports_partial_success_when_mailbox_crm_sync_fails(
     cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
 ) -> None:
@@ -752,8 +807,8 @@ async def test_create_user_accounts_reports_partial_success_when_mailbox_crm_syn
             new=AsyncMock(return_value=[contact]),
         ),
         patch.object(cog, "_migadu_client", return_value=migadu_client),
-        patch.object(cog, "_authentik_client") as authentik_client,
-        patch.object(cog, "_outline_client") as outline_client,
+        patch.object(cog, "_authentik_client") as authentik_factory,
+        patch.object(cog, "_outline_client") as outline_factory,
         patch.object(cog, "_audit_command_safe") as mock_audit,
     ):
         await cog.create_user_accounts.callback(
@@ -763,8 +818,9 @@ async def test_create_user_accounts_reports_partial_success_when_mailbox_crm_syn
             mailbox_username="jane",
         )
 
-    authentik_client.assert_not_called()
-    outline_client.assert_not_called()
+    authentik_factory.return_value.find_users_by_username_or_email.assert_not_called()
+    authentik_factory.return_value.create_user.assert_not_called()
+    outline_factory.return_value.invite_user.assert_not_called()
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Created the mailbox, but failed to update CRM" in message
     assert "Email: `jane@508.dev`" in message
@@ -794,8 +850,8 @@ async def test_create_user_accounts_rejects_migadu_address_mismatch(
             new=AsyncMock(return_value=[contact]),
         ),
         patch.object(cog, "_migadu_client", return_value=migadu_client),
-        patch.object(cog, "_authentik_client") as authentik_client,
-        patch.object(cog, "_outline_client") as outline_client,
+        patch.object(cog, "_authentik_client") as authentik_factory,
+        patch.object(cog, "_outline_client") as outline_factory,
         patch.object(cog, "_audit_command_safe") as mock_audit,
     ):
         await cog.create_user_accounts.callback(
@@ -806,13 +862,68 @@ async def test_create_user_accounts_rejects_migadu_address_mismatch(
         )
 
     mock_espo_api.request.assert_not_called()
-    authentik_client.assert_not_called()
-    outline_client.assert_not_called()
+    authentik_factory.return_value.find_users_by_username_or_email.assert_not_called()
+    authentik_factory.return_value.create_user.assert_not_called()
+    outline_factory.return_value.invite_user.assert_not_called()
     message = mock_interaction.followup.send.call_args.args[0]
     assert "returned a different address" in message
     assert "Created mailbox: `other@508.dev`" in message
     audit_metadata = mock_audit.call_args.kwargs["metadata"]
     assert audit_metadata["partial_success"] == "mailbox_created_address_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_reports_outline_invite_failure(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@508.dev"}
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = []
+    authentik_client.create_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.send_recovery_email.return_value = None
+    outline_client = Mock()
+    outline_client.invite_user.side_effect = OutlineAPIError("outline unavailable")
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        mock_espo_api.request.return_value = {"id": "crm-123"}
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Mailbox and SSO are ready, but the Outline invite failed" in message
+    assert "outline unavailable" in message
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["stage"] == "outline"
+    assert "outline unavailable" in audit_metadata["error"]
 
 
 @pytest.mark.asyncio
@@ -934,6 +1045,42 @@ async def test_invite_outline_user_invites_contact_508_email(
     assert "Email: `jane@508.dev`" in message
     assert mock_interaction.followup.send.call_args.kwargs["ephemeral"] is True
     assert mock_audit.call_args.kwargs["metadata"]["contact_id"] == "crm-123"
+
+
+@pytest.mark.asyncio
+async def test_invite_outline_user_reports_outline_api_error(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "jane@508.dev",
+    }
+    outline_client = Mock()
+    outline_client.invite_user.side_effect = OutlineAPIError("outline unavailable")
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.invite_outline_user.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+        )
+
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Outline invite failed" in message
+    assert "outline unavailable" in message
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["search_term"] == "jane"
+    assert audit_metadata["error"] == "outline unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -9,6 +9,7 @@ from five08.discord_bot.cogs.crm import (
     CreateSSOUserSelectionView,
     CreateUserAccountsSelectionView,
     OutlineInviteSelectionView,
+    SSOProvisioningPartialError,
 )
 from five08.clients.authentik import AuthentikAPIError
 from five08.clients.espo import EspoAPIError
@@ -625,6 +626,108 @@ async def test_create_user_accounts_reuses_existing_mailbox(
 
 
 @pytest.mark.asyncio
+async def test_create_user_accounts_reuses_existing_mailbox_without_backup_email(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "",
+        "c508Email": "jane@508.dev",
+        "cSsoID": "42",
+    }
+    authentik_client = Mock()
+    authentik_client.get_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client") as migadu_client,
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe"),
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane@508.dev",
+        )
+
+    migadu_client.assert_not_called()
+    mock_espo_api.request.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "User accounts are ready" in message
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_primary_508_email_does_not_skip_mailbox_creation(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane@508.dev",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@508.dev"}
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = []
+    authentik_client.create_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.send_recovery_email.return_value = None
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe"),
+    ):
+        mock_espo_api.request.return_value = {"id": "crm-123"}
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    migadu_client.create_mailbox.assert_called_once()
+    assert mock_espo_api.request.call_args_list[0].args == (
+        "PUT",
+        "Contact/crm-123",
+        {"c508Email": "jane@508.dev"},
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Mailbox: created." in message
+
+
+@pytest.mark.asyncio
 async def test_create_user_accounts_reports_partial_success_when_mailbox_crm_sync_fails(
     cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
 ) -> None:
@@ -707,6 +810,48 @@ async def test_create_user_accounts_rejects_migadu_address_mismatch(
     assert "Created mailbox: `other@508.dev`" in message
     audit_metadata = mock_audit.call_args.kwargs["metadata"]
     assert audit_metadata["partial_success"] == "mailbox_created_address_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_partial_sso_without_user_id_omits_none_line(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(
+            cog,
+            "_execute_user_accounts_provisioning",
+            new=AsyncMock(
+                side_effect=SSOProvisioningPartialError(
+                    "validation failed",
+                    partial_user_id=None,
+                    partial_success="sso_created_validation_failed",
+                ),
+            ),
+        ),
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "SSO user ID: `None`" not in message
+    assert "validation failed" in message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -512,6 +512,68 @@ async def test_create_user_accounts_creates_mailbox_sso_and_outline_invite(
 
 
 @pytest.mark.asyncio
+async def test_create_user_accounts_uses_configured_mailbox_domain_for_sso(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@example.org"}
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = []
+    authentik_client.create_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@example.org",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.send_recovery_email.return_value = None
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch(
+            "five08.discord_bot.cogs.crm.settings.migadu_mailbox_domain", "example.org"
+        ),
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe"),
+    ):
+        mock_espo_api.request.return_value = {"id": "crm-123"}
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    authentik_client.create_user.assert_called_once_with(
+        username="jane",
+        name="Jane Doe",
+        email="jane@example.org",
+    )
+    outline_client.invite_user.assert_called_once_with(
+        email="jane@example.org",
+        name="Jane Doe",
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Email: `jane@example.org`" in message
+
+
+@pytest.mark.asyncio
 async def test_create_user_accounts_reuses_existing_mailbox(
     cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
 ) -> None:
@@ -560,6 +622,91 @@ async def test_create_user_accounts_reuses_existing_mailbox(
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Mailbox: already existed/reused." in message
     assert "SSO: already existed/reused" in message
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_reports_partial_success_when_mailbox_crm_sync_fails(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@508.dev"}
+    mock_espo_api.request.side_effect = EspoAPIError("crm update failed")
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client") as authentik_client,
+        patch.object(cog, "_outline_client") as outline_client,
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    authentik_client.assert_not_called()
+    outline_client.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Created the mailbox, but failed to update CRM" in message
+    assert "Email: `jane@508.dev`" in message
+    assert "SSO provisioning and Outline invite were not started" in message
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["partial_success"] == "mailbox_created_crm_update_failed"
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_rejects_migadu_address_mismatch(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "other@508.dev"}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client") as authentik_client,
+        patch.object(cog, "_outline_client") as outline_client,
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    mock_espo_api.request.assert_not_called()
+    authentik_client.assert_not_called()
+    outline_client.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "returned a different address" in message
+    assert "Created mailbox: `other@508.dev`" in message
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["partial_success"] == "mailbox_created_address_mismatch"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -4,7 +4,12 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from five08.discord_bot.cogs.crm import CRMCog, CreateSSOUserSelectionView
+from five08.discord_bot.cogs.crm import (
+    CRMCog,
+    CreateSSOUserSelectionView,
+    CreateUserAccountsSelectionView,
+    OutlineInviteSelectionView,
+)
 from five08.clients.authentik import AuthentikAPIError
 from five08.clients.espo import EspoAPIError
 
@@ -423,3 +428,284 @@ async def test_create_sso_user_shows_selection_view_for_multiple_contacts(
     assert isinstance(view, CreateSSOUserSelectionView)
     labels = [item.label for item in view.children if hasattr(item, "label")]
     assert labels == ["Jane Doe", "John Doe"]
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_creates_mailbox_sso_and_outline_invite(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@508.dev"}
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.return_value = []
+    authentik_client.create_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.send_recovery_email.return_value = None
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {
+        "ok": True,
+        "data": {"sent": [{"email": "jane@508.dev"}], "users": []},
+    }
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        mock_espo_api.request.return_value = {"id": "crm-123"}
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    migadu_client.create_mailbox.assert_called_once()
+    mailbox_request = migadu_client.create_mailbox.call_args.args[0]
+    assert mailbox_request.local_part == "jane"
+    assert mailbox_request.backup_email == "jane.personal@example.com"
+    assert mailbox_request.name == "Jane Doe"
+    authentik_client.create_user.assert_called_once_with(
+        username="jane",
+        name="Jane Doe",
+        email="jane@508.dev",
+    )
+    outline_client.invite_user.assert_called_once_with(
+        email="jane@508.dev",
+        name="Jane Doe",
+    )
+    assert mock_espo_api.request.call_args_list[0].args == (
+        "PUT",
+        "Contact/crm-123",
+        {"c508Email": "jane@508.dev"},
+    )
+    assert mock_espo_api.request.call_args_list[1].args == (
+        "PUT",
+        "Contact/crm-123",
+        {"cSsoID": "42"},
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "User accounts are ready" in message
+    assert "Email: `jane@508.dev`" in message
+    assert "Outline invite: sent." in message
+    assert mock_interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert mock_audit.call_args.kwargs["metadata"]["outline_invited"] is True
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_reuses_existing_mailbox(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "jane@508.dev",
+        "cSsoID": "42",
+    }
+    authentik_client = Mock()
+    authentik_client.get_user.return_value = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client") as migadu_client,
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe"),
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane@508.dev",
+        )
+
+    migadu_client.assert_not_called()
+    mock_espo_api.request.assert_not_called()
+    outline_client.invite_user.assert_called_once_with(
+        email="jane@508.dev",
+        name="Jane Doe",
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Mailbox: already existed/reused." in message
+    assert "SSO: already existed/reused" in message
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_shows_selection_view_for_multiple_contacts(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contacts = [
+        {
+            "id": "crm-123",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+        },
+        {
+            "id": "crm-456",
+            "name": "Jane Smith",
+            "emailAddress": "smith@example.com",
+        },
+    ]
+
+    with patch.object(
+        cog,
+        "_search_contacts_for_lookup",
+        new=AsyncMock(return_value=contacts),
+    ):
+        sent_message = Mock()
+        mock_interaction.followup.send = AsyncMock(return_value=sent_message)
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    kwargs = mock_interaction.followup.send.call_args.kwargs
+    assert kwargs["ephemeral"] is True
+    view = kwargs["view"]
+    assert isinstance(view, CreateUserAccountsSelectionView)
+    labels = [item.label for item in view.children if hasattr(item, "label")]
+    assert labels == ["Jane Doe", "Jane Smith"]
+
+
+@pytest.mark.asyncio
+async def test_invite_outline_user_invites_contact_508_email(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "jane@508.dev",
+    }
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.invite_outline_user.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+        )
+
+    outline_client.invite_user.assert_called_once_with(
+        email="jane@508.dev",
+        name="Jane Doe",
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Outline invite sent" in message
+    assert "Email: `jane@508.dev`" in message
+    assert mock_interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert mock_audit.call_args.kwargs["metadata"]["contact_id"] == "crm-123"
+
+
+@pytest.mark.asyncio
+async def test_invite_outline_user_invites_direct_email_when_no_contact_matches(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    outline_client = Mock()
+    outline_client.invite_user.return_value = {"ok": True}
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.invite_outline_user.callback(
+            cog,
+            mock_interaction,
+            search_term="person@example.com",
+        )
+
+    outline_client.invite_user.assert_called_once_with(
+        email="person@example.com",
+        name=None,
+    )
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Email: `person@example.com`" in message
+    assert mock_audit.call_args.kwargs["metadata"]["direct_email"] is True
+
+
+@pytest.mark.asyncio
+async def test_invite_outline_user_shows_selection_view_for_multiple_contacts(
+    cog: CRMCog, mock_interaction: AsyncMock
+) -> None:
+    contacts = [
+        {
+            "id": "crm-123",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+        },
+        {
+            "id": "crm-456",
+            "name": "Jane Smith",
+            "emailAddress": "smith@example.com",
+            "c508Email": "smith@508.dev",
+        },
+    ]
+
+    with patch.object(
+        cog,
+        "_search_contacts_for_lookup",
+        new=AsyncMock(return_value=contacts),
+    ):
+        sent_message = Mock()
+        mock_interaction.followup.send = AsyncMock(return_value=sent_message)
+        await cog.invite_outline_user.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+        )
+
+    kwargs = mock_interaction.followup.send.call_args.kwargs
+    assert kwargs["ephemeral"] is True
+    view = kwargs["view"]
+    assert isinstance(view, OutlineInviteSelectionView)
+    labels = [item.label for item in view.children if hasattr(item, "label")]
+    assert labels == ["Jane Doe", "Jane Smith"]

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -493,6 +493,7 @@ async def test_create_user_accounts_creates_mailbox_sso_and_outline_invite(
     outline_client.invite_user.assert_called_once_with(
         email="jane@508.dev",
         name="Jane Doe",
+        role="member",
     )
     assert mock_espo_api.request.call_args_list[0].args == (
         "PUT",
@@ -569,6 +570,7 @@ async def test_create_user_accounts_uses_configured_mailbox_domain_for_sso(
     outline_client.invite_user.assert_called_once_with(
         email="jane@example.org",
         name="Jane Doe",
+        role="member",
     )
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Email: `jane@example.org`" in message
@@ -619,6 +621,7 @@ async def test_create_user_accounts_reuses_existing_mailbox(
     outline_client.invite_user.assert_called_once_with(
         email="jane@508.dev",
         name="Jane Doe",
+        role="member",
     )
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Mailbox: already existed/reused." in message
@@ -924,6 +927,7 @@ async def test_invite_outline_user_invites_contact_508_email(
     outline_client.invite_user.assert_called_once_with(
         email="jane@508.dev",
         name="Jane Doe",
+        role="member",
     )
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Outline invite sent" in message
@@ -956,7 +960,8 @@ async def test_invite_outline_user_invites_direct_email_when_no_contact_matches(
 
     outline_client.invite_user.assert_called_once_with(
         email="person@example.com",
-        name=None,
+        name="person",
+        role="member",
     )
     message = mock_interaction.followup.send.call_args.args[0]
     assert "Email: `person@example.com`" in message

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -398,6 +398,56 @@ async def test_create_sso_user_reconciles_user_after_create_error(
 
 
 @pytest.mark.asyncio
+async def test_create_sso_user_reports_partial_success_when_reconciled_crm_update_fails(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "c508Email": "jane@508.dev",
+        "cSsoID": None,
+    }
+    reconciled_user = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.side_effect = [
+        [],
+        [reconciled_user],
+    ]
+    authentik_client.create_user.side_effect = AuthentikAPIError(
+        "Authentik request failed with status 405: Method Not Allowed"
+    )
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.status_code = 405
+    mock_espo_api.request.side_effect = EspoAPIError("crm update failed")
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.create_sso_user.callback(cog, mock_interaction, search_term="jane")
+
+    authentik_client.send_recovery_email.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Recovered the SSO user after the create request failed" in message
+    assert "SSO user ID: `42`" in message
+    assert mock_interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["partial_user_id"] == 42
+    assert audit_metadata["partial_success"] == "sso_reconciled_crm_update_failed"
+
+
+@pytest.mark.asyncio
 async def test_create_sso_user_shows_selection_view_for_multiple_contacts(
     cog: CRMCog, mock_interaction: AsyncMock
 ) -> None:
@@ -924,6 +974,70 @@ async def test_create_user_accounts_reports_outline_invite_failure(
     audit_metadata = mock_audit.call_args.kwargs["metadata"]
     assert audit_metadata["stage"] == "outline"
     assert "outline unavailable" in audit_metadata["error"]
+
+
+@pytest.mark.asyncio
+async def test_create_user_accounts_reports_reconciled_sso_crm_partial_success(
+    cog: CRMCog, mock_interaction: AsyncMock, mock_espo_api: Mock
+) -> None:
+    contact = {
+        "id": "crm-123",
+        "name": "Jane Doe",
+        "emailAddress": "jane.personal@example.com",
+        "c508Email": "",
+        "cSsoID": None,
+    }
+    migadu_client = Mock()
+    migadu_client.create_mailbox.return_value = {"address": "jane@508.dev"}
+    reconciled_user = {
+        "pk": 42,
+        "username": "jane",
+        "email": "jane@508.dev",
+        "name": "Jane Doe",
+        "is_superuser": False,
+    }
+    authentik_client = Mock()
+    authentik_client.find_users_by_username_or_email.side_effect = [
+        [],
+        [reconciled_user],
+    ]
+    authentik_client.create_user.side_effect = AuthentikAPIError(
+        "Authentik request failed with status 405: Method Not Allowed"
+    )
+    authentik_client.resolve_email_stage_id.return_value = "stage-id"
+    authentik_client.status_code = 405
+    outline_client = Mock()
+    mock_espo_api.request.side_effect = [
+        {"id": "crm-123"},
+        EspoAPIError("crm sso update failed"),
+    ]
+
+    with (
+        patch.object(
+            cog,
+            "_search_contacts_for_lookup",
+            new=AsyncMock(return_value=[contact]),
+        ),
+        patch.object(cog, "_migadu_client", return_value=migadu_client),
+        patch.object(cog, "_authentik_client", return_value=authentik_client),
+        patch.object(cog, "_outline_client", return_value=outline_client),
+        patch.object(cog, "_audit_command_safe") as mock_audit,
+    ):
+        await cog.create_user_accounts.callback(
+            cog,
+            mock_interaction,
+            search_term="jane",
+            mailbox_username="jane",
+        )
+
+    outline_client.invite_user.assert_not_called()
+    message = mock_interaction.followup.send.call_args.args[0]
+    assert "Created the mailbox and started SSO provisioning" in message
+    assert "SSO user ID: `42`" in message
+    assert "Outline invite was not sent" in message
+    audit_metadata = mock_audit.call_args.kwargs["metadata"]
+    assert audit_metadata["partial_user_id"] == 42
+    assert audit_metadata["partial_success"] == "sso_reconciled_crm_update_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_outline_client.py
+++ b/tests/unit/test_outline_client.py
@@ -1,0 +1,61 @@
+"""Unit tests for the shared Outline API client."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from five08.clients.outline import OutlineAPIError, OutlineClient
+
+
+def test_invite_user_posts_outline_rpc_payload() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "ok": True,
+        "data": {
+            "sent": [{"email": "jane@508.dev", "name": "Jane Doe"}],
+            "users": [],
+        },
+    }
+
+    with patch("five08.clients.outline.requests.post", return_value=response) as post:
+        result = OutlineClient(
+            api_key="outline-key",
+            base_url="https://outline.example.com/api/",
+            timeout_seconds=7.0,
+        ).invite_user(email="jane@508.dev", name="Jane Doe")
+
+    post.assert_called_once_with(
+        "https://outline.example.com/api/users.invite",
+        headers={
+            "Accept": "application/json",
+            "Authorization": "Bearer outline-key",
+            "Content-Type": "application/json",
+        },
+        json={
+            "invites": [{"email": "jane@508.dev", "name": "Jane Doe"}],
+            "suppressEmail": False,
+        },
+        timeout=7.0,
+    )
+    assert result["ok"] is True
+
+
+def test_invite_user_raises_on_http_error() -> None:
+    response = Mock()
+    response.status_code = 403
+    response.text = "Forbidden"
+
+    with patch("five08.clients.outline.requests.post", return_value=response):
+        with pytest.raises(OutlineAPIError, match="status=403"):
+            OutlineClient(api_key="outline-key").invite_user(email="jane@508.dev")
+
+
+def test_invite_user_raises_on_request_error() -> None:
+    with patch(
+        "five08.clients.outline.requests.post",
+        side_effect=requests.Timeout("timed out"),
+    ):
+        with pytest.raises(OutlineAPIError, match="request failed"):
+            OutlineClient(api_key="outline-key").invite_user(email="jane@508.dev")

--- a/tests/unit/test_outline_client.py
+++ b/tests/unit/test_outline_client.py
@@ -5,7 +5,25 @@ from unittest.mock import Mock, patch
 import pytest
 import requests
 
-from five08.clients.outline import OutlineAPIError, OutlineClient
+from five08.clients.outline import (
+    OutlineAPIError,
+    OutlineClient,
+    normalize_outline_api_base_url,
+)
+
+
+def test_normalize_outline_api_base_url_accepts_root_url() -> None:
+    assert (
+        normalize_outline_api_base_url("https://outline.example.com/")
+        == "https://outline.example.com/api"
+    )
+
+
+def test_normalize_outline_api_base_url_accepts_api_url() -> None:
+    assert (
+        normalize_outline_api_base_url("https://outline.example.com/api/")
+        == "https://outline.example.com/api"
+    )
 
 
 def test_invite_user_posts_outline_rpc_payload() -> None:
@@ -22,7 +40,7 @@ def test_invite_user_posts_outline_rpc_payload() -> None:
     with patch("five08.clients.outline.requests.post", return_value=response) as post:
         result = OutlineClient(
             api_key="outline-key",
-            base_url="https://outline.example.com/api/",
+            base_url="https://outline.example.com/",
             timeout_seconds=7.0,
         ).invite_user(email="jane@508.dev", name="Jane Doe")
 

--- a/uv.lock
+++ b/uv.lock
@@ -753,9 +753,9 @@ dev = [
     { name = "pre-commit-uv" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "pytest-asyncio", specifier = "~=1.3.0" },
-    { name = "pytest-mock", specifier = "~=3.14" },
-    { name = "ruff", specifier = "~=0.15.0" },
-    { name = "types-requests", specifier = ">=2.32.4.20250913" },
+    { name = "pytest-mock", specifier = "~=3.15" },
+    { name = "ruff", specifier = "~=0.15.10" },
+    { name = "types-requests", specifier = ">=2.33.0.20260408" },
     { name = "watchfiles", specifier = ">=1.1.1" },
 ]
 
@@ -1878,27 +1878,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.2"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148 }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565 },
-    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354 },
-    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767 },
-    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591 },
-    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771 },
-    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791 },
-    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271 },
-    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707 },
-    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151 },
-    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132 },
-    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717 },
-    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122 },
-    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295 },
-    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641 },
-    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885 },
-    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725 },
-    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649 },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713 },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267 },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182 },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012 },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479 },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040 },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377 },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784 },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088 },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770 },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355 },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758 },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498 },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765 },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277 },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758 },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821 },
 ]
 
 [[package]]
@@ -2001,14 +2001,14 @@ wheels = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.4.20250913"
+version = "2.33.0.20260508"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/27/489922f4505975b11de2b5ad07b4fe1dca0bca9be81a703f26c5f3acfce5/types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d", size = 23113 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/6b/eb226bdd61a982c9a03e02c657fb4ab001733506e6423906ac142331f2e3/types_requests-2.33.0.20260508.tar.gz", hash = "sha256:81b2ae5f0d20967714a6aa5ef9284c05570d7cb06b7de8f2a77b918b63ddd411", size = 23991 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/20/9a227ea57c1285986c4cf78400d0a91615d25b24e257fd9e2969606bdfae/types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1", size = 20658 },
+    { url = "https://files.pythonhosted.org/packages/cb/96/080db0afdf2c5cc5fe512b41354e8d114fe8f65e9510c56ff8dfd40216ce/types_requests-2.33.0.20260508-py3-none-any.whl", hash = "sha256:fa01459cca184229713df03709db46a905325906d27e042cd4fd7ea3d15d3400", size = 20722 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds Outline user invitation support plus Discord commands to invite a person to Outline directly or provision all user accounts in one flow. The combined flow creates or reuses the 508 mailbox, creates or links the Authentik SSO user with the same email, and sends the Outline invite; the standalone Outline command supports normal CRM search terms or a direct email address.

## Related Issue
#54

## How Has This Been Tested?
- `uv run pytest tests/unit/test_crm_create_sso_user.py tests/unit/test_outline_client.py`
- `uv run pytest tests/unit/test_discord_command_metadata.py`
- `./scripts/lint.sh`
- `./scripts/mypy.sh`
- `./scripts/test.sh`
