### PR TITLE
[codex] Add agent account provisioning workflows

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
@@ -562,7 +562,7 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
             capabilities.extend(
                 [
                     "- CRM: search contacts, approve/reject onboarding, and submit member agreements.",
-                    "- Ops: create 508 mailboxes.",
+                    "- Ops: create 508 accounts, Authentik SSO users, Outline invites, and mailboxes.",
                 ]
             )
         if not capabilities:

--- a/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
@@ -1000,8 +1000,27 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
                         lines.append(f"- {tool_name}: {result_status} ({result_error})")
                     else:
                         lines.append(f"- {tool_name}: {result_status}")
+                    recovery_email_error = self._result_recovery_email_error(
+                        result_payload
+                    )
+                    if recovery_email_error:
+                        lines.append(f"  Recovery email failed: {recovery_email_error}")
 
         return "\n".join(lines)[:1900]
+
+    @staticmethod
+    def _result_recovery_email_error(payload: object) -> str | None:
+        if not isinstance(payload, dict):
+            return None
+        direct_error = str(payload.get("recovery_email_error") or "").strip()
+        if direct_error:
+            return direct_error
+        sso_payload = payload.get("sso")
+        if isinstance(sso_payload, dict):
+            nested_error = str(sso_payload.get("recovery_email_error") or "").strip()
+            if nested_error:
+                return nested_error
+        return None
 
     @staticmethod
     def _format_issue_result_lines(

--- a/packages/shared/src/five08/agent/__init__.py
+++ b/packages/shared/src/five08/agent/__init__.py
@@ -22,6 +22,7 @@ from five08.agent.policy import PolicyDecision, PolicyEngine
 from five08.agent.tools import (
     InMemoryTaskStore,
     ToolManifest,
+    ToolPartialSuccessError,
     ToolRegistry,
     ToolRuntimeConfig,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "PolicyEngine",
     "RiskLevel",
     "ToolManifest",
+    "ToolPartialSuccessError",
     "ToolRegistry",
     "ToolRuntimeConfig",
 ]

--- a/packages/shared/src/five08/agent/evals.py
+++ b/packages/shared/src/five08/agent/evals.py
@@ -1056,21 +1056,29 @@ def _response_from_live_draft(
     if resolved_member_agreement is not None:
         return resolved_member_agreement
     if draft.status == "needs_clarification" or not draft.actions:
-        question = draft.clarification_question or "What should I do next?"
-        return AgentResponse(
-            status="needs_clarification",
-            message=question,
-            clarification_question=question,
+        fallback_action = _deterministic_live_planner_fallback(
+            orchestrator=orchestrator,
+            message=message,
         )
+        if fallback_action is not None:
+            actions = [fallback_action]
+        else:
+            question = draft.clarification_question or "What should I do next?"
+            return AgentResponse(
+                status="needs_clarification",
+                message=question,
+                clarification_question=question,
+            )
+    else:
+        actions = [
+            AgentToolAction(
+                tool_name=action.tool_name,
+                arguments=action.arguments,
+                summary=action.summary or f"Call {action.tool_name}",
+            )
+            for action in draft.actions
+        ]
 
-    actions = [
-        AgentToolAction(
-            tool_name=action.tool_name,
-            arguments=action.arguments,
-            summary=action.summary or f"Call {action.tool_name}",
-        )
-        for action in draft.actions
-    ]
     for action in actions:
         manifest = orchestrator.registry.get(action.tool_name)
         if manifest is None:
@@ -1145,6 +1153,24 @@ def _response_from_live_draft(
         results=results,
         message=orchestrator._execution_message(results),
     )
+
+
+def _deterministic_live_planner_fallback(
+    *,
+    orchestrator: AgentOrchestrator,
+    message: str,
+) -> AgentToolAction | None:
+    action = orchestrator._parse_action(message)
+    if action is None:
+        return None
+    if action.tool_name != "task_read.search_tasks":
+        return None
+    if orchestrator.registry.get(action.tool_name) is None:
+        return None
+    if _live_action_clarification(orchestrator, action) is not None:
+        return None
+    action.summary = action.summary or f"Call {action.tool_name}"
+    return action
 
 
 def _live_action_clarification(

--- a/packages/shared/src/five08/agent/evals.py
+++ b/packages/shared/src/five08/agent/evals.py
@@ -82,6 +82,9 @@ For a GitHub issue create request, do not ask for optional body text. Use the ph
 For "Create a GitHub issue to improve search UI in repo 508-dev/508-workflows", call github_issue.create_issue with {"repository":"508-dev/508-workflows","title":"improve search UI"}.
 For "Create GitHub issue in repo 508-dev/508-workflows titled Fix onboarding sync", call github_issue.create_issue with {"repository":"508-dev/508-workflows","title":"Fix onboarding sync"}.
 CRM contact lookup is a read/search action. For "Find contact Sarah", "Find member Sarah", "Lookup contact Sarah", or "Look up info on Sarah", call crm_read.search_contacts with {"query":"Sarah","limit":5}. A person name or partial name is enough for this read action; do not ask for a contact ID or email.
+For "Approve CRM contact contact-123", call crm_write.update_contact with {"contact_id":"contact-123","updates":{"cOnboardingState":"approved"}}.
+For "Reject CRM contact contact-123", call crm_write.update_contact with {"contact_id":"contact-123","updates":{"cOnboardingState":"rejected"}}.
+For CRM approval and rejection requests, do not ask what approval action is needed when the verb is approve or reject and the CRM contact ID is present.
 For "Send member agreement to Sarah Example sarah@example.com", call docuseal_write.create_member_agreement_submission with {"submitter_name":"Sarah Example","submitter_email":"sarah@example.com","send_email":true}.
 For "Send member agreement to Jane Doe at jane@example.com", call docuseal_write.create_member_agreement_submission with {"submitter_name":"Jane Doe","submitter_email":"jane@example.com","send_email":true}.
 For "Create SSO user for CRM contact abc123", call sso_write.create_user with {"contact_id":"abc123"}.

--- a/packages/shared/src/five08/agent/evals.py
+++ b/packages/shared/src/five08/agent/evals.py
@@ -69,6 +69,9 @@ Available tools and arguments:
 - crm_write.update_contact: contact_id string, updates object. Onboarding state field is cOnboardingState.
 - docuseal_write.create_member_agreement_submission: submitter_email, submitter_name, send_email true.
 - mail_write.create_mailbox: local_part, backup_email, name.
+- sso_write.create_user: contact_id string or contact_query string.
+- outline_write.invite_user: email string, or contact_id/contact_query for a CRM contact.
+- account_write.create_user_accounts: contact_id string or contact_query string, mailbox_username string.
 
 If a task search lacks a project, return needs_clarification with "Which project should I search?"
 For a task search like "Show tasks for project Atlas matching onboarding", call task_read.search_tasks with {"project":"Atlas","query":"onboarding"}.
@@ -81,6 +84,9 @@ For "Create GitHub issue in repo 508-dev/508-workflows titled Fix onboarding syn
 CRM contact lookup is a read/search action. For "Find contact Sarah", "Find member Sarah", "Lookup contact Sarah", or "Look up info on Sarah", call crm_read.search_contacts with {"query":"Sarah","limit":5}. A person name or partial name is enough for this read action; do not ask for a contact ID or email.
 For "Send member agreement to Sarah Example sarah@example.com", call docuseal_write.create_member_agreement_submission with {"submitter_name":"Sarah Example","submitter_email":"sarah@example.com","send_email":true}.
 For "Send member agreement to Jane Doe at jane@example.com", call docuseal_write.create_member_agreement_submission with {"submitter_name":"Jane Doe","submitter_email":"jane@example.com","send_email":true}.
+For "Create SSO user for CRM contact abc123", call sso_write.create_user with {"contact_id":"abc123"}.
+For "Invite jane@508.dev to Outline", call outline_write.invite_user with {"email":"jane@508.dev"}.
+For "Create 508 accounts for Jane Doe with mailbox jane@508.dev", call account_write.create_user_accounts with {"contact_query":"Jane Doe","mailbox_username":"jane@508.dev"}.
 For writes, still return the intended write action; confirmation is handled by policy.
 For permission-sensitive requests, still return the intended action; policy handles denial.
 """
@@ -1200,11 +1206,28 @@ def _live_action_clarification(
             return "What backup email should I use?"
         if not _non_empty_arg(args, "name"):
             return "What display name should I use?"
+    if tool_name == "sso_write.create_user":
+        if not _has_contact_reference(args):
+            return "Which CRM contact should I create the SSO user for?"
+        return None
+    if tool_name == "outline_write.invite_user":
+        if not _non_empty_arg(args, "email") and not _has_contact_reference(args):
+            return "Who should I invite to Outline?"
+        return None
+    if tool_name == "account_write.create_user_accounts":
+        if not _has_contact_reference(args):
+            return "Which CRM contact should I create accounts for?"
+        if not _non_empty_arg(args, "mailbox_username"):
+            return "What 508 mailbox username should I create?"
     return None
 
 
 def _non_empty_arg(args: dict[str, Any], key: str) -> bool:
     return _non_empty_text(args.get(key))
+
+
+def _has_contact_reference(args: dict[str, Any]) -> bool:
+    return _non_empty_arg(args, "contact_id") or _non_empty_arg(args, "contact_query")
 
 
 def _non_empty_text(value: Any) -> bool:

--- a/packages/shared/src/five08/agent/intent_normalizer.py
+++ b/packages/shared/src/five08/agent/intent_normalizer.py
@@ -32,6 +32,9 @@ Rewrite the user's request into one supported command pattern when confident:
 - Create GitHub issue titled <title> [in repo owner/name]
 - Send member agreement to <name> at <email>
 - Create mailbox <mailbox> for <name> with backup email <email>
+- Create SSO user for <CRM contact ID or contact name>
+- Invite <email or CRM contact name> to Outline
+- Create 508 accounts for <CRM contact ID or contact name> with mailbox <mailbox>
 
 Do not invent IDs, emails, project names, repositories, or contact names.
 Use null when the request is small talk, help, a sensitive report/list request,

--- a/packages/shared/src/five08/agent/orchestrator.py
+++ b/packages/shared/src/five08/agent/orchestrator.py
@@ -23,6 +23,11 @@ from five08.clients.migadu import normalize_migadu_mailbox_domain
 
 _TASK_ID_RE = re.compile(r"\bTASK-\d+\b", re.IGNORECASE)
 _DATE_ISO_RE = re.compile(r"\b(20\d{2}-\d{2}-\d{2})\b")
+_CONTACT_ID_REFERENCE_RE = re.compile(
+    r"\b(?:crm\s+)?contact\s+([A-Za-z0-9_-]*\d[A-Za-z0-9_-]*)\b",
+    re.IGNORECASE,
+)
+_CONTACT_QUERY_PREFIX_RE = re.compile(r"^(?:crm\s+)?contact\s+", re.IGNORECASE)
 _MONTH_DATE_RE = re.compile(
     r"\b(january|february|march|april|may|june|july|august|september|october|november|december)"
     r"\s+(\d{1,2})(?:,\s*|\s+)(20\d{2})\b",
@@ -797,11 +802,7 @@ class AgentOrchestrator:
 
     @staticmethod
     def _extract_contact_reference(text: str) -> dict[str, str] | None:
-        contact_id_match = re.search(
-            r"\b(?:crm\s+)?contact\s+([A-Za-z0-9_-]{2,})\b",
-            text,
-            re.IGNORECASE,
-        )
+        contact_id_match = _CONTACT_ID_REFERENCE_RE.search(text)
         if contact_id_match is not None:
             return {"contact_id": contact_id_match.group(1)}
 
@@ -813,18 +814,16 @@ class AgentOrchestrator:
         )
         if query_match is None:
             return None
-        query = _clean_text(query_match.group(1))
+        query = _clean_text(
+            _CONTACT_QUERY_PREFIX_RE.sub("", query_match.group(1), count=1)
+        )
         if not query:
             return None
         return {"contact_query": query}
 
     @classmethod
     def _extract_outline_contact_reference(cls, text: str) -> dict[str, str] | None:
-        contact_id_match = re.search(
-            r"\b(?:crm\s+)?contact\s+([A-Za-z0-9_-]{2,})\b",
-            text,
-            re.IGNORECASE,
-        )
+        contact_id_match = _CONTACT_ID_REFERENCE_RE.search(text)
         if contact_id_match is not None:
             return {"contact_id": contact_id_match.group(1)}
 
@@ -834,7 +833,9 @@ class AgentOrchestrator:
             re.IGNORECASE,
         )
         if invite_match is not None:
-            query = _clean_text(invite_match.group(1))
+            query = _clean_text(
+                _CONTACT_QUERY_PREFIX_RE.sub("", invite_match.group(1), count=1)
+            )
             if query:
                 return {"contact_query": query}
         return cls._extract_contact_reference(text)

--- a/packages/shared/src/five08/agent/orchestrator.py
+++ b/packages/shared/src/five08/agent/orchestrator.py
@@ -790,7 +790,7 @@ class AgentOrchestrator:
     @staticmethod
     def _extract_mailbox_username(text: str) -> str | None:
         match = re.search(
-            r"\b(?:mailbox|508\s+(?:email|address)|email|username)"
+            r"\b(?:mailbox\s+username|mailbox|508\s+(?:email|address)|email|username)"
             r"\s+(?:for\s+)?([A-Za-z0-9._%+-]+"
             r"(?:@[A-Za-z0-9.-]+\.[A-Za-z]{2,})?)\b",
             text,

--- a/packages/shared/src/five08/agent/orchestrator.py
+++ b/packages/shared/src/five08/agent/orchestrator.py
@@ -491,6 +491,16 @@ class AgentOrchestrator:
             keyword in lowered for keyword in ["send", "create", "submit"]
         ):
             return self._parse_member_agreement(text)
+        if self._is_user_accounts_create_request(lowered):
+            return self._parse_user_accounts_create(text)
+        if "sso" in lowered and any(
+            keyword in lowered for keyword in ["create", "link", "provision"]
+        ):
+            return self._parse_sso_user_create(text)
+        if "outline" in lowered and any(
+            keyword in lowered for keyword in ["invite", "add"]
+        ):
+            return self._parse_outline_invite(text)
         if "mailbox" in lowered and any(
             keyword in lowered for keyword in ["create", "provision"]
         ):
@@ -692,6 +702,133 @@ class AgentOrchestrator:
             },
             summary=f"Create mailbox {local_part} for {name}",
         )
+
+    @staticmethod
+    def _is_user_accounts_create_request(lowered: str) -> bool:
+        has_create = any(keyword in lowered for keyword in ["create", "provision"])
+        has_account_target = any(
+            keyword in lowered
+            for keyword in [
+                "508 account",
+                "508 accounts",
+                "user account",
+                "user accounts",
+                "account bundle",
+            ]
+        )
+        return has_create and has_account_target
+
+    def _parse_user_accounts_create(self, text: str) -> AgentToolAction | None:
+        mailbox_username = self._extract_mailbox_username(text)
+        contact_arguments = self._extract_contact_reference(text)
+        if mailbox_username is None or contact_arguments is None:
+            return None
+        arguments = dict(contact_arguments)
+        arguments["mailbox_username"] = mailbox_username
+        contact_label = contact_arguments.get("contact_id") or contact_arguments.get(
+            "contact_query"
+        )
+        return AgentToolAction(
+            tool_name="account_write.create_user_accounts",
+            arguments=arguments,
+            summary=f"Create 508 accounts for {contact_label}",
+        )
+
+    def _parse_sso_user_create(self, text: str) -> AgentToolAction | None:
+        contact_arguments = self._extract_contact_reference(text)
+        if contact_arguments is None:
+            return None
+        contact_label = contact_arguments.get("contact_id") or contact_arguments.get(
+            "contact_query"
+        )
+        return AgentToolAction(
+            tool_name="sso_write.create_user",
+            arguments=contact_arguments,
+            summary=f"Create or link SSO user for {contact_label}",
+        )
+
+    def _parse_outline_invite(self, text: str) -> AgentToolAction | None:
+        email_match = re.search(
+            r"\b([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,})\b",
+            text,
+            re.IGNORECASE,
+        )
+        if email_match is not None:
+            email = email_match.group(1)
+            return AgentToolAction(
+                tool_name="outline_write.invite_user",
+                arguments={"email": email},
+                summary=f"Invite {email} to Outline",
+            )
+
+        contact_arguments = self._extract_outline_contact_reference(text)
+        if contact_arguments is None:
+            return None
+        contact_label = contact_arguments.get("contact_id") or contact_arguments.get(
+            "contact_query"
+        )
+        return AgentToolAction(
+            tool_name="outline_write.invite_user",
+            arguments=contact_arguments,
+            summary=f"Invite {contact_label} to Outline",
+        )
+
+    @staticmethod
+    def _extract_mailbox_username(text: str) -> str | None:
+        match = re.search(
+            r"\b(?:mailbox|508\s+(?:email|address)|email|username)"
+            r"\s+(?:for\s+)?([A-Za-z0-9._%+-]+"
+            r"(?:@[A-Za-z0-9.-]+\.[A-Za-z]{2,})?)\b",
+            text,
+            re.IGNORECASE,
+        )
+        if match is None:
+            return None
+        return match.group(1).strip()
+
+    @staticmethod
+    def _extract_contact_reference(text: str) -> dict[str, str] | None:
+        contact_id_match = re.search(
+            r"\b(?:crm\s+)?contact\s+([A-Za-z0-9_-]{2,})\b",
+            text,
+            re.IGNORECASE,
+        )
+        if contact_id_match is not None:
+            return {"contact_id": contact_id_match.group(1)}
+
+        query_match = re.search(
+            r"\bfor\s+(.+?)(?=\s+(?:with|using|and)\s+"
+            r"(?:mailbox|508\s+(?:email|address)|email|username)\b|$)",
+            text,
+            re.IGNORECASE,
+        )
+        if query_match is None:
+            return None
+        query = _clean_text(query_match.group(1))
+        if not query:
+            return None
+        return {"contact_query": query}
+
+    @classmethod
+    def _extract_outline_contact_reference(cls, text: str) -> dict[str, str] | None:
+        contact_id_match = re.search(
+            r"\b(?:crm\s+)?contact\s+([A-Za-z0-9_-]{2,})\b",
+            text,
+            re.IGNORECASE,
+        )
+        if contact_id_match is not None:
+            return {"contact_id": contact_id_match.group(1)}
+
+        invite_match = re.search(
+            r"\binvite\s+(.+?)\s+to\s+outline\b",
+            text,
+            re.IGNORECASE,
+        )
+        if invite_match is not None:
+            query = _clean_text(invite_match.group(1))
+            if query:
+                return {"contact_query": query}
+        return cls._extract_contact_reference(text)
 
     @staticmethod
     def _extract_mailbox_backup_email(text: str) -> str | None:
@@ -1120,6 +1257,9 @@ class AgentOrchestrator:
             "crm_write.update_contact": "update_crm_contact",
             "docuseal_write.create_member_agreement_submission": "send_member_agreement",
             "mail_write.create_mailbox": "create_mailbox",
+            "sso_write.create_user": "create_sso_user",
+            "outline_write.invite_user": "invite_outline_user",
+            "account_write.create_user_accounts": "create_user_accounts",
         }.get(tool_name, "unknown")
 
     @staticmethod

--- a/packages/shared/src/five08/agent/orchestrator.py
+++ b/packages/shared/src/five08/agent/orchestrator.py
@@ -505,12 +505,12 @@ class AgentOrchestrator:
             keyword in lowered for keyword in ["send", "create", "submit"]
         ):
             return self._parse_member_agreement(text)
-        if self._is_user_accounts_create_request(lowered):
-            return self._parse_user_accounts_create(text)
         if "sso" in lowered and any(
             keyword in lowered for keyword in ["create", "link", "provision"]
         ):
             return self._parse_sso_user_create(text)
+        if self._is_user_accounts_create_request(lowered):
+            return self._parse_user_accounts_create(text)
         if "outline" in lowered and any(
             keyword in lowered for keyword in ["invite", "add"]
         ):
@@ -828,7 +828,7 @@ class AgentOrchestrator:
             return {"contact_id": contact_id_match.group(1)}
 
         invite_match = re.search(
-            r"\binvite\s+(.+?)\s+to\s+outline\b",
+            r"\b(?:invite|add)\s+(.+?)\s+to\s+outline\b",
             text,
             re.IGNORECASE,
         )

--- a/packages/shared/src/five08/agent/orchestrator.py
+++ b/packages/shared/src/five08/agent/orchestrator.py
@@ -18,7 +18,7 @@ from five08.agent.models import (
 )
 from five08.agent.model_routing import AgentModelConfig
 from five08.agent.policy import PolicyEngine
-from five08.agent.tools import ToolRegistry
+from five08.agent.tools import ToolPartialSuccessError, ToolRegistry
 from five08.clients.migadu import normalize_migadu_mailbox_domain
 
 _TASK_ID_RE = re.compile(r"\bTASK-\d+\b", re.IGNORECASE)
@@ -404,6 +404,15 @@ class AgentOrchestrator:
                         tool_name=action.tool_name,
                         status="failed",
                         error=str(exc.args[0]) if exc.args else str(exc),
+                    )
+                )
+            except ToolPartialSuccessError as exc:
+                results.append(
+                    AgentExecutionResult(
+                        tool_name=action.tool_name,
+                        status="failed",
+                        result=exc.result,
+                        error=str(exc),
                     )
                 )
             except Exception as exc:

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -350,7 +350,11 @@ class ToolRegistry:
             "sso_write.create_user": ToolManifest(
                 name="sso_write.create_user",
                 risk="high",
-                required_scopes=("user:manage",),
+                required_scopes=(
+                    "user:manage",
+                    "crm:contact:read",
+                    "crm:contact:update",
+                ),
                 requires_confirmation=True,
                 tenant_scoped=True,
                 idempotent=False,
@@ -359,7 +363,7 @@ class ToolRegistry:
             "outline_write.invite_user": ToolManifest(
                 name="outline_write.invite_user",
                 risk="high",
-                required_scopes=("integration:manage",),
+                required_scopes=("integration:manage", "crm:contact:read"),
                 requires_confirmation=True,
                 tenant_scoped=True,
                 idempotent=False,
@@ -368,7 +372,13 @@ class ToolRegistry:
             "account_write.create_user_accounts": ToolManifest(
                 name="account_write.create_user_accounts",
                 risk="high",
-                required_scopes=("mailbox:create", "user:manage", "integration:manage"),
+                required_scopes=(
+                    "mailbox:create",
+                    "user:manage",
+                    "integration:manage",
+                    "crm:contact:read",
+                    "crm:contact:update",
+                ),
                 requires_confirmation=True,
                 tenant_scoped=True,
                 idempotent=False,
@@ -500,9 +510,12 @@ class ToolRegistry:
         return normalized_repository
 
     def _crm_repository(self) -> EspoContactRepository:
+        return EspoContactRepository(self._espo_client())
+
+    def _espo_client(self) -> EspoClient:
         base_url = _required_config(self.runtime_config.espo_base_url, "ESPO_BASE_URL")
         api_key = _required_config(self.runtime_config.espo_api_key, "ESPO_API_KEY")
-        return EspoContactRepository(EspoClient(base_url, api_key))
+        return EspoClient(base_url, api_key)
 
     def _search_crm_contacts(self, arguments: dict[str, Any]) -> dict[str, Any]:
         query = str(arguments.get("query") or "").strip()
@@ -591,12 +604,6 @@ class ToolRegistry:
             ),
         )
 
-    def _espo_client(self) -> EspoClient:
-        return EspoClient(
-            _required_config(self.runtime_config.espo_base_url, "ESPO_BASE_URL"),
-            _required_config(self.runtime_config.espo_api_key, "ESPO_API_KEY"),
-        )
-
     def _resolve_account_contact(
         self,
         arguments: dict[str, Any],
@@ -639,7 +646,7 @@ class ToolRegistry:
         normalized = search_term.strip()
         if not normalized:
             return []
-        if re.fullmatch(r"[A-Za-z0-9_-]{8,}", normalized):
+        if _looks_like_crm_contact_id(normalized):
             try:
                 contact = client.get_contact(normalized)
             except EspoAPIError:
@@ -805,11 +812,38 @@ class ToolRegistry:
                         raise
                     user = reconciled_matches[0]
                     recovered_existing_after_create_error = True
-                user_id = self._validate_authentik_user_for_contact(
-                    user,
-                    expected_username=username,
-                    expected_email=email,
-                )
+                try:
+                    user_id = self._validate_authentik_user_for_contact(
+                        user,
+                        expected_username=username,
+                        expected_email=email,
+                    )
+                except ValueError as exc:
+                    if created or recovered_existing_after_create_error:
+                        result = self._sso_result(
+                            contact_id=contact_id,
+                            contact_name=contact_name,
+                            username=username,
+                            email=email,
+                            user_id=_maybe_authentik_user_pk(user),
+                            created=created,
+                            crm_updated=False,
+                            recovery_email_error=None,
+                            recovered_existing_after_create_error=(
+                                recovered_existing_after_create_error
+                            ),
+                            partial_success=(
+                                "sso_created_validation_failed"
+                                if created
+                                else "sso_reconciled_validation_failed"
+                            ),
+                            error=_short_error(exc),
+                        )
+                        raise ToolPartialSuccessError(
+                            "SSO user is ready, but validation failed.",
+                            result,
+                        ) from exc
+                    raise
                 if created:
                     try:
                         client.send_recovery_email(
@@ -864,7 +898,7 @@ class ToolRegistry:
         contact_name: str,
         username: str,
         email: str,
-        user_id: int,
+        user_id: int | None,
         created: bool,
         crm_updated: bool,
         recovery_email_error: str | None,
@@ -914,13 +948,17 @@ class ToolRegistry:
         return None
 
     def _normalize_508_email(self, value: Any) -> str | None:
-        text = str(value or "").strip().lower()
         configured_domain = normalize_migadu_mailbox_domain(
             self.runtime_config.migadu_mailbox_domain
         )
-        if not text or not text.endswith(f"@{configured_domain}"):
+        try:
+            email = _normalize_full_email(value, field_label="508 email")
+        except ValueError:
             return None
-        return text
+        _local_part, _sep, domain = email.partition("@")
+        if domain != configured_domain:
+            return None
+        return email
 
     def _crm_sso_id(self, contact: dict[str, Any]) -> int | None:
         raw_value = _optional_str(contact.get(SSO_ID_FIELD))
@@ -1141,7 +1179,10 @@ class ToolRegistry:
 
     def _create_migadu_mailbox(self, arguments: dict[str, Any]) -> dict[str, Any]:
         local_part = str(arguments.get("local_part") or "").strip().lower()
-        backup_email = str(arguments.get("backup_email") or "").strip()
+        backup_email = _normalize_full_email(
+            arguments.get("backup_email"),
+            field_label="Mailbox backup_email",
+        )
         name = str(arguments.get("name") or "").strip()
         if not local_part or not backup_email or not name:
             raise ValueError("Mailbox local_part, backup_email, and name are required")
@@ -1270,6 +1311,8 @@ class ToolRegistry:
                 )
         if not local_part:
             raise ValueError("Mailbox username is missing a local part.")
+        if not _is_valid_email_local_part(local_part):
+            raise ValueError("Mailbox username contains invalid characters.")
         return f"{local_part}@{configured_domain}", local_part
 
 
@@ -1291,9 +1334,27 @@ def _normalize_full_email(value: Any, *, field_label: str) -> str:
     normalized = str(value or "").strip().lower()
     if not normalized:
         raise ValueError(f"{field_label} is required.")
-    if " " in normalized or normalized.count("@") != 1:
+    if re.search(r"\s", normalized):
+        raise ValueError(f"{field_label} must be a full email address.")
+    local_part, sep, domain = normalized.partition("@")
+    if sep != "@" or not local_part or not domain or "@" in domain:
+        raise ValueError(f"{field_label} must be a full email address.")
+    if not _is_valid_email_local_part(local_part):
+        raise ValueError(f"{field_label} must be a full email address.")
+    if not re.fullmatch(r"[A-Za-z0-9.-]+\.[A-Za-z]{2,}", domain):
         raise ValueError(f"{field_label} must be a full email address.")
     return normalized
+
+
+def _is_valid_email_local_part(value: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9._%+-]+", value))
+
+
+def _maybe_authentik_user_pk(user: dict[str, Any]) -> int | None:
+    try:
+        return _authentik_user_pk(user)
+    except ValueError:
+        return None
 
 
 def _authentik_user_pk(user: dict[str, Any]) -> int:
@@ -1321,7 +1382,25 @@ def _is_mailbox_result(value: dict[str, Any]) -> bool:
 
 
 def _is_sso_result(value: dict[str, Any]) -> bool:
-    return value.get("user_id") is not None and "crm_updated" in value
+    return (
+        _optional_str(value.get("username")) is not None
+        and _optional_str(value.get("email")) is not None
+        and "crm_updated" in value
+    )
+
+
+def _looks_like_crm_contact_id(value: str) -> bool:
+    if re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        value,
+        re.IGNORECASE,
+    ):
+        return True
+    if value.casefold().startswith("contact-"):
+        return True
+    return bool(
+        re.fullmatch(r"[A-Za-z0-9_-]{8,}", value) and any(ch.isdigit() for ch in value)
+    )
 
 
 def _optional_date(value: Any) -> str | None:

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -744,6 +744,7 @@ class ToolRegistry:
         user_id: int
         created = False
         crm_updated = False
+        recovered_existing_after_create_error = False
         recovery_email_error: str | None = None
         linked_sso_id = self._crm_sso_id(contact)
 
@@ -782,24 +783,41 @@ class ToolRegistry:
                         or "default-recovery-email"
                     ),
                 )
-                user = client.create_user(
-                    username=username,
-                    name=contact_name,
-                    email=email,
-                )
-                created = True
+                try:
+                    user = client.create_user(
+                        username=username,
+                        name=contact_name,
+                        email=email,
+                    )
+                    created = True
+                except AuthentikAPIError as exc:
+                    reconciled_matches = client.find_users_by_username_or_email(
+                        username=username,
+                        email=email,
+                    )
+                    if len(reconciled_matches) > 1:
+                        raise ValueError(
+                            "Multiple Authentik users matched this CRM contact after "
+                            "the create attempt. Resolve the duplicate manually "
+                            "before linking."
+                        ) from exc
+                    if not reconciled_matches:
+                        raise
+                    user = reconciled_matches[0]
+                    recovered_existing_after_create_error = True
                 user_id = self._validate_authentik_user_for_contact(
                     user,
                     expected_username=username,
                     expected_email=email,
                 )
-                try:
-                    client.send_recovery_email(
-                        user_id=user_id,
-                        email_stage=recovery_email_stage_id,
-                    )
-                except AuthentikAPIError as exc:
-                    recovery_email_error = _short_error(exc)
+                if created:
+                    try:
+                        client.send_recovery_email(
+                            user_id=user_id,
+                            email_stage=recovery_email_stage_id,
+                        )
+                    except AuthentikAPIError as exc:
+                        recovery_email_error = _short_error(exc)
 
             try:
                 self._espo_client().update_contact(
@@ -815,6 +833,9 @@ class ToolRegistry:
                     created=created,
                     crm_updated=False,
                     recovery_email_error=recovery_email_error,
+                    recovered_existing_after_create_error=(
+                        recovered_existing_after_create_error
+                    ),
                     partial_success="sso_user_ready_crm_update_failed",
                     error=_short_error(exc),
                 )
@@ -833,6 +854,7 @@ class ToolRegistry:
             created=created,
             crm_updated=crm_updated,
             recovery_email_error=recovery_email_error,
+            recovered_existing_after_create_error=recovered_existing_after_create_error,
         )
 
     @staticmethod
@@ -846,6 +868,7 @@ class ToolRegistry:
         created: bool,
         crm_updated: bool,
         recovery_email_error: str | None,
+        recovered_existing_after_create_error: bool = False,
         partial_success: str | None = None,
         error: str | None = None,
     ) -> dict[str, Any]:
@@ -857,6 +880,7 @@ class ToolRegistry:
             "user_id": user_id,
             "created": created,
             "crm_updated": crm_updated,
+            "recovered_existing_after_create_error": recovered_existing_after_create_error,
             "recovery_email_error": recovery_email_error,
         }
         if partial_success is not None:
@@ -1166,10 +1190,19 @@ class ToolRegistry:
         )
         created_address = str(mailbox.get("address") or target_email).strip().lower()
         if created_address != target_email:
-            raise ValueError(
+            message = (
                 "Migadu created a mailbox but returned a different address "
                 f"{created_address} than requested {target_email}."
             )
+            result = self._mailbox_result(
+                email=created_address,
+                created=True,
+                crm_updated=False,
+                backup_email=backup_email,
+                partial_success="mailbox_created_address_mismatch",
+                error=message,
+            )
+            raise ToolPartialSuccessError(message, result)
 
         try:
             self._espo_client().update_contact(contact_id, {"c508Email": target_email})

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -3,21 +3,26 @@
 from __future__ import annotations
 
 import itertools
+import re
 import threading
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from typing import Any
 
 from five08.agent.models import RiskLevel
+from five08.clients.authentik import AuthentikAPIError, AuthentikClient
 from five08.clients.docuseal import create_member_agreement_submission
-from five08.clients.espo import EspoClient
+from five08.clients.espo import EspoAPIError, EspoClient
 from five08.clients.github import GitHubClient
 from five08.clients.migadu import (
     MigaduClient,
     MigaduMailboxCreateRequest,
     normalize_migadu_mailbox_domain,
 )
+from five08.clients.outline import OutlineClient
 from five08.crm_contacts import EspoContactRepository
+
+SSO_ID_FIELD = "cSsoID"
 
 
 @dataclass(frozen=True)
@@ -48,6 +53,14 @@ class ToolRuntimeConfig:
     migadu_api_user: str | None = None
     migadu_api_key: str | None = None
     migadu_mailbox_domain: str = "508.dev"
+    authentik_api_base_url: str | None = None
+    authentik_api_token: str | None = None
+    authentik_api_timeout_seconds: float = 20.0
+    authentik_recovery_email_stage_id: str | None = None
+    authentik_recovery_email_stage_name: str = "default-recovery-email"
+    outline_base_url: str = "https://app.getoutline.com"
+    outline_api_key: str | None = None
+    outline_api_timeout_seconds: float = 20.0
 
     @classmethod
     def from_settings(cls, settings: Any) -> "ToolRuntimeConfig":
@@ -71,6 +84,34 @@ class ToolRuntimeConfig:
                 settings,
                 "migadu_mailbox_domain",
                 "508.dev",
+            ),
+            authentik_api_base_url=getattr(settings, "authentik_api_base_url", None),
+            authentik_api_token=getattr(settings, "authentik_api_token", None),
+            authentik_api_timeout_seconds=getattr(
+                settings,
+                "authentik_api_timeout_seconds",
+                20.0,
+            ),
+            authentik_recovery_email_stage_id=getattr(
+                settings,
+                "authentik_recovery_email_stage_id",
+                None,
+            ),
+            authentik_recovery_email_stage_name=getattr(
+                settings,
+                "authentik_recovery_email_stage_name",
+                "default-recovery-email",
+            ),
+            outline_base_url=getattr(
+                settings,
+                "outline_base_url",
+                "https://app.getoutline.com",
+            ),
+            outline_api_key=getattr(settings, "outline_api_key", None),
+            outline_api_timeout_seconds=getattr(
+                settings,
+                "outline_api_timeout_seconds",
+                20.0,
             ),
         )
 
@@ -298,6 +339,33 @@ class ToolRegistry:
                 idempotent=False,
                 write=True,
             ),
+            "sso_write.create_user": ToolManifest(
+                name="sso_write.create_user",
+                risk="high",
+                required_scopes=("user:manage",),
+                requires_confirmation=True,
+                tenant_scoped=True,
+                idempotent=False,
+                write=True,
+            ),
+            "outline_write.invite_user": ToolManifest(
+                name="outline_write.invite_user",
+                risk="high",
+                required_scopes=("integration:manage",),
+                requires_confirmation=True,
+                tenant_scoped=True,
+                idempotent=False,
+                write=True,
+            ),
+            "account_write.create_user_accounts": ToolManifest(
+                name="account_write.create_user_accounts",
+                risk="high",
+                required_scopes=("mailbox:create", "user:manage", "integration:manage"),
+                requires_confirmation=True,
+                tenant_scoped=True,
+                idempotent=False,
+                write=True,
+            ),
         }
 
     def get(self, tool_name: str) -> ToolManifest | None:
@@ -379,6 +447,12 @@ class ToolRegistry:
             return self._create_docuseal_member_agreement(arguments)
         if tool_name == "mail_write.create_mailbox":
             return self._create_migadu_mailbox(arguments)
+        if tool_name == "sso_write.create_user":
+            return self._create_sso_user(arguments)
+        if tool_name == "outline_write.invite_user":
+            return self._invite_outline_user(arguments)
+        if tool_name == "account_write.create_user_accounts":
+            return self._create_user_accounts(arguments)
         raise KeyError(f"Unknown tool {tool_name}")
 
     def _github_client(self) -> GitHubClient:
@@ -509,12 +583,503 @@ class ToolRegistry:
             )
         )
 
+    def _authentik_client(self) -> AuthentikClient:
+        return AuthentikClient(
+            base_url=_required_config(
+                self.runtime_config.authentik_api_base_url,
+                "AUTHENTIK_API_BASE_URL",
+            ),
+            api_token=_required_config(
+                self.runtime_config.authentik_api_token,
+                "AUTHENTIK_API_TOKEN",
+            ),
+            timeout_seconds=max(
+                1.0,
+                float(self.runtime_config.authentik_api_timeout_seconds),
+            ),
+        )
+
+    def _outline_client(self) -> OutlineClient:
+        return OutlineClient(
+            api_key=_required_config(
+                self.runtime_config.outline_api_key,
+                "OUTLINE_API_KEY",
+            ),
+            base_url=self.runtime_config.outline_base_url
+            or "https://app.getoutline.com",
+            timeout_seconds=max(
+                1.0, float(self.runtime_config.outline_api_timeout_seconds)
+            ),
+        )
+
+    def _espo_client(self) -> EspoClient:
+        return EspoClient(
+            _required_config(self.runtime_config.espo_base_url, "ESPO_BASE_URL"),
+            _required_config(self.runtime_config.espo_api_key, "ESPO_API_KEY"),
+        )
+
+    def _resolve_account_contact(
+        self,
+        arguments: dict[str, Any],
+        *,
+        select: str = f"id,name,emailAddress,c508Email,{SSO_ID_FIELD}",
+    ) -> dict[str, Any]:
+        client = self._espo_client()
+        contact_id = _optional_str(arguments.get("contact_id"))
+        if contact_id is not None:
+            return client.get_contact(contact_id)
+
+        query = _optional_str(arguments.get("contact_query")) or _optional_str(
+            arguments.get("search_term")
+        )
+        if query is None:
+            raise ValueError("CRM contact_id or contact_query is required")
+
+        contacts = self._search_contacts_for_lookup(
+            client,
+            query,
+            max_size=2,
+            select=select,
+        )
+        if not contacts:
+            raise ValueError(f"No CRM contact found for: {query}")
+        if len(contacts) > 1:
+            raise ValueError(
+                "Multiple CRM contacts matched. Use a CRM contact ID to disambiguate."
+            )
+        return contacts[0]
+
+    def _search_contacts_for_lookup(
+        self,
+        client: EspoClient,
+        search_term: str,
+        *,
+        max_size: int,
+        select: str,
+    ) -> list[dict[str, Any]]:
+        normalized = search_term.strip()
+        if not normalized:
+            return []
+        if re.fullmatch(r"[A-Za-z0-9_-]{8,}", normalized):
+            try:
+                contact = client.get_contact(normalized)
+            except EspoAPIError:
+                contact = {}
+            if contact.get("id"):
+                return [contact]
+
+        filters = self._contact_search_filters(normalized)
+        if not filters:
+            return []
+        response = client.list_contacts(
+            {
+                "where": [{"type": "or", "value": filters}],
+                "maxSize": max_size,
+                "select": select,
+            }
+        )
+        contacts = response.get("list")
+        if not isinstance(contacts, list):
+            return []
+        deduped: list[dict[str, Any]] = []
+        seen_ids: set[str] = set()
+        for contact in contacts:
+            if not isinstance(contact, dict):
+                continue
+            contact_id = str(contact.get("id") or "")
+            if contact_id in seen_ids:
+                continue
+            seen_ids.add(contact_id)
+            deduped.append(contact)
+        return deduped
+
+    def _contact_search_filters(self, search_term: str) -> list[dict[str, Any]]:
+        normalized = search_term.strip()
+        if not normalized:
+            return []
+        if "@" in normalized:
+            local_part, _, domain = normalized.partition("@")
+            configured_domain = normalize_migadu_mailbox_domain(
+                self.runtime_config.migadu_mailbox_domain
+            )
+            domain_aliases = {"", configured_domain}
+            if "." in configured_domain:
+                domain_aliases.add(configured_domain.split(".", 1)[0])
+            email = (
+                f"{local_part}@{configured_domain}"
+                if local_part and domain.casefold() in domain_aliases
+                else normalized
+            )
+            return [
+                {"type": "equals", "attribute": "emailAddress", "value": email},
+                {"type": "equals", "attribute": "c508Email", "value": email},
+            ]
+
+        filters: list[dict[str, Any]] = [
+            {"type": "contains", "attribute": "name", "value": normalized}
+        ]
+        name_parts = [part for part in re.split(r"\s+", normalized) if part]
+        if len(name_parts) >= 2:
+            filters.append(
+                {
+                    "type": "and",
+                    "value": [
+                        {
+                            "type": "contains",
+                            "attribute": "firstName",
+                            "value": name_parts[0],
+                        },
+                        {
+                            "type": "contains",
+                            "attribute": "lastName",
+                            "value": name_parts[-1],
+                        },
+                    ],
+                }
+            )
+        if " " not in normalized:
+            filters.append(
+                {
+                    "type": "equals",
+                    "attribute": "c508Email",
+                    "value": (
+                        f"{normalized}@"
+                        f"{normalize_migadu_mailbox_domain(self.runtime_config.migadu_mailbox_domain)}"
+                    ),
+                }
+            )
+        return filters
+
+    def _create_sso_user(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        contact = self._resolve_account_contact(arguments)
+        return self._create_sso_user_for_contact(contact)
+
+    def _create_sso_user_for_contact(self, contact: dict[str, Any]) -> dict[str, Any]:
+        contact_id = _required_text(
+            contact.get("id"), "Selected contact is missing a CRM ID"
+        )
+        contact_name = _optional_str(contact.get("name")) or "Unknown"
+        username, email = self._resolve_sso_identity_for_contact(contact)
+        client = self._authentik_client()
+
+        user_id: int
+        created = False
+        crm_updated = False
+        recovery_email_error: str | None = None
+        linked_sso_id = self._crm_sso_id(contact)
+
+        if linked_sso_id is not None:
+            user = client.get_user(linked_sso_id)
+            user_id = self._validate_authentik_user_for_contact(
+                user,
+                expected_username=username,
+                expected_email=email,
+            )
+        else:
+            matches = client.find_users_by_username_or_email(
+                username=username,
+                email=email,
+            )
+            if len(matches) > 1:
+                raise ValueError(
+                    "Multiple Authentik users matched this CRM contact. "
+                    "Resolve the duplicate manually before linking."
+                )
+            if matches:
+                user_id = self._validate_authentik_user_for_contact(
+                    matches[0],
+                    expected_username=username,
+                    expected_email=email,
+                )
+            else:
+                recovery_email_stage_id = client.resolve_email_stage_id(
+                    stage_id=_optional_str(
+                        self.runtime_config.authentik_recovery_email_stage_id
+                    ),
+                    stage_name=(
+                        _optional_str(
+                            self.runtime_config.authentik_recovery_email_stage_name
+                        )
+                        or "default-recovery-email"
+                    ),
+                )
+                user = client.create_user(
+                    username=username,
+                    name=contact_name,
+                    email=email,
+                )
+                created = True
+                user_id = self._validate_authentik_user_for_contact(
+                    user,
+                    expected_username=username,
+                    expected_email=email,
+                )
+                try:
+                    client.send_recovery_email(
+                        user_id=user_id,
+                        email_stage=recovery_email_stage_id,
+                    )
+                except AuthentikAPIError as exc:
+                    recovery_email_error = _short_error(exc)
+
+            self._espo_client().update_contact(contact_id, {SSO_ID_FIELD: str(user_id)})
+            crm_updated = True
+
+        return {
+            "contact_id": contact_id,
+            "contact_name": contact_name,
+            "username": username,
+            "email": email,
+            "user_id": user_id,
+            "created": created,
+            "crm_updated": crm_updated,
+            "recovery_email_error": recovery_email_error,
+        }
+
+    def _resolve_sso_identity_for_contact(
+        self,
+        contact: dict[str, Any],
+    ) -> tuple[str, str]:
+        email = self._contact_508_email(contact)
+        if email is None:
+            configured_domain = normalize_migadu_mailbox_domain(
+                self.runtime_config.migadu_mailbox_domain
+            )
+            raise ValueError(
+                f"Selected contact does not have a @{configured_domain} email in CRM."
+            )
+        username = email.split("@", 1)[0].strip().lower()
+        if not username:
+            raise ValueError("Unable to derive a 508 username from the CRM email.")
+        return username, email
+
+    def _contact_508_email(self, contact: dict[str, Any]) -> str | None:
+        for field_name in ("c508Email", "emailAddress"):
+            email = self._normalize_508_email(contact.get(field_name))
+            if email is not None:
+                return email
+        return None
+
+    def _normalize_508_email(self, value: Any) -> str | None:
+        text = str(value or "").strip().lower()
+        configured_domain = normalize_migadu_mailbox_domain(
+            self.runtime_config.migadu_mailbox_domain
+        )
+        if not text or not text.endswith(f"@{configured_domain}"):
+            return None
+        return text
+
+    def _crm_sso_id(self, contact: dict[str, Any]) -> int | None:
+        raw_value = _optional_str(contact.get(SSO_ID_FIELD))
+        if raw_value is None:
+            return None
+        if raw_value.isdigit():
+            return int(raw_value)
+        raise ValueError(f"{SSO_ID_FIELD} must be a numeric Authentik user id.")
+
+    def _validate_authentik_user_for_contact(
+        self,
+        user: dict[str, Any],
+        *,
+        expected_username: str,
+        expected_email: str,
+    ) -> int:
+        if bool(user.get("is_superuser")):
+            raise ValueError("Refusing to use an Authentik superuser for this command.")
+        actual_username = _optional_str(user.get("username"))
+        if actual_username != expected_username:
+            raise ValueError(
+                "Matched Authentik username does not match the CRM-derived 508 username."
+            )
+        actual_email = self._normalize_508_email(user.get("email"))
+        if actual_email != expected_email:
+            configured_domain = normalize_migadu_mailbox_domain(
+                self.runtime_config.migadu_mailbox_domain
+            )
+            raise ValueError(
+                "Matched Authentik email does not match the CRM-derived "
+                f"@{configured_domain} email."
+            )
+        return _authentik_user_pk(user)
+
+    def _invite_outline_user(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        direct_email = _optional_str(arguments.get("email"))
+        if direct_email is not None:
+            email = _normalize_full_email(
+                direct_email, field_label="Outline invite email"
+            )
+            name = _optional_str(arguments.get("name")) or email.partition("@")[0]
+            self._outline_client().invite_user(email=email, name=name, role="member")
+            return {"email": email, "name": name, "direct_email": True}
+
+        contact = self._resolve_account_contact(
+            arguments,
+            select="id,name,emailAddress,c508Email",
+        )
+        return self._invite_outline_user_for_contact(contact)
+
+    def _invite_outline_user_for_contact(
+        self, contact: dict[str, Any]
+    ) -> dict[str, Any]:
+        contact_id = _required_text(
+            contact.get("id"), "Selected contact is missing a CRM ID"
+        )
+        contact_name = _optional_str(contact.get("name")) or "Unknown"
+        email = self._contact_508_email(contact) or _optional_str(
+            contact.get("emailAddress")
+        )
+        normalized_email = _normalize_full_email(
+            email,
+            field_label="Outline invite email",
+        )
+        self._outline_client().invite_user(
+            email=normalized_email,
+            name=contact_name,
+            role="member",
+        )
+        return {
+            "contact_id": contact_id,
+            "contact_name": contact_name,
+            "email": normalized_email,
+            "direct_email": False,
+        }
+
+    def _create_user_accounts(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        contact = self._resolve_account_contact(arguments)
+        mailbox_username = _required_text(
+            arguments.get("mailbox_username"),
+            "mailbox_username is required",
+        )
+        mailbox = self._create_migadu_mailbox_for_contact(
+            contact=contact,
+            mailbox_username=mailbox_username,
+        )
+        sso = self._create_sso_user_for_contact(contact)
+        outline = self._invite_outline_user_for_contact(contact)
+        return {
+            "contact_id": _required_text(
+                contact.get("id"),
+                "Selected contact is missing a CRM ID",
+            ),
+            "contact_name": _optional_str(contact.get("name")) or "Unknown",
+            "email": mailbox["email"],
+            "mailbox": mailbox,
+            "sso": sso,
+            "outline": outline,
+        }
+
+    def _create_migadu_mailbox_for_contact(
+        self,
+        *,
+        contact: dict[str, Any],
+        mailbox_username: str,
+    ) -> dict[str, Any]:
+        contact_id = _required_text(
+            contact.get("id"), "Selected contact is missing a CRM ID"
+        )
+        target_email, local_part = self._normalize_mailbox_username(mailbox_username)
+        existing_email = self._normalize_508_email(contact.get("c508Email"))
+        if existing_email is not None:
+            if existing_email != target_email:
+                raise ValueError(
+                    f"CRM contact already has a different 508 email: {existing_email}."
+                )
+            return {
+                "email": existing_email,
+                "created": False,
+                "crm_updated": False,
+                "backup_email": "",
+            }
+
+        backup_email = _normalize_full_email(
+            contact.get("emailAddress"),
+            field_label="CRM primary email",
+        )
+        contact_name = _optional_str(contact.get("name")) or local_part
+        mailbox = self._create_migadu_mailbox(
+            {
+                "local_part": local_part,
+                "backup_email": backup_email,
+                "name": contact_name,
+            }
+        )
+        created_address = str(mailbox.get("address") or target_email).strip().lower()
+        if created_address != target_email:
+            raise ValueError(
+                "Migadu created a mailbox but returned a different address "
+                f"{created_address} than requested {target_email}."
+            )
+
+        self._espo_client().update_contact(contact_id, {"c508Email": target_email})
+        contact["c508Email"] = target_email
+        return {
+            "email": target_email,
+            "created": True,
+            "crm_updated": True,
+            "backup_email": backup_email,
+        }
+
+    def _normalize_mailbox_username(self, mailbox_username: str) -> tuple[str, str]:
+        normalized = mailbox_username.strip().lower()
+        if not normalized:
+            raise ValueError("Please provide a mailbox username like jane.")
+        if " " in normalized:
+            raise ValueError("Mailbox username cannot include spaces.")
+        configured_domain = normalize_migadu_mailbox_domain(
+            self.runtime_config.migadu_mailbox_domain
+        )
+        if "@" not in normalized:
+            local_part = normalized
+        else:
+            if normalized.count("@") != 1:
+                raise ValueError("Mailbox username must be in the format name@domain.")
+            local_part, username_domain = normalized.split("@", 1)
+            if username_domain != configured_domain:
+                raise ValueError(
+                    f"Mailbox username must be omitted or use the @{configured_domain} domain."
+                )
+        if not local_part:
+            raise ValueError("Mailbox username is missing a local part.")
+        return f"{local_part}@{configured_domain}", local_part
+
 
 def _optional_str(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     stripped = value.strip()
     return stripped or None
+
+
+def _required_text(value: Any, message: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _normalize_full_email(value: Any, *, field_label: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not normalized:
+        raise ValueError(f"{field_label} is required.")
+    if " " in normalized or normalized.count("@") != 1:
+        raise ValueError(f"{field_label} must be a full email address.")
+    return normalized
+
+
+def _authentik_user_pk(user: dict[str, Any]) -> int:
+    raw_value = user.get("pk")
+    if isinstance(raw_value, int) and not isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, str) and raw_value.strip().isdigit():
+        return int(raw_value.strip())
+    raise ValueError("Authentik response did not include a numeric user id.")
+
+
+def _short_error(exc: Exception) -> str:
+    text = " ".join(str(exc).split()).strip()
+    if len(text) > 200:
+        return text[:200].rstrip() + "..."
+    return text
 
 
 def _optional_date(value: Any) -> str | None:

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -684,7 +684,8 @@ class ToolRegistry:
         if not normalized:
             return []
         if "@" in normalized:
-            local_part, _, domain = normalized.partition("@")
+            email_query = normalized.lower()
+            local_part, _, domain = email_query.partition("@")
             configured_domain = normalize_migadu_mailbox_domain(
                 self.runtime_config.migadu_mailbox_domain
             )
@@ -694,7 +695,7 @@ class ToolRegistry:
             email = (
                 f"{local_part}@{configured_domain}"
                 if local_part and domain.casefold() in domain_aliases
-                else normalized
+                else email_query
             )
             return [
                 {"type": "equals", "attribute": "emailAddress", "value": email},
@@ -779,17 +780,10 @@ class ToolRegistry:
                     expected_email=email,
                 )
             else:
-                recovery_email_stage_id = client.resolve_email_stage_id(
-                    stage_id=_optional_str(
-                        self.runtime_config.authentik_recovery_email_stage_id
-                    ),
-                    stage_name=(
-                        _optional_str(
-                            self.runtime_config.authentik_recovery_email_stage_name
-                        )
-                        or "default-recovery-email"
-                    ),
-                )
+                (
+                    recovery_email_stage_id,
+                    recovery_email_error,
+                ) = self._resolve_recovery_email_stage_id(client)
                 try:
                     user = client.create_user(
                         username=username,
@@ -844,7 +838,7 @@ class ToolRegistry:
                             result,
                         ) from exc
                     raise
-                if created:
+                if created and recovery_email_stage_id is not None:
                     try:
                         client.send_recovery_email(
                             user_id=user_id,
@@ -993,6 +987,25 @@ class ToolRegistry:
             )
         return _authentik_user_pk(user)
 
+    def _resolve_recovery_email_stage_id(
+        self, client: AuthentikClient
+    ) -> tuple[str | None, str | None]:
+        try:
+            stage_id = client.resolve_email_stage_id(
+                stage_id=_optional_str(
+                    self.runtime_config.authentik_recovery_email_stage_id
+                ),
+                stage_name=(
+                    _optional_str(
+                        self.runtime_config.authentik_recovery_email_stage_name
+                    )
+                    or "default-recovery-email"
+                ),
+            )
+        except AuthentikAPIError as exc:
+            return None, _short_error(exc)
+        return stage_id, None
+
     def _invite_outline_user(self, arguments: dict[str, Any]) -> dict[str, Any]:
         direct_email = _optional_str(arguments.get("email"))
         if direct_email is not None:
@@ -1111,8 +1124,10 @@ class ToolRegistry:
         contact: dict[str, Any],
         mailbox_username: str,
     ) -> None:
-        self._authentik_client()
+        authentik_client = self._authentik_client()
         self._outline_client()
+        if self._crm_sso_id(contact) is None:
+            self._resolve_recovery_email_stage_id(authentik_client)
         target_email, _local_part = self._normalize_mailbox_username(mailbox_username)
         existing_email = self._normalize_508_email(contact.get("c508Email"))
         if existing_email is None:

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -688,7 +688,7 @@ class ToolRegistry:
             configured_domain = normalize_migadu_mailbox_domain(
                 self.runtime_config.migadu_mailbox_domain
             )
-            domain_aliases = {"", configured_domain}
+            domain_aliases = {configured_domain}
             if "." in configured_domain:
                 domain_aliases.add(configured_domain.split(".", 1)[0])
             email = (

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -38,6 +38,14 @@ class ToolManifest:
     write: bool = False
 
 
+class ToolPartialSuccessError(RuntimeError):
+    """Raised when an irreversible tool step succeeded before a later failure."""
+
+    def __init__(self, message: str, result: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.result = result
+
+
 @dataclass(frozen=True)
 class ToolRuntimeConfig:
     """Runtime credentials and defaults for deterministic external tools."""
@@ -554,35 +562,6 @@ class ToolRegistry:
             send_email=bool(arguments.get("send_email", True)),
         )
 
-    def _create_migadu_mailbox(self, arguments: dict[str, Any]) -> dict[str, Any]:
-        local_part = str(arguments.get("local_part") or "").strip().lower()
-        backup_email = str(arguments.get("backup_email") or "").strip()
-        name = str(arguments.get("name") or "").strip()
-        if not local_part or not backup_email or not name:
-            raise ValueError("Mailbox local_part, backup_email, and name are required")
-        username = _required_config(
-            self.runtime_config.migadu_api_user,
-            "MIGADU_API_USER",
-        )
-        api_key = _required_config(
-            self.runtime_config.migadu_api_key,
-            "MIGADU_API_KEY",
-        )
-        client = MigaduClient(
-            username=username,
-            api_key=api_key,
-            domain=normalize_migadu_mailbox_domain(
-                self.runtime_config.migadu_mailbox_domain
-            ),
-        )
-        return client.create_mailbox(
-            MigaduMailboxCreateRequest(
-                local_part=local_part,
-                backup_email=backup_email,
-                name=name,
-            )
-        )
-
     def _authentik_client(self) -> AuthentikClient:
         return AuthentikClient(
             base_url=_required_config(
@@ -822,10 +801,55 @@ class ToolRegistry:
                 except AuthentikAPIError as exc:
                     recovery_email_error = _short_error(exc)
 
-            self._espo_client().update_contact(contact_id, {SSO_ID_FIELD: str(user_id)})
+            try:
+                self._espo_client().update_contact(
+                    contact_id, {SSO_ID_FIELD: str(user_id)}
+                )
+            except EspoAPIError as exc:
+                result = self._sso_result(
+                    contact_id=contact_id,
+                    contact_name=contact_name,
+                    username=username,
+                    email=email,
+                    user_id=user_id,
+                    created=created,
+                    crm_updated=False,
+                    recovery_email_error=recovery_email_error,
+                    partial_success="sso_user_ready_crm_update_failed",
+                    error=_short_error(exc),
+                )
+                raise ToolPartialSuccessError(
+                    "SSO user is ready, but updating CRM cSsoID failed.",
+                    result,
+                ) from exc
             crm_updated = True
 
-        return {
+        return self._sso_result(
+            contact_id=contact_id,
+            contact_name=contact_name,
+            username=username,
+            email=email,
+            user_id=user_id,
+            created=created,
+            crm_updated=crm_updated,
+            recovery_email_error=recovery_email_error,
+        )
+
+    @staticmethod
+    def _sso_result(
+        *,
+        contact_id: str,
+        contact_name: str,
+        username: str,
+        email: str,
+        user_id: int,
+        created: bool,
+        crm_updated: bool,
+        recovery_email_error: str | None,
+        partial_success: str | None = None,
+        error: str | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
             "contact_id": contact_id,
             "contact_name": contact_name,
             "username": username,
@@ -835,6 +859,11 @@ class ToolRegistry:
             "crm_updated": crm_updated,
             "recovery_email_error": recovery_email_error,
         }
+        if partial_success is not None:
+            result["partial_success"] = partial_success
+        if error is not None:
+            result["error"] = error
+        return result
 
     def _resolve_sso_identity_for_contact(
         self,
@@ -950,23 +979,155 @@ class ToolRegistry:
             arguments.get("mailbox_username"),
             "mailbox_username is required",
         )
-        mailbox = self._create_migadu_mailbox_for_contact(
-            contact=contact,
-            mailbox_username=mailbox_username,
+        self._preflight_user_accounts(
+            contact=contact, mailbox_username=mailbox_username
         )
-        sso = self._create_sso_user_for_contact(contact)
-        outline = self._invite_outline_user_for_contact(contact)
-        return {
-            "contact_id": _required_text(
-                contact.get("id"),
-                "Selected contact is missing a CRM ID",
-            ),
-            "contact_name": _optional_str(contact.get("name")) or "Unknown",
-            "email": mailbox["email"],
+        contact_id = _required_text(
+            contact.get("id"),
+            "Selected contact is missing a CRM ID",
+        )
+        contact_name = _optional_str(contact.get("name")) or "Unknown"
+        mailbox: dict[str, Any] | None = None
+        sso: dict[str, Any] | None = None
+        outline: dict[str, Any] | None = None
+
+        try:
+            mailbox = self._create_migadu_mailbox_for_contact(
+                contact=contact,
+                mailbox_username=mailbox_username,
+            )
+            sso = self._create_sso_user_for_contact(contact)
+            outline = self._invite_outline_user_for_contact(contact)
+        except ToolPartialSuccessError as exc:
+            partial_result = exc.result
+            if mailbox is None and _is_mailbox_result(partial_result):
+                mailbox = partial_result
+            elif sso is None and _is_sso_result(partial_result):
+                sso = partial_result
+            raise ToolPartialSuccessError(
+                "User account provisioning partially completed.",
+                self._user_accounts_result(
+                    contact_id=contact_id,
+                    contact_name=contact_name,
+                    email=self._user_accounts_email(mailbox=mailbox, contact=contact),
+                    mailbox=mailbox,
+                    sso=sso,
+                    outline=outline,
+                    partial_success="user_accounts_partial",
+                    error=str(exc),
+                ),
+            ) from exc
+        except Exception as exc:
+            if mailbox is None and sso is None and outline is None:
+                raise
+            raise ToolPartialSuccessError(
+                "User account provisioning partially completed.",
+                self._user_accounts_result(
+                    contact_id=contact_id,
+                    contact_name=contact_name,
+                    email=self._user_accounts_email(mailbox=mailbox, contact=contact),
+                    mailbox=mailbox,
+                    sso=sso,
+                    outline=outline,
+                    partial_success="user_accounts_partial",
+                    error=_short_error(exc),
+                ),
+            ) from exc
+
+        return self._user_accounts_result(
+            contact_id=contact_id,
+            contact_name=contact_name,
+            email=self._user_accounts_email(mailbox=mailbox, contact=contact),
+            mailbox=mailbox,
+            sso=sso,
+            outline=outline,
+        )
+
+    def _preflight_user_accounts(
+        self,
+        *,
+        contact: dict[str, Any],
+        mailbox_username: str,
+    ) -> None:
+        self._authentik_client()
+        self._outline_client()
+        target_email, _local_part = self._normalize_mailbox_username(mailbox_username)
+        existing_email = self._normalize_508_email(contact.get("c508Email"))
+        if existing_email is None:
+            self._migadu_client()
+        elif existing_email != target_email:
+            raise ValueError(
+                f"CRM contact already has a different 508 email: {existing_email}."
+            )
+
+    @staticmethod
+    def _user_accounts_result(
+        *,
+        contact_id: str,
+        contact_name: str,
+        email: str | None,
+        mailbox: dict[str, Any] | None,
+        sso: dict[str, Any] | None,
+        outline: dict[str, Any] | None,
+        partial_success: str | None = None,
+        error: str | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "contact_id": contact_id,
+            "contact_name": contact_name,
+            "email": email,
             "mailbox": mailbox,
             "sso": sso,
             "outline": outline,
         }
+        if partial_success is not None:
+            result["partial_success"] = partial_success
+        if error is not None:
+            result["error"] = error
+        return result
+
+    def _user_accounts_email(
+        self,
+        *,
+        mailbox: dict[str, Any] | None,
+        contact: dict[str, Any],
+    ) -> str | None:
+        if mailbox is not None:
+            email = _optional_str(mailbox.get("email"))
+            if email is not None:
+                return email
+        return self._contact_508_email(contact)
+
+    def _migadu_client(self) -> MigaduClient:
+        username = _required_config(
+            self.runtime_config.migadu_api_user,
+            "MIGADU_API_USER",
+        )
+        api_key = _required_config(
+            self.runtime_config.migadu_api_key,
+            "MIGADU_API_KEY",
+        )
+        return MigaduClient(
+            username=username,
+            api_key=api_key,
+            domain=normalize_migadu_mailbox_domain(
+                self.runtime_config.migadu_mailbox_domain
+            ),
+        )
+
+    def _create_migadu_mailbox(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        local_part = str(arguments.get("local_part") or "").strip().lower()
+        backup_email = str(arguments.get("backup_email") or "").strip()
+        name = str(arguments.get("name") or "").strip()
+        if not local_part or not backup_email or not name:
+            raise ValueError("Mailbox local_part, backup_email, and name are required")
+        return self._migadu_client().create_mailbox(
+            MigaduMailboxCreateRequest(
+                local_part=local_part,
+                backup_email=backup_email,
+                name=name,
+            )
+        )
 
     def _create_migadu_mailbox_for_contact(
         self,
@@ -984,12 +1145,12 @@ class ToolRegistry:
                 raise ValueError(
                     f"CRM contact already has a different 508 email: {existing_email}."
                 )
-            return {
-                "email": existing_email,
-                "created": False,
-                "crm_updated": False,
-                "backup_email": "",
-            }
+            return self._mailbox_result(
+                email=existing_email,
+                created=False,
+                crm_updated=False,
+                backup_email="",
+            )
 
         backup_email = _normalize_full_email(
             contact.get("emailAddress"),
@@ -1010,14 +1171,50 @@ class ToolRegistry:
                 f"{created_address} than requested {target_email}."
             )
 
-        self._espo_client().update_contact(contact_id, {"c508Email": target_email})
+        try:
+            self._espo_client().update_contact(contact_id, {"c508Email": target_email})
+        except EspoAPIError as exc:
+            result = self._mailbox_result(
+                email=target_email,
+                created=True,
+                crm_updated=False,
+                backup_email=backup_email,
+                partial_success="mailbox_created_crm_update_failed",
+                error=_short_error(exc),
+            )
+            raise ToolPartialSuccessError(
+                "Mailbox was created, but updating CRM c508Email failed.",
+                result,
+            ) from exc
         contact["c508Email"] = target_email
-        return {
-            "email": target_email,
-            "created": True,
-            "crm_updated": True,
+        return self._mailbox_result(
+            email=target_email,
+            created=True,
+            crm_updated=True,
+            backup_email=backup_email,
+        )
+
+    @staticmethod
+    def _mailbox_result(
+        *,
+        email: str,
+        created: bool,
+        crm_updated: bool,
+        backup_email: str,
+        partial_success: str | None = None,
+        error: str | None = None,
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "email": email,
+            "created": created,
+            "crm_updated": crm_updated,
             "backup_email": backup_email,
         }
+        if partial_success is not None:
+            result["partial_success"] = partial_success
+        if error is not None:
+            result["error"] = error
+        return result
 
     def _normalize_mailbox_username(self, mailbox_username: str) -> tuple[str, str]:
         normalized = mailbox_username.strip().lower()
@@ -1080,6 +1277,18 @@ def _short_error(exc: Exception) -> str:
     if len(text) > 200:
         return text[:200].rstrip() + "..."
     return text
+
+
+def _is_mailbox_result(value: dict[str, Any]) -> bool:
+    return (
+        _optional_str(value.get("email")) is not None
+        and "backup_email" in value
+        and "crm_updated" in value
+    )
+
+
+def _is_sso_result(value: dict[str, Any]) -> bool:
+    return value.get("user_id") is not None and "crm_updated" in value
 
 
 def _optional_date(value: Any) -> str | None:

--- a/tests/evals/discord-agent/fixtures/v1/index.json
+++ b/tests/evals/discord-agent/fixtures/v1/index.json
@@ -22,6 +22,9 @@
     "member_agreement_crm_ambiguous_001.json",
     "member_agreement_missing_email_clarification_001.json",
     "mailbox_create_confirmation_001.json",
+    "sso_user_create_confirmation_001.json",
+    "outline_invite_confirmation_001.json",
+    "user_accounts_create_confirmation_001.json",
     "missing_project_clarification_001.json",
     "thread_followup_latest_message_001.json"
   ]

--- a/tests/evals/discord-agent/fixtures/v1/outline_invite_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/outline_invite_confirmation_001.json
@@ -25,7 +25,7 @@
       {
         "tool_name": "outline_write.invite_user",
         "requires_confirmation": true,
-        "required_scopes": ["integration:manage"],
+        "required_scopes": ["integration:manage", "crm:contact:read"],
         "arguments": {
           "email": "jane@508.dev"
         }

--- a/tests/evals/discord-agent/fixtures/v1/outline_invite_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/outline_invite_confirmation_001.json
@@ -1,0 +1,35 @@
+{
+  "version": "discord-agent-trajectory.v1",
+  "id": "outline_invite_confirmation_001",
+  "description": "Admins can draft an Outline invite behind confirmation.",
+  "tags": ["weekly", "outline", "write", "confirmation"],
+  "suite": {
+    "canonical": true,
+    "weekly": true
+  },
+  "context": {
+    "discord_user_id": "789",
+    "organization_id": "org-1",
+    "guild_id": "org-1",
+    "roles": ["Admin"]
+  },
+  "request": {
+    "message": "Invite jane@508.dev to Outline"
+  },
+  "expect": {
+    "status": "requires_confirmation",
+    "intent": "invite_outline_user",
+    "model_tier": "strong",
+    "requires_confirmation": true,
+    "actions": [
+      {
+        "tool_name": "outline_write.invite_user",
+        "requires_confirmation": true,
+        "required_scopes": ["integration:manage"],
+        "arguments": {
+          "email": "jane@508.dev"
+        }
+      }
+    ]
+  }
+}

--- a/tests/evals/discord-agent/fixtures/v1/sso_user_create_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/sso_user_create_confirmation_001.json
@@ -1,0 +1,35 @@
+{
+  "version": "discord-agent-trajectory.v1",
+  "id": "sso_user_create_confirmation_001",
+  "description": "Admins can draft Authentik SSO user creation behind confirmation.",
+  "tags": ["weekly", "sso", "write", "confirmation"],
+  "suite": {
+    "canonical": true,
+    "weekly": true
+  },
+  "context": {
+    "discord_user_id": "789",
+    "organization_id": "org-1",
+    "guild_id": "org-1",
+    "roles": ["Admin"]
+  },
+  "request": {
+    "message": "Create SSO user for CRM contact abc123"
+  },
+  "expect": {
+    "status": "requires_confirmation",
+    "intent": "create_sso_user",
+    "model_tier": "strong",
+    "requires_confirmation": true,
+    "actions": [
+      {
+        "tool_name": "sso_write.create_user",
+        "requires_confirmation": true,
+        "required_scopes": ["user:manage"],
+        "arguments": {
+          "contact_id": "abc123"
+        }
+      }
+    ]
+  }
+}

--- a/tests/evals/discord-agent/fixtures/v1/sso_user_create_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/sso_user_create_confirmation_001.json
@@ -25,7 +25,11 @@
       {
         "tool_name": "sso_write.create_user",
         "requires_confirmation": true,
-        "required_scopes": ["user:manage"],
+        "required_scopes": [
+          "user:manage",
+          "crm:contact:read",
+          "crm:contact:update"
+        ],
         "arguments": {
           "contact_id": "abc123"
         }

--- a/tests/evals/discord-agent/fixtures/v1/user_accounts_create_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/user_accounts_create_confirmation_001.json
@@ -28,7 +28,9 @@
         "required_scopes": [
           "mailbox:create",
           "user:manage",
-          "integration:manage"
+          "integration:manage",
+          "crm:contact:read",
+          "crm:contact:update"
         ],
         "arguments": {
           "contact_query": "Jane Doe",

--- a/tests/evals/discord-agent/fixtures/v1/user_accounts_create_confirmation_001.json
+++ b/tests/evals/discord-agent/fixtures/v1/user_accounts_create_confirmation_001.json
@@ -1,0 +1,40 @@
+{
+  "version": "discord-agent-trajectory.v1",
+  "id": "user_accounts_create_confirmation_001",
+  "description": "Admins can draft full 508 account provisioning behind confirmation.",
+  "tags": ["weekly", "accounts", "write", "confirmation"],
+  "suite": {
+    "canonical": true,
+    "weekly": true
+  },
+  "context": {
+    "discord_user_id": "789",
+    "organization_id": "org-1",
+    "guild_id": "org-1",
+    "roles": ["Admin"]
+  },
+  "request": {
+    "message": "Create 508 accounts for Jane Doe with mailbox jane@508.dev"
+  },
+  "expect": {
+    "status": "requires_confirmation",
+    "intent": "create_user_accounts",
+    "model_tier": "strong",
+    "requires_confirmation": true,
+    "actions": [
+      {
+        "tool_name": "account_write.create_user_accounts",
+        "requires_confirmation": true,
+        "required_scopes": [
+          "mailbox:create",
+          "user:manage",
+          "integration:manage"
+        ],
+        "arguments": {
+          "contact_query": "Jane Doe",
+          "mailbox_username": "jane@508.dev"
+        }
+      }
+    ]
+  }
+}

--- a/tests/unit/test_agent_cog.py
+++ b/tests/unit/test_agent_cog.py
@@ -440,7 +440,9 @@ async def test_agent_command_answers_help_without_backend() -> None:
     assert "I can help with:" in response
     assert "GitHub issues:" in response
     assert "CRM:" in response
-    assert "create 508 mailboxes" in response
+    assert "create 508 accounts" in response
+    assert "Authentik SSO users" in response
+    assert "Outline invites" in response
     assert "`/agent`" not in response
     cog._post_agent_request.assert_not_awaited()
     cog._audit_command_safe.assert_not_called()
@@ -848,7 +850,9 @@ async def test_agent_mention_answers_help_without_backend() -> None:
     assert "I can help with:" in response
     assert "GitHub issues:" in response
     assert "CRM:" in response
-    assert "create 508 mailboxes" in response
+    assert "create 508 accounts" in response
+    assert "Authentik SSO users" in response
+    assert "Outline invites" in response
     assert "Tasks:" not in response
     assert "Kimai" not in response
     assert "`/agent`" in response

--- a/tests/unit/test_agent_cog.py
+++ b/tests/unit/test_agent_cog.py
@@ -157,6 +157,55 @@ def test_format_agent_response_renders_contact_results() -> None:
     assert "Sarah Example sarah@example.com contact-1" in message
 
 
+def test_format_agent_response_surfaces_sso_recovery_email_warning() -> None:
+    cog = AgentCog.__new__(AgentCog)
+
+    message = cog._format_agent_response(
+        {
+            "status": "executed",
+            "results": [
+                {
+                    "tool_name": "sso_write.create_user",
+                    "status": "succeeded",
+                    "result": {
+                        "user_id": 42,
+                        "recovery_email_error": "stage unavailable",
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "- sso_write.create_user: succeeded" in message
+    assert "Recovery email failed: stage unavailable" in message
+
+
+def test_format_agent_response_surfaces_nested_sso_recovery_email_warning() -> None:
+    cog = AgentCog.__new__(AgentCog)
+
+    message = cog._format_agent_response(
+        {
+            "status": "executed",
+            "results": [
+                {
+                    "tool_name": "account_write.create_user_accounts",
+                    "status": "succeeded",
+                    "result": {
+                        "email": "jane@508.dev",
+                        "sso": {
+                            "user_id": 42,
+                            "recovery_email_error": "stage unavailable",
+                        },
+                    },
+                }
+            ],
+        }
+    )
+
+    assert "- account_write.create_user_accounts: succeeded" in message
+    assert "Recovery email failed: stage unavailable" in message
+
+
 def test_audit_result_treats_error_payload_as_error() -> None:
     assert (
         AgentCog._audit_result_for_agent_response(

--- a/tests/unit/test_agent_evals.py
+++ b/tests/unit/test_agent_evals.py
@@ -131,6 +131,57 @@ def test_live_planner_eval_uses_provider_response(
     assert (tmp_path / "observed.live_planner.canonical.openai-direct.json").exists()
 
 
+def test_live_planner_eval_falls_back_for_parseable_clarification(monkeypatch) -> None:
+    class FakeResponse:
+        status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, object]:
+            return {
+                "usage": {
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "total_tokens": 120,
+                },
+                "choices": [
+                    {
+                        "message": {
+                            "content": (
+                                '{"status":"needs_clarification",'
+                                '"intent":"search_project_tasks",'
+                                '"clarification_question":"Which project should I search?",'
+                                '"actions":[]}'
+                            )
+                        }
+                    }
+                ],
+            }
+
+    def fake_post(*args: object, **kwargs: object) -> FakeResponse:
+        return FakeResponse()
+
+    monkeypatch.setenv("OPENAI_API_KEY_DIRECT", "direct-key")
+    monkeypatch.setattr("five08.agent.evals.requests.post", fake_post)
+
+    report = run_live_planner_eval_suite(
+        suite="canonical",
+        model="openai-direct",
+        ids=["search_project_tasks_001"],
+        timeout_seconds=1,
+    )
+
+    assert report.summary["passed"] == 1
+    assert report.summary["failed"] == 0
+    scenario = report.scenarios[0]
+    assert scenario.status == "passed"
+    assert scenario.observed.actions[0].arguments == {
+        "project": "Atlas",
+        "query": "onboarding",
+    }
+
+
 def test_live_planner_eval_retries_one_bad_plan(monkeypatch) -> None:
     class FakeResponse:
         status_code = 200

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1285,6 +1285,22 @@ def test_sso_user_create_treats_named_contact_as_lookup_query() -> None:
     assert action.arguments == {"contact_query": "Jane Doe"}
 
 
+def test_sso_user_account_create_plans_sso_tool() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create SSO user account for CRM contact abc123",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    assert response.plan.intent == "create_sso_user"
+    action = response.plan.actions[0]
+    assert action.tool_name == "sso_write.create_user"
+    assert action.arguments == {"contact_id": "abc123"}
+
+
 def test_outline_invite_plans_direct_email_tool() -> None:
     orchestrator = AgentOrchestrator()
 
@@ -1300,6 +1316,22 @@ def test_outline_invite_plans_direct_email_tool() -> None:
     assert action.tool_name == "outline_write.invite_user"
     assert action.required_scopes == ["integration:manage", "crm:contact:read"]
     assert action.arguments == {"email": "jane@508.dev"}
+
+
+def test_outline_invite_plans_add_named_contact() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Add Jane Doe to Outline",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    assert response.plan.intent == "invite_outline_user"
+    action = response.plan.actions[0]
+    assert action.tool_name == "outline_write.invite_user"
+    assert action.arguments == {"contact_query": "Jane Doe"}
 
 
 def test_user_accounts_create_plans_combined_account_tool() -> None:

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1244,6 +1244,79 @@ def test_mailbox_create_rejects_non_configured_mailbox_domain() -> None:
     assert response.plan is None
 
 
+def test_sso_user_create_plans_admin_account_tool() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create SSO user for CRM contact abc123",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    assert response.plan.intent == "create_sso_user"
+    action = response.plan.actions[0]
+    assert action.tool_name == "sso_write.create_user"
+    assert action.required_scopes == ["user:manage"]
+    assert action.arguments == {"contact_id": "abc123"}
+
+
+def test_outline_invite_plans_direct_email_tool() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Invite jane@508.dev to Outline",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    assert response.plan.intent == "invite_outline_user"
+    action = response.plan.actions[0]
+    assert action.tool_name == "outline_write.invite_user"
+    assert action.required_scopes == ["integration:manage"]
+    assert action.arguments == {"email": "jane@508.dev"}
+
+
+def test_user_accounts_create_plans_combined_account_tool() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create 508 accounts for Jane Doe with mailbox jane@508.dev",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    assert response.plan.intent == "create_user_accounts"
+    action = response.plan.actions[0]
+    assert action.tool_name == "account_write.create_user_accounts"
+    assert action.required_scopes == [
+        "mailbox:create",
+        "user:manage",
+        "integration:manage",
+    ]
+    assert action.arguments == {
+        "contact_query": "Jane Doe",
+        "mailbox_username": "jane@508.dev",
+    }
+
+
+def test_user_accounts_create_is_admin_only() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create 508 accounts for Jane Doe with mailbox jane@508.dev",
+        _context(roles=["Engineer"]),
+    )
+
+    assert response.status == "denied"
+    assert response.plan is not None
+    action = response.plan.actions[0]
+    assert action.tool_name == "account_write.create_user_accounts"
+    assert "mailbox:create" in response.message
+
+
 def test_github_issue_create_uses_runtime_configured_default_repo(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import date, timezone
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -15,10 +16,13 @@ from five08.agent import (
     InMemoryTaskStore,
     PolicyEngine,
     ToolManifest,
+    ToolPartialSuccessError,
     ToolRuntimeConfig,
 )
 from five08.agent.intent_normalizer import OpenAICompatibleIntentNormalizer
 from five08.agent.tools import ToolRegistry
+from five08.clients.espo import EspoAPIError
+from five08.clients.outline import OutlineAPIError
 
 
 def _context(
@@ -1244,7 +1248,7 @@ def test_mailbox_create_rejects_non_configured_mailbox_domain() -> None:
     assert response.plan is None
 
 
-def test_sso_user_create_plans_admin_account_tool() -> None:
+def test_sso_user_create_plans_sso_user_tool() -> None:
     orchestrator = AgentOrchestrator()
 
     response = orchestrator.plan(
@@ -1315,6 +1319,366 @@ def test_user_accounts_create_is_admin_only() -> None:
     action = response.plan.actions[0]
     assert action.tool_name == "account_write.create_user_accounts"
     assert "mailbox:create" in response.message
+
+
+def _account_runtime_config(
+    *,
+    outline_api_key: str | None = "outline-key",
+) -> ToolRuntimeConfig:
+    return ToolRuntimeConfig(
+        espo_base_url="https://crm.example",
+        espo_api_key="espo-key",
+        migadu_api_user="migadu-user",
+        migadu_api_key="migadu-key",
+        authentik_api_base_url="https://sso.example",
+        authentik_api_token="authentik-token",
+        authentik_recovery_email_stage_id="stage-1",
+        outline_api_key=outline_api_key,
+    )
+
+
+def _install_account_tool_fakes(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    contact: dict[str, Any] | None = None,
+    fail_crm_update_fields: set[str] | None = None,
+    fail_outline_invite: bool = False,
+) -> SimpleNamespace:
+    initial_contact = contact or {
+        "id": "contact-1",
+        "name": "Jane Doe",
+        "emailAddress": "jane@example.com",
+        "c508Email": None,
+        "cSsoID": None,
+    }
+
+    class FakeEspoClient:
+        contacts: dict[str, dict[str, Any]] = {
+            str(initial_contact["id"]): dict(initial_contact)
+        }
+        updates: list[tuple[str, dict[str, Any]]] = []
+        fail_fields = fail_crm_update_fields or set()
+
+        def __init__(
+            self,
+            base_url: str,
+            api_key: str,
+            timeout_seconds: float = 20.0,
+        ) -> None:
+            self.base_url = base_url
+            self.api_key = api_key
+            self.timeout_seconds = timeout_seconds
+
+        def get_contact(self, contact_id: str) -> dict[str, Any]:
+            return dict(self.contacts[contact_id])
+
+        def update_contact(
+            self,
+            contact_id: str,
+            updates: dict[str, Any],
+        ) -> dict[str, Any]:
+            if self.fail_fields.intersection(updates):
+                raise EspoAPIError("CRM update failed")
+            self.contacts[contact_id].update(updates)
+            self.updates.append((contact_id, dict(updates)))
+            return dict(self.contacts[contact_id])
+
+        def list_contacts(self, params: dict[str, Any]) -> dict[str, Any]:
+            return {"list": [dict(item) for item in self.contacts.values()]}
+
+    class FakeAuthentikClient:
+        created_users: list[dict[str, Any]] = []
+        recovery_emails: list[tuple[int | str, str]] = []
+
+        def __init__(
+            self,
+            base_url: str,
+            api_token: str,
+            timeout_seconds: float = 20.0,
+        ) -> None:
+            self.base_url = base_url
+            self.api_token = api_token
+            self.timeout_seconds = timeout_seconds
+
+        def find_users_by_username_or_email(
+            self,
+            *,
+            username: str,
+            email: str,
+            page_size: int = 20,
+        ) -> list[dict[str, Any]]:
+            return []
+
+        def resolve_email_stage_id(
+            self,
+            *,
+            stage_name: str,
+            stage_id: str | None = None,
+            page_size: int = 20,
+        ) -> str:
+            return stage_id or "stage-1"
+
+        def create_user(
+            self,
+            *,
+            username: str,
+            name: str,
+            email: str | None = None,
+            is_active: bool = True,
+            path: str | None = None,
+            user_type: str = "internal",
+            groups: list[str] | None = None,
+            roles: list[str] | None = None,
+            attributes: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            user = {
+                "pk": 42,
+                "username": username,
+                "name": name,
+                "email": email,
+                "is_superuser": False,
+            }
+            self.created_users.append(user)
+            return user
+
+        def get_user(self, user_id: int | str) -> dict[str, Any]:
+            return {
+                "pk": user_id,
+                "username": "jane",
+                "email": "jane@508.dev",
+                "is_superuser": False,
+            }
+
+        def send_recovery_email(
+            self,
+            *,
+            user_id: int | str,
+            email_stage: str,
+            token_duration: str | None = None,
+        ) -> None:
+            self.recovery_emails.append((user_id, email_stage))
+
+    class FakeMigaduClient:
+        created_mailboxes: list[dict[str, Any]] = []
+
+        def __init__(self, username: str, api_key: str, domain: str) -> None:
+            self.username = username
+            self.api_key = api_key
+            self.domain = domain
+
+        def create_mailbox(self, request: object) -> dict[str, Any]:
+            local_part = str(getattr(request, "local_part"))
+            mailbox = {"address": f"{local_part}@{self.domain}"}
+            self.created_mailboxes.append(mailbox)
+            return mailbox
+
+    class FakeOutlineClient:
+        invites: list[dict[str, Any]] = []
+
+        def __init__(
+            self,
+            api_key: str,
+            base_url: str = "https://app.getoutline.com",
+            timeout_seconds: float = 20.0,
+        ) -> None:
+            self.api_key = api_key
+            self.base_url = base_url
+            self.timeout_seconds = timeout_seconds
+
+        def invite_user(
+            self,
+            *,
+            email: str,
+            name: str | None = None,
+            role: str = "member",
+        ) -> dict[str, Any]:
+            if fail_outline_invite:
+                raise OutlineAPIError("Outline invite failed")
+            invite = {"email": email, "name": name, "role": role}
+            self.invites.append(invite)
+            return invite
+
+    monkeypatch.setattr("five08.agent.tools.EspoClient", FakeEspoClient)
+    monkeypatch.setattr("five08.agent.tools.AuthentikClient", FakeAuthentikClient)
+    monkeypatch.setattr("five08.agent.tools.MigaduClient", FakeMigaduClient)
+    monkeypatch.setattr("five08.agent.tools.OutlineClient", FakeOutlineClient)
+    return SimpleNamespace(
+        espo=FakeEspoClient,
+        authentik=FakeAuthentikClient,
+        migadu=FakeMigaduClient,
+        outline=FakeOutlineClient,
+    )
+
+
+def test_sso_user_tool_executes_and_links_crm(monkeypatch: pytest.MonkeyPatch) -> None:
+    fakes = _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "sso_write.create_user",
+        {"contact_id": "contact-1"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"user:manage"},
+    )
+
+    assert result["user_id"] == 42
+    assert result["crm_updated"] is True
+    assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
+
+
+def test_sso_user_tool_partial_result_preserves_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+        fail_crm_update_fields={"cSsoID"},
+    )
+    orchestrator = AgentOrchestrator(
+        registry=ToolRegistry(runtime_config=_account_runtime_config())
+    )
+    context = _context(roles=["Admin"])
+    response = orchestrator.plan("Create SSO user for CRM contact contact-1", context)
+
+    assert response.plan is not None
+    results = orchestrator.execute_plan(response.plan, context, confirmed=True)
+
+    assert results[0].status == "failed"
+    assert results[0].error == "SSO user is ready, but updating CRM cSsoID failed."
+    assert results[0].result["user_id"] == 42
+    assert results[0].result["crm_updated"] is False
+    assert results[0].result["partial_success"] == "sso_user_ready_crm_update_failed"
+
+
+def test_outline_invite_tool_executes_direct_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(monkeypatch)
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "outline_write.invite_user",
+        {"email": "jane@508.dev"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"integration:manage"},
+    )
+
+    assert result == {
+        "email": "jane@508.dev",
+        "name": "jane",
+        "direct_email": True,
+    }
+    assert fakes.outline.invites == [
+        {"email": "jane@508.dev", "name": "jane", "role": "member"}
+    ]
+
+
+def test_user_accounts_tool_executes_all_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(monkeypatch)
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "account_write.create_user_accounts",
+        {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+    )
+
+    assert result["email"] == "jane@508.dev"
+    assert result["mailbox"]["created"] is True
+    assert result["sso"]["user_id"] == 42
+    assert result["outline"]["email"] == "jane@508.dev"
+    assert fakes.migadu.created_mailboxes == [{"address": "jane@508.dev"}]
+    assert ("contact-1", {"c508Email": "jane@508.dev"}) in fakes.espo.updates
+    assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
+
+
+def test_user_accounts_tool_preflights_before_mailbox_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(monkeypatch)
+    registry = ToolRegistry(
+        runtime_config=_account_runtime_config(outline_api_key=None)
+    )
+
+    with pytest.raises(RuntimeError, match="OUTLINE_API_KEY"):
+        registry.execute(
+            "account_write.create_user_accounts",
+            {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+        )
+
+    assert fakes.migadu.created_mailboxes == []
+    assert fakes.espo.updates == []
+
+
+def test_user_accounts_tool_partial_result_preserves_created_mailbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(monkeypatch, fail_crm_update_fields={"c508Email"})
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "account_write.create_user_accounts",
+            {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+        )
+
+    result = exc_info.value.result
+    assert result["partial_success"] == "user_accounts_partial"
+    assert result["mailbox"]["email"] == "jane@508.dev"
+    assert result["mailbox"]["crm_updated"] is False
+    assert result["mailbox"]["partial_success"] == "mailbox_created_crm_update_failed"
+    assert result["sso"] is None
+    assert result["outline"] is None
+
+
+def test_user_accounts_tool_partial_result_preserves_later_steps(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(monkeypatch, fail_outline_invite=True)
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "account_write.create_user_accounts",
+            {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+        )
+
+    result = exc_info.value.result
+    assert result["partial_success"] == "user_accounts_partial"
+    assert result["mailbox"]["email"] == "jane@508.dev"
+    assert result["sso"]["user_id"] == 42
+    assert result["outline"] is None
+    assert result["error"] == "Outline invite failed"
 
 
 def test_github_issue_create_uses_runtime_configured_default_repo(

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1378,6 +1378,24 @@ def test_user_accounts_create_treats_named_contact_as_lookup_query() -> None:
     }
 
 
+def test_user_accounts_create_accepts_mailbox_username_label() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create 508 accounts for Jane Doe with mailbox username jane",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    action = response.plan.actions[0]
+    assert action.tool_name == "account_write.create_user_accounts"
+    assert action.arguments == {
+        "contact_query": "Jane Doe",
+        "mailbox_username": "jane",
+    }
+
+
 def test_user_accounts_create_is_admin_only() -> None:
     orchestrator = AgentOrchestrator()
 
@@ -1418,8 +1436,10 @@ def _install_account_tool_fakes(
     authentik_create_error: bool = False,
     authentik_reconcile_after_create_error: bool = False,
     authentik_created_user: dict[str, Any] | None = None,
+    fail_recovery_stage_resolution: bool = False,
     migadu_address: str | None = None,
 ) -> SimpleNamespace:
+    events: list[str] = []
     initial_contact = contact or {
         "id": "contact-1",
         "name": "Jane Doe",
@@ -1506,6 +1526,9 @@ def _install_account_tool_fakes(
             stage_id: str | None = None,
             page_size: int = 20,
         ) -> str:
+            events.append("resolve_recovery_stage")
+            if fail_recovery_stage_resolution:
+                raise AuthentikAPIError("Recovery stage not found")
             return stage_id or "stage-1"
 
         def create_user(
@@ -1521,6 +1544,7 @@ def _install_account_tool_fakes(
             roles: list[str] | None = None,
             attributes: dict[str, Any] | None = None,
         ) -> dict[str, Any]:
+            events.append("create_sso_user")
             self.create_attempted = True
             if authentik_create_error:
                 raise AuthentikAPIError("Authentik create timed out")
@@ -1560,6 +1584,7 @@ def _install_account_tool_fakes(
             self.domain = domain
 
         def create_mailbox(self, request: object) -> dict[str, Any]:
+            events.append("create_mailbox")
             local_part = str(getattr(request, "local_part"))
             mailbox = {"address": migadu_address or f"{local_part}@{self.domain}"}
             self.created_mailboxes.append(mailbox)
@@ -1600,6 +1625,7 @@ def _install_account_tool_fakes(
         authentik=FakeAuthentikClient,
         migadu=FakeMigaduClient,
         outline=FakeOutlineClient,
+        events=events,
     )
 
 
@@ -1632,6 +1658,17 @@ def test_contact_search_filters_expand_short_508_domain() -> None:
     registry = ToolRegistry(runtime_config=_account_runtime_config())
 
     filters = registry._contact_search_filters("jane@508")  # noqa: SLF001
+
+    assert filters == [
+        {"type": "equals", "attribute": "emailAddress", "value": "jane@508.dev"},
+        {"type": "equals", "attribute": "c508Email", "value": "jane@508.dev"},
+    ]
+
+
+def test_contact_search_filters_lowercase_email_queries() -> None:
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    filters = registry._contact_search_filters("Jane@508")  # noqa: SLF001
 
     assert filters == [
         {"type": "equals", "attribute": "emailAddress", "value": "jane@508.dev"},
@@ -1837,6 +1874,38 @@ def test_sso_user_tool_reconciles_after_authentik_create_error(
     assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
 
 
+def test_sso_user_tool_continues_when_recovery_stage_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+        fail_recovery_stage_resolution=True,
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "sso_write.create_user",
+        {"contact_id": "contact-1"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
+    )
+
+    assert result["user_id"] == 42
+    assert result["created"] is True
+    assert result["crm_updated"] is True
+    assert result["recovery_email_error"] == "Recovery stage not found"
+    assert fakes.authentik.recovery_emails == []
+    assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
+
+
 def test_outline_invite_tool_executes_direct_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1955,6 +2024,36 @@ def test_user_accounts_tool_preflights_before_mailbox_creation(
 
     assert fakes.migadu.created_mailboxes == []
     assert fakes.espo.updates == []
+
+
+def test_user_accounts_tool_preflights_recovery_stage_before_mailbox_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(
+        monkeypatch,
+        fail_recovery_stage_resolution=True,
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "account_write.create_user_accounts",
+        {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={
+            "mailbox:create",
+            "user:manage",
+            "integration:manage",
+            "crm:contact:read",
+            "crm:contact:update",
+        },
+    )
+
+    assert result["mailbox"]["email"] == "jane@508.dev"
+    assert result["sso"]["recovery_email_error"] == "Recovery stage not found"
+    assert fakes.events.index("resolve_recovery_stage") < fakes.events.index(
+        "create_mailbox"
+    )
 
 
 def test_user_accounts_tool_partial_result_preserves_created_mailbox(

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1628,6 +1628,28 @@ def test_contact_lookup_does_not_treat_long_name_as_contact_id() -> None:
     assert client.get_contact_calls == 0
 
 
+def test_contact_search_filters_expand_short_508_domain() -> None:
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    filters = registry._contact_search_filters("jane@508")  # noqa: SLF001
+
+    assert filters == [
+        {"type": "equals", "attribute": "emailAddress", "value": "jane@508.dev"},
+        {"type": "equals", "attribute": "c508Email", "value": "jane@508.dev"},
+    ]
+
+
+def test_contact_search_filters_do_not_expand_missing_email_domain() -> None:
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    filters = registry._contact_search_filters("jane@")  # noqa: SLF001
+
+    assert filters == [
+        {"type": "equals", "attribute": "emailAddress", "value": "jane@"},
+        {"type": "equals", "attribute": "c508Email", "value": "jane@"},
+    ]
+
+
 def test_sso_user_tool_executes_and_links_crm(monkeypatch: pytest.MonkeyPatch) -> None:
     fakes = _install_account_tool_fakes(
         monkeypatch,

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -21,6 +21,7 @@ from five08.agent import (
 )
 from five08.agent.intent_normalizer import OpenAICompatibleIntentNormalizer
 from five08.agent.tools import ToolRegistry
+from five08.clients.authentik import AuthentikAPIError
 from five08.clients.espo import EspoAPIError
 from five08.clients.outline import OutlineAPIError
 
@@ -1265,6 +1266,21 @@ def test_sso_user_create_plans_sso_user_tool() -> None:
     assert action.arguments == {"contact_id": "abc123"}
 
 
+def test_sso_user_create_treats_named_contact_as_lookup_query() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create SSO user for contact Jane Doe",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    action = response.plan.actions[0]
+    assert action.tool_name == "sso_write.create_user"
+    assert action.arguments == {"contact_query": "Jane Doe"}
+
+
 def test_outline_invite_plans_direct_email_tool() -> None:
     orchestrator = AgentOrchestrator()
 
@@ -1300,6 +1316,24 @@ def test_user_accounts_create_plans_combined_account_tool() -> None:
         "user:manage",
         "integration:manage",
     ]
+    assert action.arguments == {
+        "contact_query": "Jane Doe",
+        "mailbox_username": "jane@508.dev",
+    }
+
+
+def test_user_accounts_create_treats_named_contact_as_lookup_query() -> None:
+    orchestrator = AgentOrchestrator()
+
+    response = orchestrator.plan(
+        "Create 508 accounts for contact Jane Doe with mailbox jane@508.dev",
+        _context(roles=["Admin"]),
+    )
+
+    assert response.status == "requires_confirmation"
+    assert response.plan is not None
+    action = response.plan.actions[0]
+    assert action.tool_name == "account_write.create_user_accounts"
     assert action.arguments == {
         "contact_query": "Jane Doe",
         "mailbox_username": "jane@508.dev",
@@ -1343,6 +1377,9 @@ def _install_account_tool_fakes(
     contact: dict[str, Any] | None = None,
     fail_crm_update_fields: set[str] | None = None,
     fail_outline_invite: bool = False,
+    authentik_create_error: bool = False,
+    authentik_reconcile_after_create_error: bool = False,
+    migadu_address: str | None = None,
 ) -> SimpleNamespace:
     initial_contact = contact or {
         "id": "contact-1",
@@ -1389,6 +1426,7 @@ def _install_account_tool_fakes(
     class FakeAuthentikClient:
         created_users: list[dict[str, Any]] = []
         recovery_emails: list[tuple[int | str, str]] = []
+        create_attempted = False
 
         def __init__(
             self,
@@ -1407,6 +1445,19 @@ def _install_account_tool_fakes(
             email: str,
             page_size: int = 20,
         ) -> list[dict[str, Any]]:
+            if (
+                authentik_create_error
+                and authentik_reconcile_after_create_error
+                and self.create_attempted
+            ):
+                return [
+                    {
+                        "pk": 42,
+                        "username": username,
+                        "email": email,
+                        "is_superuser": False,
+                    }
+                ]
             return []
 
         def resolve_email_stage_id(
@@ -1431,6 +1482,9 @@ def _install_account_tool_fakes(
             roles: list[str] | None = None,
             attributes: dict[str, Any] | None = None,
         ) -> dict[str, Any]:
+            self.create_attempted = True
+            if authentik_create_error:
+                raise AuthentikAPIError("Authentik create timed out")
             user = {
                 "pk": 42,
                 "username": username,
@@ -1468,7 +1522,7 @@ def _install_account_tool_fakes(
 
         def create_mailbox(self, request: object) -> dict[str, Any]:
             local_part = str(getattr(request, "local_part"))
-            mailbox = {"address": f"{local_part}@{self.domain}"}
+            mailbox = {"address": migadu_address or f"{local_part}@{self.domain}"}
             self.created_mailboxes.append(mailbox)
             return mailbox
 
@@ -1566,6 +1620,39 @@ def test_sso_user_tool_partial_result_preserves_user_id(
     assert results[0].result["partial_success"] == "sso_user_ready_crm_update_failed"
 
 
+def test_sso_user_tool_reconciles_after_authentik_create_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+        authentik_create_error=True,
+        authentik_reconcile_after_create_error=True,
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "sso_write.create_user",
+        {"contact_id": "contact-1"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"user:manage"},
+    )
+
+    assert result["user_id"] == 42
+    assert result["crm_updated"] is True
+    assert result["created"] is False
+    assert result["recovered_existing_after_create_error"] is True
+    assert fakes.authentik.recovery_emails == []
+    assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
+
+
 def test_outline_invite_tool_executes_direct_email(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1654,6 +1741,30 @@ def test_user_accounts_tool_partial_result_preserves_created_mailbox(
     assert result["mailbox"]["email"] == "jane@508.dev"
     assert result["mailbox"]["crm_updated"] is False
     assert result["mailbox"]["partial_success"] == "mailbox_created_crm_update_failed"
+    assert result["sso"] is None
+    assert result["outline"] is None
+
+
+def test_user_accounts_tool_partial_result_preserves_address_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(monkeypatch, migadu_address="jane-other@508.dev")
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "account_write.create_user_accounts",
+            {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+        )
+
+    result = exc_info.value.result
+    assert result["partial_success"] == "user_accounts_partial"
+    assert result["mailbox"]["email"] == "jane-other@508.dev"
+    assert result["mailbox"]["crm_updated"] is False
+    assert result["mailbox"]["partial_success"] == "mailbox_created_address_mismatch"
     assert result["sso"] is None
     assert result["outline"] is None
 

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -1262,7 +1262,11 @@ def test_sso_user_create_plans_sso_user_tool() -> None:
     assert response.plan.intent == "create_sso_user"
     action = response.plan.actions[0]
     assert action.tool_name == "sso_write.create_user"
-    assert action.required_scopes == ["user:manage"]
+    assert action.required_scopes == [
+        "user:manage",
+        "crm:contact:read",
+        "crm:contact:update",
+    ]
     assert action.arguments == {"contact_id": "abc123"}
 
 
@@ -1294,7 +1298,7 @@ def test_outline_invite_plans_direct_email_tool() -> None:
     assert response.plan.intent == "invite_outline_user"
     action = response.plan.actions[0]
     assert action.tool_name == "outline_write.invite_user"
-    assert action.required_scopes == ["integration:manage"]
+    assert action.required_scopes == ["integration:manage", "crm:contact:read"]
     assert action.arguments == {"email": "jane@508.dev"}
 
 
@@ -1315,6 +1319,8 @@ def test_user_accounts_create_plans_combined_account_tool() -> None:
         "mailbox:create",
         "user:manage",
         "integration:manage",
+        "crm:contact:read",
+        "crm:contact:update",
     ]
     assert action.arguments == {
         "contact_query": "Jane Doe",
@@ -1379,6 +1385,7 @@ def _install_account_tool_fakes(
     fail_outline_invite: bool = False,
     authentik_create_error: bool = False,
     authentik_reconcile_after_create_error: bool = False,
+    authentik_created_user: dict[str, Any] | None = None,
     migadu_address: str | None = None,
 ) -> SimpleNamespace:
     initial_contact = contact or {
@@ -1485,7 +1492,7 @@ def _install_account_tool_fakes(
             self.create_attempted = True
             if authentik_create_error:
                 raise AuthentikAPIError("Authentik create timed out")
-            user = {
+            user = authentik_created_user or {
                 "pk": 42,
                 "username": username,
                 "name": name,
@@ -1564,6 +1571,31 @@ def _install_account_tool_fakes(
     )
 
 
+def test_contact_lookup_does_not_treat_long_name_as_contact_id() -> None:
+    class FakeEspoClient:
+        get_contact_calls = 0
+
+        def get_contact(self, contact_id: str) -> dict[str, Any]:
+            self.get_contact_calls += 1
+            raise AssertionError(f"unexpected contact id lookup: {contact_id}")
+
+        def list_contacts(self, params: dict[str, Any]) -> dict[str, Any]:
+            return {"list": []}
+
+    client = FakeEspoClient()
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    contacts = registry._search_contacts_for_lookup(  # noqa: SLF001
+        client,
+        "Jennifer",
+        max_size=2,
+        select="id,name",
+    )
+
+    assert contacts == []
+    assert client.get_contact_calls == 0
+
+
 def test_sso_user_tool_executes_and_links_crm(monkeypatch: pytest.MonkeyPatch) -> None:
     fakes = _install_account_tool_fakes(
         monkeypatch,
@@ -1582,12 +1614,39 @@ def test_sso_user_tool_executes_and_links_crm(monkeypatch: pytest.MonkeyPatch) -
         {"contact_id": "contact-1"},
         organization_id="org-1",
         actor_id="123",
-        actor_scopes={"user:manage"},
+        actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
     )
 
     assert result["user_id"] == 42
     assert result["crm_updated"] is True
     assert ("contact-1", {"cSsoID": "42"}) in fakes.espo.updates
+
+
+def test_sso_user_tool_ignores_malformed_508_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@508.dev",
+            "c508Email": "bad @508.dev",
+            "cSsoID": None,
+        },
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    result = registry.execute(
+        "sso_write.create_user",
+        {"contact_id": "contact-1"},
+        organization_id="org-1",
+        actor_id="123",
+        actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
+    )
+
+    assert result["username"] == "jane"
+    assert result["email"] == "jane@508.dev"
 
 
 def test_sso_user_tool_partial_result_preserves_user_id(
@@ -1620,6 +1679,77 @@ def test_sso_user_tool_partial_result_preserves_user_id(
     assert results[0].result["partial_success"] == "sso_user_ready_crm_update_failed"
 
 
+def test_sso_user_tool_partial_result_preserves_created_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+        authentik_created_user={
+            "pk": 42,
+            "username": "other",
+            "email": "jane@508.dev",
+            "is_superuser": False,
+        },
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "sso_write.create_user",
+            {"contact_id": "contact-1"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
+        )
+
+    result = exc_info.value.result
+    assert result["user_id"] == 42
+    assert result["crm_updated"] is False
+    assert result["partial_success"] == "sso_created_validation_failed"
+
+
+def test_sso_user_tool_partial_result_handles_created_user_without_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(
+        monkeypatch,
+        contact={
+            "id": "contact-1",
+            "name": "Jane Doe",
+            "emailAddress": "jane@example.com",
+            "c508Email": "jane@508.dev",
+            "cSsoID": None,
+        },
+        authentik_created_user={
+            "username": "jane",
+            "email": "jane@508.dev",
+            "is_superuser": False,
+        },
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "sso_write.create_user",
+            {"contact_id": "contact-1"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
+        )
+
+    result = exc_info.value.result
+    assert result["user_id"] is None
+    assert result["crm_updated"] is False
+    assert result["partial_success"] == "sso_created_validation_failed"
+
+
 def test_sso_user_tool_reconciles_after_authentik_create_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1642,7 +1772,7 @@ def test_sso_user_tool_reconciles_after_authentik_create_error(
         {"contact_id": "contact-1"},
         organization_id="org-1",
         actor_id="123",
-        actor_scopes={"user:manage"},
+        actor_scopes={"user:manage", "crm:contact:read", "crm:contact:update"},
     )
 
     assert result["user_id"] == 42
@@ -1664,7 +1794,7 @@ def test_outline_invite_tool_executes_direct_email(
         {"email": "jane@508.dev"},
         organization_id="org-1",
         actor_id="123",
-        actor_scopes={"integration:manage"},
+        actor_scopes={"integration:manage", "crm:contact:read"},
     )
 
     assert result == {
@@ -1675,6 +1805,46 @@ def test_outline_invite_tool_executes_direct_email(
     assert fakes.outline.invites == [
         {"email": "jane@508.dev", "name": "jane", "role": "member"}
     ]
+
+
+@pytest.mark.parametrize("email", ["foo@", "@bar.com"])
+def test_outline_invite_tool_rejects_incomplete_email(
+    monkeypatch: pytest.MonkeyPatch,
+    email: str,
+) -> None:
+    _install_account_tool_fakes(monkeypatch)
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ValueError, match="full email address"):
+        registry.execute(
+            "outline_write.invite_user",
+            {"email": email},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"integration:manage", "crm:contact:read"},
+        )
+
+
+def test_mailbox_create_tool_validates_backup_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fakes = _install_account_tool_fakes(monkeypatch)
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ValueError, match="full email address"):
+        registry.execute(
+            "mail_write.create_mailbox",
+            {
+                "local_part": "jane",
+                "backup_email": "foo@",
+                "name": "Jane Doe",
+            },
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={"mailbox:create"},
+        )
+
+    assert fakes.migadu.created_mailboxes == []
 
 
 def test_user_accounts_tool_executes_all_steps(
@@ -1688,7 +1858,13 @@ def test_user_accounts_tool_executes_all_steps(
         {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
         organization_id="org-1",
         actor_id="123",
-        actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+        actor_scopes={
+            "mailbox:create",
+            "user:manage",
+            "integration:manage",
+            "crm:contact:read",
+            "crm:contact:update",
+        },
     )
 
     assert result["email"] == "jane@508.dev"
@@ -1714,7 +1890,13 @@ def test_user_accounts_tool_preflights_before_mailbox_creation(
             {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
             organization_id="org-1",
             actor_id="123",
-            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+            actor_scopes={
+                "mailbox:create",
+                "user:manage",
+                "integration:manage",
+                "crm:contact:read",
+                "crm:contact:update",
+            },
         )
 
     assert fakes.migadu.created_mailboxes == []
@@ -1733,7 +1915,13 @@ def test_user_accounts_tool_partial_result_preserves_created_mailbox(
             {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
             organization_id="org-1",
             actor_id="123",
-            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+            actor_scopes={
+                "mailbox:create",
+                "user:manage",
+                "integration:manage",
+                "crm:contact:read",
+                "crm:contact:update",
+            },
         )
 
     result = exc_info.value.result
@@ -1757,7 +1945,13 @@ def test_user_accounts_tool_partial_result_preserves_address_mismatch(
             {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
             organization_id="org-1",
             actor_id="123",
-            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+            actor_scopes={
+                "mailbox:create",
+                "user:manage",
+                "integration:manage",
+                "crm:contact:read",
+                "crm:contact:update",
+            },
         )
 
     result = exc_info.value.result
@@ -1766,6 +1960,42 @@ def test_user_accounts_tool_partial_result_preserves_address_mismatch(
     assert result["mailbox"]["crm_updated"] is False
     assert result["mailbox"]["partial_success"] == "mailbox_created_address_mismatch"
     assert result["sso"] is None
+    assert result["outline"] is None
+
+
+def test_user_accounts_tool_partial_result_preserves_sso_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_account_tool_fakes(
+        monkeypatch,
+        authentik_created_user={
+            "username": "jane",
+            "email": "jane@508.dev",
+            "is_superuser": False,
+        },
+    )
+    registry = ToolRegistry(runtime_config=_account_runtime_config())
+
+    with pytest.raises(ToolPartialSuccessError) as exc_info:
+        registry.execute(
+            "account_write.create_user_accounts",
+            {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
+            organization_id="org-1",
+            actor_id="123",
+            actor_scopes={
+                "mailbox:create",
+                "user:manage",
+                "integration:manage",
+                "crm:contact:read",
+                "crm:contact:update",
+            },
+        )
+
+    result = exc_info.value.result
+    assert result["partial_success"] == "user_accounts_partial"
+    assert result["mailbox"]["email"] == "jane@508.dev"
+    assert result["sso"]["user_id"] is None
+    assert result["sso"]["partial_success"] == "sso_created_validation_failed"
     assert result["outline"] is None
 
 
@@ -1781,7 +2011,13 @@ def test_user_accounts_tool_partial_result_preserves_later_steps(
             {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},
             organization_id="org-1",
             actor_id="123",
-            actor_scopes={"mailbox:create", "user:manage", "integration:manage"},
+            actor_scopes={
+                "mailbox:create",
+                "user:manage",
+                "integration:manage",
+                "crm:contact:read",
+                "crm:contact:update",
+            },
         )
 
     result = exc_info.value.result


### PR DESCRIPTION
## Summary
- add agent planner routes and executable tools for Authentik SSO creation/linking, Outline invites, and combined 508 account provisioning
- update the bot help message to advertise the expanded Ops account workflows
- add unit tests and canonical eval fixtures for the new planner actions

## Validation
- pre-commit hook: ruff, ruff format, mypy
- uv run pytest tests/unit/test_agent_gateway.py tests/unit/test_agent_cog.py -q
- uv run python -m five08.agent.evals --suite canonical

## Notes
- The canonical eval suite still reports the existing known failure `crm_contact_info_lookup_001`; no new failures were introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added support for creating 508 user accounts with integrated mailbox provisioning and account setup
* Added support for creating Authentik SSO users for CRM contacts
* Added support for inviting users to Outline via email or CRM contact lookup
* Updated bot help text to document expanded capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/508-dev/508-workflows/pull/282)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->