### PR TITLE
[codex] Share agent local request mapping

### DIFF
--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -70,6 +70,14 @@ public channels. A follow-up in the same thread should mention the bot again so
 the bot has an explicit user trigger and fresh Discord role context for that
 request.
 
+Production mention handling depends on Discord gateway and channel access:
+The bot requests all intents in code, but the production Discord application
+should have the Message Content privileged intent enabled or approved in the
+Developer Portal. Direct mentions expose message content even without that
+intent, but follow-up messages in bot-created threads need it because they do
+not mention the bot. The bot also needs channel permissions to view the channel,
+send messages, create public threads, and send messages in threads.
+
 Audit writes are best-effort and do not block command execution. If the audit
 store is unavailable, treat the agent surface as temporarily untraced until the
 audit pipeline is healthy again.

--- a/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
@@ -7,7 +7,7 @@ import difflib
 import logging
 import re
 import time
-from typing import Any
+from typing import Any, Literal
 
 import discord
 import requests
@@ -241,6 +241,15 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
         """Send a natural-language request to the backend agent gateway."""
         await interaction.response.defer(ephemeral=True)
 
+        local_response = self._local_agent_response(
+            request=request,
+            roles=self._role_names_from_user(interaction.user),
+            transport="slash",
+        )
+        if local_response is not None:
+            await interaction.followup.send(local_response, ephemeral=True)
+            return
+
         context = self._build_agent_context(interaction)
         try:
             response = await self._post_agent_request(
@@ -334,64 +343,16 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
             )
             return
 
-        if self._is_agent_help_request(request):
+        local_response = self._local_agent_response(
+            request=request,
+            roles=self._role_names_from_user(message.author),
+            transport="mention",
+        )
+        if local_response is not None:
             await self._send_mention_public_response(
                 message=message,
                 request=request,
-                content=self._agent_capabilities_message(
-                    roles=self._role_names_from_user(message.author)
-                ),
-            )
-            return
-
-        if self._is_agent_presence_check(request):
-            await self._send_mention_public_response(
-                message=message,
-                request=request,
-                content=(
-                    "Yes, I can see this. Ask for a supported workflow, or ask "
-                    "`what can you do?` for examples."
-                ),
-            )
-            return
-
-        if self._is_agent_acknowledgement(request):
-            await self._send_mention_public_response(
-                message=message,
-                request=request,
-                content="Got it.",
-            )
-            return
-
-        if self._is_unlinked_discord_members_request(request):
-            await self._send_mention_public_response(
-                message=message,
-                request=request,
-                content=(
-                    "That report includes member identity/linkage data, so use "
-                    "`/unlinked-discord-users` for the private ephemeral response."
-                ),
-            )
-            return
-
-        if self._is_onboarding_people_request(request):
-            await self._send_mention_public_response(
-                message=message,
-                request=request,
-                content=(
-                    "That is CRM people/onboarding data, so use "
-                    "`/view-onboarding-queue` for the private ephemeral queue view. "
-                    "For targeted lookup, use `/search-members`."
-                ),
-            )
-            return
-
-        member_lookup_target = self._member_info_lookup_target(request)
-        if member_lookup_target is not None:
-            await self._send_mention_public_response(
-                message=message,
-                request=request,
-                content=self._member_lookup_command_message(member_lookup_target),
+                content=local_response,
             )
             return
 
@@ -527,6 +488,51 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
         normalized = request.casefold().strip(" ?!.")
         return AgentCog._matches_smalltalk(normalized, _AGENT_ACKNOWLEDGEMENTS)
 
+    def _local_agent_response(
+        self,
+        *,
+        request: str,
+        roles: list[str],
+        transport: Literal["slash", "mention"],
+    ) -> str | None:
+        if self._is_agent_help_request(request):
+            return self._agent_capabilities_message(roles=roles, transport=transport)
+        if self._is_agent_presence_check(request):
+            return (
+                "Yes, I can see this. Ask for a supported workflow, or ask "
+                "`what can you do?` for examples."
+            )
+        if self._is_agent_acknowledgement(request):
+            return "Got it."
+        if self._is_unlinked_discord_members_request(request):
+            if transport == "slash":
+                return (
+                    "That report includes member identity/linkage data, so use "
+                    "`/unlinked-discord-users` for the dedicated report."
+                )
+            return (
+                "That report includes member identity/linkage data, so use "
+                "`/unlinked-discord-users` for the private ephemeral response."
+            )
+        if self._is_onboarding_people_request(request):
+            if transport == "slash":
+                return (
+                    "That is CRM people/onboarding data, so use "
+                    "`/view-onboarding-queue` for the dedicated queue view. "
+                    "For targeted lookup, keep using `/agent`."
+                )
+            return (
+                "That is CRM people/onboarding data, so use "
+                "`/view-onboarding-queue` for the private ephemeral queue view. "
+                "For targeted lookup, use `/search-members`."
+            )
+        if transport == "slash":
+            return None
+        member_lookup_target = self._member_info_lookup_target(request)
+        if member_lookup_target is not None:
+            return self._member_lookup_command_message(member_lookup_target)
+        return None
+
     @staticmethod
     def _matches_smalltalk(normalized: str, phrases: frozenset[str]) -> bool:
         if normalized in phrases:
@@ -539,7 +545,11 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
         )
 
     @staticmethod
-    def _agent_capabilities_message(*, roles: list[str]) -> str:
+    def _agent_capabilities_message(
+        *,
+        roles: list[str],
+        transport: Literal["slash", "mention"] = "mention",
+    ) -> str:
         normalized_roles = {role.strip().casefold() for role in roles}
         is_admin = bool(normalized_roles & {"admin", "owner", "steering committee"})
         is_engineer = "engineer" in normalized_roles or is_admin
@@ -556,21 +566,29 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
                 ]
             )
         if not capabilities:
-            return "\n".join(
+            lines = [
+                "I do not see any agent workflows available for your current Discord roles."
+            ]
+            if transport == "mention":
+                lines.extend(
+                    [
+                        "",
+                        "Use `/agent` when you want the response kept private.",
+                    ]
+                )
+            return "\n".join(lines)
+        lines = [
+            "I can help with:",
+            *capabilities,
+        ]
+        if transport == "mention":
+            lines.extend(
                 [
-                    "I do not see any agent workflows available for your current Discord roles.",
                     "",
                     "Use `/agent` when you want the response kept private.",
                 ]
             )
-        return "\n".join(
-            [
-                "I can help with:",
-                *capabilities,
-                "",
-                "Use `/agent` when you want the response kept private.",
-            ]
-        )
+        return "\n".join(lines)
 
     @staticmethod
     def _is_unlinked_discord_members_request(request: str) -> bool:

--- a/tests/unit/test_agent_cog.py
+++ b/tests/unit/test_agent_cog.py
@@ -400,6 +400,160 @@ def test_build_agent_context_from_message_uses_thread_message_context() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_command_answers_presence_check_without_backend() -> None:
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock()
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(id=123, roles=[]),
+    )
+
+    await AgentCog.agent_command.callback(cog, interaction, "do you see this")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    interaction.followup.send.assert_awaited_once()
+    assert "I can see this" in interaction.followup.send.await_args.args[0]
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+    cog._post_agent_request.assert_not_awaited()
+    cog._audit_command_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_command_answers_help_without_backend() -> None:
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock()
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(
+            id=123,
+            roles=[SimpleNamespace(name="Admin")],
+        ),
+    )
+
+    await AgentCog.agent_command.callback(cog, interaction, "what can you do?")
+
+    response = interaction.followup.send.await_args.args[0]
+    assert "I can help with:" in response
+    assert "GitHub issues:" in response
+    assert "CRM:" in response
+    assert "create 508 mailboxes" in response
+    assert "`/agent`" not in response
+    cog._post_agent_request.assert_not_awaited()
+    cog._audit_command_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_command_answers_acknowledgement_without_backend() -> None:
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock()
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(id=123, roles=[]),
+    )
+
+    await AgentCog.agent_command.callback(cog, interaction, "thanks")
+
+    interaction.followup.send.assert_awaited_once_with("Got it.", ephemeral=True)
+    cog._post_agent_request.assert_not_awaited()
+    cog._audit_command_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_command_routes_unlinked_member_report_to_dedicated_command() -> (
+    None
+):
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock()
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(id=123, roles=[]),
+    )
+
+    await AgentCog.agent_command.callback(
+        cog,
+        interaction,
+        "can you look up people with no discord linked but are members",
+    )
+
+    response = interaction.followup.send.await_args.args[0]
+    assert "/unlinked-discord-users" in response
+    assert "dedicated report" in response
+    assert "ephemeral" not in response
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+    cog._post_agent_request.assert_not_awaited()
+    cog._audit_command_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_command_routes_onboarding_people_report_to_dedicated_command() -> (
+    None
+):
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock()
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(id=123, roles=[]),
+    )
+
+    await AgentCog.agent_command.callback(
+        cog,
+        interaction,
+        "find me people in the onboarding queue",
+    )
+
+    response = interaction.followup.send.await_args.args[0]
+    assert "/view-onboarding-queue" in response
+    assert "dedicated queue view" in response
+    assert "ephemeral" not in response
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+    cog._post_agent_request.assert_not_awaited()
+    cog._audit_command_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_agent_command_member_info_lookup_reaches_gateway() -> None:
+    cog = AgentCog.__new__(AgentCog)
+    cog._post_agent_request = AsyncMock(
+        return_value={"status": "executed", "message": "Done"}
+    )
+    cog._audit_command_safe = Mock()
+    interaction = SimpleNamespace(
+        id=999,
+        guild_id=456,
+        channel_id=789,
+        message=None,
+        response=SimpleNamespace(defer=AsyncMock()),
+        followup=SimpleNamespace(send=AsyncMock()),
+        user=SimpleNamespace(
+            id=123,
+            roles=[SimpleNamespace(name="Admin")],
+        ),
+    )
+
+    await AgentCog.agent_command.callback(cog, interaction, "Look up info on Caleb")
+
+    cog._post_agent_request.assert_awaited_once()
+    assert cog._post_agent_request.await_args.kwargs["message"] == (
+        "Look up info on Caleb"
+    )
+    assert cog._post_agent_request.await_args.kwargs["context"]["roles"] == ["Admin"]
+    response = interaction.followup.send.await_args.args[0]
+    assert "Agent status: executed" in response
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+    cog._audit_command_safe.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_confirmation_context_in_dm_uses_cached_original_guild_roles() -> None:
     member = SimpleNamespace(roles=[SimpleNamespace(name="Member")])
     guild = SimpleNamespace(get_member=Mock(return_value=member))


### PR DESCRIPTION
## Summary
- route `/agent` through shared local handling for help, presence checks, acknowledgements, and report-style sensitive redirects
- keep delivery wording transport-aware so slash commands stay ephemeral without mention-oriented privacy copy
- preserve `/agent` CRM member info lookups as backend gateway requests, while `@mention` continues to redirect those to `/search-members`
- document production Discord mention requirements around Message Content intent and channel/thread permissions

## Validation
- `uv run pytest tests/unit/test_agent_cog.py`
- `./scripts/lint.sh`
- `./scripts/test.sh`

## Notes
- This PR is ready for review.