### PR TITLE
[codex] Fix audit backend URL defaults

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -127,7 +127,7 @@ Use `.env.example` as the source of defaults.
 
 ## Discord Bot Core
 
-- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree API port, Compose injects `http://api:8090`)
+- `Optional`: `BACKEND_API_BASE_URL` (default: `http://127.0.0.1:8090`; `./scripts/dev.sh` overrides it to the worktree web/API port, Compose injects `http://web:8090`)
 - `Optional`: `HEALTHCHECK_PORT` (host-run `./scripts/dev.sh` ignores `.env` for this key and defaults to a deterministic per-worktree value near `30000 + WORKTREE_ENV_SLOT`; export it in your shell only when you intentionally want a fixed port, and avoid browser-unsafe ports such as `5060`)
 - Note: bot message chunking follows Discord's 2000 character limit in code.
 
@@ -168,7 +168,7 @@ Use `.env.example` as the source of defaults.
 
 ## Discord CRM Audit Logging (Best Effort)
 
-- `Optional`: `AUDIT_API_BASE_URL` (when set with `API_SHARED_SECRET`, CRM commands emit best-effort audit events)
+- `Optional`: `AUDIT_API_BASE_URL` (defaults to `BACKEND_API_BASE_URL`; Compose clears stale `.env` values so the fallback uses the injected backend URL)
 - `Optional`: `AUDIT_API_TIMEOUT_SECONDS` (default: `2.0`)
 - `Optional`: `DISCORD_LOGS_WEBHOOK_URL` (if set, command and job events are posted to this Discord webhook)
 - `Optional`: `DISCORD_LOGS_WEBHOOK_WAIT` (default: `true`; appends `wait=true` unless already present in the webhook URL)

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Use `.env.example` as the source of truth for defaults.
 
 ### Discord CRM Audit Logging (Best Effort)
 
-- `Optional`: `AUDIT_API_BASE_URL` (when set with `API_SHARED_SECRET`, CRM commands emit best-effort audit events)
+- `Optional`: `AUDIT_API_BASE_URL` (defaults to `BACKEND_API_BASE_URL`; Compose clears stale `.env` values so the fallback uses the injected backend URL)
 - `Optional`: `AUDIT_API_TIMEOUT_SECONDS` (default: `2.0`)
 - `Optional`: `DISCORD_LOGS_WEBHOOK_URL` (if set, command and job events are posted to this Discord webhook)
 - `Optional`: `DISCORD_LOGS_WEBHOOK_WAIT` (default: `true`; request delivery confirmation from Discord)

--- a/apps/discord_bot/src/five08/discord_bot/utils/audit.py
+++ b/apps/discord_bot/src/five08/discord_bot/utils/audit.py
@@ -449,8 +449,10 @@ def create_discord_audit_logger() -> DiscordAuditLogger:
     """Build the standard Discord audit logger from bot settings."""
     from five08.discord_bot.config import settings
 
+    audit_base_url = (settings.audit_api_base_url or "").strip()
+    backend_base_url = settings.backend_api_base_url.strip()
     return DiscordAuditLogger(
-        base_url=settings.audit_api_base_url,
+        base_url=audit_base_url or backend_base_url,
         shared_secret=settings.api_shared_secret,
         timeout_seconds=settings.audit_api_timeout_seconds,
         discord_logs_webhook_url=settings.discord_logs_webhook_url,

--- a/compose.yaml
+++ b/compose.yaml
@@ -69,6 +69,7 @@ services:
       REDIS_URL: redis://redis:6379/0
       REDIS_QUEUE_NAME: ${REDIS_QUEUE_NAME:-jobs.default}
       BACKEND_API_BASE_URL: http://web:8090
+      AUDIT_API_BASE_URL: ""
     restart: unless-stopped
     networks:
       - default

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -13,6 +13,9 @@ export MINIO_ENDPOINT="http://127.0.0.1:${MINIO_API_HOST_PORT}"
 export BACKEND_API_BASE_URL="http://127.0.0.1:${WEB_PORT}"
 export WORKER_API_BASE_URL="http://127.0.0.1:${WEB_PORT}"
 export DISCORD_BOT_INTERNAL_BASE_URL="http://127.0.0.1:${HEALTHCHECK_PORT}"
+if [ -z "${AUDIT_API_BASE_URL-}" ]; then
+  export AUDIT_API_BASE_URL="$BACKEND_API_BASE_URL"
+fi
 
 shell_quote() {
   python3 -c 'import shlex, sys; print(shlex.quote(sys.argv[1]))' "$1"
@@ -81,6 +84,7 @@ EOF
     emit_export REDIS_URL "$REDIS_URL"
     emit_export MINIO_ENDPOINT "$MINIO_ENDPOINT"
     emit_export BACKEND_API_BASE_URL "$BACKEND_API_BASE_URL"
+    emit_export AUDIT_API_BASE_URL "$AUDIT_API_BASE_URL"
     emit_export WORKER_API_BASE_URL "$WORKER_API_BASE_URL"
     emit_export DISCORD_BOT_INTERNAL_BASE_URL "$DISCORD_BOT_INTERNAL_BASE_URL"
     printf 'export POSTGRES_URL="$('%s' print-postgres-url)"\n' "$(shell_quote "$script_dir/dev.sh")"

--- a/tests/unit/test_discord_audit.py
+++ b/tests/unit/test_discord_audit.py
@@ -1,8 +1,12 @@
 """Unit tests for Discord audit helper."""
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from five08.discord_bot.utils.audit import DiscordAuditLogger
+from five08.discord_bot.utils.audit import (
+    DiscordAuditLogger,
+    create_discord_audit_logger,
+)
 
 
 def _mock_interaction() -> Mock:
@@ -49,6 +53,38 @@ def test_log_admin_sso_action_disabled_logger_does_not_queue() -> None:
         )
 
     mock_queue.assert_not_called()
+
+
+def test_create_discord_audit_logger_defaults_to_backend_base_url() -> None:
+    mock_settings = SimpleNamespace(
+        audit_api_base_url=None,
+        backend_api_base_url="http://web:8090",
+        api_shared_secret="secret",
+        audit_api_timeout_seconds=1.0,
+        discord_logs_webhook_url=None,
+        discord_logs_webhook_wait=True,
+    )
+
+    with patch("five08.discord_bot.config.settings", mock_settings):
+        logger = create_discord_audit_logger()
+
+    assert logger.base_url == "http://web:8090"
+
+
+def test_create_discord_audit_logger_treats_blank_audit_url_as_unset() -> None:
+    mock_settings = SimpleNamespace(
+        audit_api_base_url="   ",
+        backend_api_base_url="http://web:8090",
+        api_shared_secret="secret",
+        audit_api_timeout_seconds=1.0,
+        discord_logs_webhook_url=None,
+        discord_logs_webhook_wait=True,
+    )
+
+    with patch("five08.discord_bot.config.settings", mock_settings):
+        logger = create_discord_audit_logger()
+
+    assert logger.base_url == "http://web:8090"
 
 
 def test_log_admin_sso_action_skips_blank_actor_email() -> None:


### PR DESCRIPTION
## Summary

- Point Discord bot audit writes at the renamed Compose backend service `web:8090`.
- Default `AUDIT_API_BASE_URL` to `BACKEND_API_BASE_URL` so audit config does not drift from the normal backend URL.
- Document the fallback and update the stale `api:8090` reference.

## Root Cause

The backend Compose service was renamed from `api` to `web`, but audit writes used a separate `AUDIT_API_BASE_URL` setting. A stale explicit value like `http://api:8090` could still override the working backend URL and fail DNS resolution from the Discord bot container.

## Validation

- `uv run pytest tests/unit/test_discord_audit.py`
- `uv run ruff check apps/discord_bot/src/five08/discord_bot/utils/audit.py tests/unit/test_discord_audit.py`
- `uv run ruff format --check apps/discord_bot/src/five08/discord_bot/utils/audit.py tests/unit/test_discord_audit.py`
- Commit hook: `ruff`, `ruff format`, `mypy`