### PR TITLE
[codex] Fix Discord dashboard login links

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Use `.env.example` as the source of truth for defaults.
 - `Optional`: `AUTH_SESSION_COOKIE_NAME` (default: `five08_session`)
 - `Optional`: `AUTH_SESSION_TTL_SECONDS` (default: `86400`, one day)
 - `Optional`: `DASHBOARD_DEFAULT_PATH` (default: `/dashboard`)
-- `Optional`: `DASHBOARD_PUBLIC_BASE_URL` (base URL for generated deep links)
+- `Optional`: `DASHBOARD_PUBLIC_BASE_URL` (public base URL for generated deep links; set this in production, for example `https://workflows.508.dev`)
 - Note: OIDC timeout/cache timings are fixed in code; auth cookies always use `SameSite=Lax` and enable `secure` automatically outside local/dev/test environments.
 
 ### Discord Admin Deep-Link Validation

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -65,7 +65,8 @@ curl -X GET "http://localhost:8090/jobs/<job_id>" \
 - `GET /auth/me`: Return active session identity.
 - `POST /auth/logout`: Clear active session cookie + server session.
 - `POST /auth/discord/links`: Create one-time dashboard deep link from Discord command context.
-- `GET /auth/discord/link/{token}`: Resolve Discord deep link into authenticated dashboard redirect.
+- `GET /auth/discord/link/{token}`: Show a no-store confirmation page for a Discord dashboard deep link without consuming the token.
+- `POST /auth/discord/link/{token}/consume`: Consume the one-time Discord dashboard deep link and redirect to the authenticated dashboard session.
 - Auth flows emit best-effort human audit events (`auth.login`, `auth.logout`) under source `admin_dashboard`.
 
 Discord deep-link identity policy:
@@ -74,8 +75,10 @@ Discord deep-link identity policy:
 - `DISCORD_ADMIN_ROLES` controls which Discord roles can receive admin dashboard permissions (`Admin,Owner` recommended).
 - `OIDC_ADMIN_GROUPS` controls normal OIDC dashboard admin membership (`authentik Admins` recommended).
 - `AUTH_SESSION_TTL_SECONDS` controls dashboard session lifetime after login (`86400`, one day, by default).
+- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=true` (default): Discord deep links also require OIDC email identity checks against the linked CRM/Discord dashboard user.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=false`: Discord deep links create a Discord-backed session directly after re-validating active CRM membership + Discord Steering Committee+ role, without forcing an OIDC roundtrip.
+- In local/dev/test only, the trusted Discord bot role context can create and consume a dashboard link when the local `people` cache has no matching CRM-linked row. Production still requires the normal CRM/people identity.
 - Jobs, reruns, people sync, and audit are sensitive admin permissions and require an SSO-validated dashboard session even when the user entered through a Discord link. Local/dev/test environments allow these permissions for development.
 
 ### Known handler wiring expectation

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -24,7 +24,7 @@ import uvicorn
 from fastapi import FastAPI, Query, Request
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from psycopg import Connection
 from psycopg.rows import dict_row
 
@@ -75,6 +75,7 @@ from five08.backend.auth import (
     DASHBOARD_PERMISSION_PEOPLE_SYNC,
     DASHBOARD_SENSITIVE_PERMISSIONS,
     DiscordAdminVerifier,
+    DiscordAdminIdentity,
     DiscordLinkGrant,
     OIDCProviderClient,
     PendingOIDCState,
@@ -91,6 +92,8 @@ from five08.backend.auth import (
 from five08.backend.dashboard import (
     dashboard_assets_dir,
     dashboard_html,
+    discord_link_continue_html,
+    discord_link_unavailable_html,
     login_required_html,
     oidc_not_configured_html,
 )
@@ -145,6 +148,8 @@ class DiscordLinkCreateRequest(BaseModel):
 
     discord_user_id: str
     next_path: str | None = None
+    discord_display_name: str | None = None
+    discord_roles: list[str] = Field(default_factory=list)
 
 
 class AgentConfirmationRequest(BaseModel):
@@ -625,6 +630,31 @@ def _dashboard_dev_sensitive_access_enabled() -> bool:
         "development",
         "test",
     }
+
+
+def _dev_discord_link_identity_from_roles(
+    *,
+    discord_user_id: str,
+    discord_roles: list[str],
+    discord_display_name: str | None,
+    required_role: str = "Member",
+) -> DiscordAdminIdentity | None:
+    """Allow trusted bot role context as a local/dev fallback without CRM sync."""
+    if not _dashboard_dev_sensitive_access_enabled():
+        return None
+    if not has_dashboard_discord_role(
+        discord_roles,
+        required_role,
+        admin_role_names=settings.discord_admin_role_names,
+    ):
+        return None
+    return DiscordAdminIdentity(
+        discord_user_id=discord_user_id,
+        crm_contact_id="",
+        email=None,
+        display_name=discord_display_name,
+        discord_roles=discord_roles,
+    )
 
 
 def _request_prefers_json(request: Request) -> bool:
@@ -3607,8 +3637,14 @@ async def auth_callback_handler(
             )
             return JSONResponse({"error": "link_not_found"}, status_code=404)
 
+        dev_role_identity = _dev_discord_link_identity_from_roles(
+            discord_user_id=grant.discord_user_id,
+            discord_roles=grant.discord_roles,
+            discord_display_name=grant.discord_display_name,
+        )
+        identity: DiscordAdminIdentity | None
         if enforce_discord_link_identity_checks:
-            if not email:
+            if not email and dev_role_identity is None:
                 await _write_auth_audit_event(
                     action="auth.login",
                     result=AuditResult.DENIED,
@@ -3623,34 +3659,42 @@ async def auth_callback_handler(
                 )
 
             verifier = _discord_admin_verifier_from_app(request.app)
-            linked = await verifier.is_dashboard_email_for_discord_user(
-                email=email,
-                discord_user_id=grant.discord_user_id,
-                http_client=http_client,
-            )
+            linked = False
+            if email:
+                linked = await verifier.is_dashboard_email_for_discord_user(
+                    email=email,
+                    discord_user_id=grant.discord_user_id,
+                    http_client=http_client,
+                )
             if not linked:
-                await _write_auth_audit_event(
-                    action="auth.login",
-                    result=AuditResult.DENIED,
-                    actor_subject=audit_actor_subject,
-                    actor_display_name=display_name,
-                    metadata={
-                        "reason": "oidc_user_not_linked_to_dashboard_user",
-                        "discord_user_id": grant.discord_user_id,
-                    },
-                    correlation_id=state,
+                if dev_role_identity is not None:
+                    identity = dev_role_identity
+                else:
+                    await _write_auth_audit_event(
+                        action="auth.login",
+                        result=AuditResult.DENIED,
+                        actor_subject=audit_actor_subject,
+                        actor_display_name=display_name,
+                        metadata={
+                            "reason": "oidc_user_not_linked_to_dashboard_user",
+                            "discord_user_id": grant.discord_user_id,
+                        },
+                        correlation_id=state,
+                    )
+                    return JSONResponse(
+                        {
+                            "error": "forbidden",
+                            "detail": "oidc_user_not_linked_to_discord_dashboard_user",
+                        },
+                        status_code=403,
+                    )
+            else:
+                identity = await verifier.resolve_dashboard_identity(
+                    discord_user_id=grant.discord_user_id,
+                    http_client=http_client,
                 )
-                return JSONResponse(
-                    {
-                        "error": "forbidden",
-                        "detail": "oidc_user_not_linked_to_discord_dashboard_user",
-                    },
-                    status_code=403,
-                )
-            identity = await verifier.resolve_dashboard_identity(
-                discord_user_id=grant.discord_user_id,
-                http_client=http_client,
-            )
+                if identity is None:
+                    identity = dev_role_identity
             if identity is None:
                 await _write_auth_audit_event(
                     action="auth.login",
@@ -3689,6 +3733,8 @@ async def auth_callback_handler(
                 discord_user_id=grant.discord_user_id,
                 http_client=http_client,
             )
+            if identity is None:
+                identity = dev_role_identity
             if identity is None:
                 await _write_auth_audit_event(
                     action="auth.login",
@@ -3877,6 +3923,14 @@ async def auth_discord_link_create_handler(request: Request) -> JSONResponse:
         discord_user_id=payload.discord_user_id,
         http_client=http_client,
     )
+    dev_role_identity = None
+    if not is_dashboard_user:
+        dev_role_identity = _dev_discord_link_identity_from_roles(
+            discord_user_id=payload.discord_user_id,
+            discord_roles=payload.discord_roles,
+            discord_display_name=payload.discord_display_name,
+        )
+        is_dashboard_user = dev_role_identity is not None
     if not is_dashboard_user:
         return JSONResponse(
             {"error": "forbidden", "detail": "discord_user_not_allowed"},
@@ -3893,6 +3947,10 @@ async def auth_discord_link_create_handler(request: Request) -> JSONResponse:
         payload=DiscordLinkGrant(
             discord_user_id=payload.discord_user_id,
             next_path=next_path,
+            discord_roles=payload.discord_roles if dev_role_identity else [],
+            discord_display_name=(
+                payload.discord_display_name if dev_role_identity else None
+            ),
         ),
         ttl_seconds=settings.discord_link_ttl_seconds,
     )
@@ -3914,15 +3972,47 @@ async def auth_discord_link_create_handler(request: Request) -> JSONResponse:
 async def auth_discord_link_redirect_handler(
     request: Request,
     token: str,
-) -> JSONResponse | RedirectResponse:
-    """Handle one-time Discord deep link and create or resume an admin session."""
+) -> JSONResponse | HTMLResponse:
+    """Render a non-consuming interstitial for one-time Discord deep links."""
     store = _auth_store_from_app(request.app)
     if store is None:
         return JSONResponse({"error": "auth_not_ready"}, status_code=503)
 
     grant = await store.get_discord_link(token)
     if grant is None:
-        return JSONResponse({"error": "link_not_found"}, status_code=404)
+        if _request_prefers_json(request):
+            return JSONResponse({"error": "link_not_found"}, status_code=404)
+        response = HTMLResponse(discord_link_unavailable_html(), status_code=404)
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        return response
+
+    response = HTMLResponse(
+        discord_link_continue_html(token=token),
+        status_code=200,
+    )
+    response.headers["Cache-Control"] = "no-store"
+    response.headers["Referrer-Policy"] = "no-referrer"
+    return response
+
+
+async def auth_discord_link_consume_handler(
+    request: Request,
+    token: str,
+) -> JSONResponse | HTMLResponse | RedirectResponse:
+    """Consume one-time Discord deep link and create or resume a dashboard session."""
+    store = _auth_store_from_app(request.app)
+    if store is None:
+        return JSONResponse({"error": "auth_not_ready"}, status_code=503)
+
+    grant = await store.get_discord_link(token)
+    if grant is None:
+        if _request_prefers_json(request):
+            return JSONResponse({"error": "link_not_found"}, status_code=404)
+        response = HTMLResponse(discord_link_unavailable_html(), status_code=404)
+        response.headers["Cache-Control"] = "no-store"
+        response.headers["Referrer-Policy"] = "no-referrer"
+        return response
 
     session_id, session = await _current_session(request)
     if not settings.discord_link_require_oidc_identity_checks:
@@ -3932,6 +4022,12 @@ async def auth_discord_link_redirect_handler(
             discord_user_id=grant.discord_user_id,
             http_client=http_client,
         )
+        if identity is None:
+            identity = _dev_discord_link_identity_from_roles(
+                discord_user_id=grant.discord_user_id,
+                discord_roles=grant.discord_roles,
+                discord_display_name=grant.discord_display_name,
+            )
         if identity is None:
             return JSONResponse(
                 {"error": "forbidden", "detail": "discord_user_not_allowed"},
@@ -3968,8 +4064,8 @@ async def auth_discord_link_redirect_handler(
         )
         await store.delete_discord_link(token)
 
-        response = RedirectResponse(url=grant.next_path, status_code=302)
-        _set_session_cookie(response, session_id)
+        redirect_response = RedirectResponse(url=grant.next_path, status_code=302)
+        _set_session_cookie(redirect_response, session_id)
         await _write_auth_audit_event(
             action="auth.login",
             result=AuditResult.SUCCESS,
@@ -3991,10 +4087,15 @@ async def auth_discord_link_redirect_handler(
             resource_id=session_id,
             correlation_id=token,
         )
-        return response
+        return redirect_response
 
     if session is not None:
-        if not session.email:
+        dev_role_identity = _dev_discord_link_identity_from_roles(
+            discord_user_id=grant.discord_user_id,
+            discord_roles=grant.discord_roles,
+            discord_display_name=grant.discord_display_name,
+        )
+        if not session.email and dev_role_identity is None:
             return JSONResponse(
                 {"error": "forbidden", "detail": "email_claim_required"},
                 status_code=403,
@@ -4002,24 +4103,31 @@ async def auth_discord_link_redirect_handler(
 
         verifier = _discord_admin_verifier_from_app(request.app)
         http_client = _http_client_from_app(request.app)
-        linked = await verifier.is_dashboard_email_for_discord_user(
-            email=session.email,
-            discord_user_id=grant.discord_user_id,
-            http_client=http_client,
-        )
-        if not linked:
-            return JSONResponse(
-                {
-                    "error": "forbidden",
-                    "detail": "oidc_user_not_linked_to_discord_dashboard_user",
-                },
-                status_code=403,
+        linked = False
+        if session.email:
+            linked = await verifier.is_dashboard_email_for_discord_user(
+                email=session.email,
+                discord_user_id=grant.discord_user_id,
+                http_client=http_client,
             )
-
-        identity = await verifier.resolve_dashboard_identity(
-            discord_user_id=grant.discord_user_id,
-            http_client=http_client,
-        )
+        if not linked:
+            if dev_role_identity is not None:
+                identity = dev_role_identity
+            else:
+                return JSONResponse(
+                    {
+                        "error": "forbidden",
+                        "detail": "oidc_user_not_linked_to_discord_dashboard_user",
+                    },
+                    status_code=403,
+                )
+        else:
+            identity = await verifier.resolve_dashboard_identity(
+                discord_user_id=grant.discord_user_id,
+                http_client=http_client,
+            )
+            if identity is None:
+                identity = dev_role_identity
         if identity is None:
             return JSONResponse(
                 {"error": "forbidden", "detail": "discord_user_not_allowed"},
@@ -4282,6 +4390,12 @@ def create_app(*, run_lifespan: bool = True) -> FastAPI:
         "/auth/discord/link/{token}",
         auth_discord_link_redirect_handler,
         methods=["GET"],
+        response_model=None,
+    )
+    app.add_api_route(
+        "/auth/discord/link/{token}/consume",
+        auth_discord_link_consume_handler,
+        methods=["POST"],
         response_model=None,
     )
 

--- a/apps/api/src/five08/backend/auth.py
+++ b/apps/api/src/five08/backend/auth.py
@@ -113,6 +113,8 @@ class DiscordLinkGrant:
 
     discord_user_id: str
     next_path: str
+    discord_roles: list[str] = field(default_factory=list)
+    discord_display_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -221,6 +223,10 @@ class RedisAuthStore:
             return DiscordLinkGrant(
                 discord_user_id=str(value["discord_user_id"]),
                 next_path=str(value["next_path"]),
+                discord_roles=_to_string_list(value.get("discord_roles")),
+                discord_display_name=_to_optional_str(
+                    value.get("discord_display_name")
+                ),
             )
         except Exception:
             logger.warning("Invalid discord-link payload in Redis")

--- a/apps/api/src/five08/backend/dashboard.py
+++ b/apps/api/src/five08/backend/dashboard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from html import escape
 from pathlib import Path
 
 
@@ -192,6 +193,144 @@ def oidc_not_configured_html() -> str:
     <div class="actions">
       <a class="button" href="/dashboard">Back to dashboard</a>
     </div>
+  </main>
+</body>
+</html>
+"""
+
+
+def discord_link_continue_html(*, token: str) -> str:
+    """Return a confirmation page for one-time Discord dashboard links."""
+    form_action = f"/auth/discord/link/{escape(token, quote=True)}/consume"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>Opening Dashboard</title>
+  <style>
+    :root {{
+      color-scheme: dark;
+      --bg: #0f1110;
+      --panel: #181b19;
+      --text: #eceee8;
+      --muted: #9ca39a;
+      --line: #343a33;
+      --accent: #3fbfa8;
+      --accent-strong: #61d9c5;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", sans-serif;
+    }}
+    * {{ box-sizing: border-box; }}
+    body {{
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      background: var(--bg);
+      color: var(--text);
+    }}
+    main {{
+      width: min(520px, 100%);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 28px;
+      display: grid;
+      gap: 16px;
+    }}
+    h1, p {{ margin: 0; }}
+    h1 {{ font-size: 22px; letter-spacing: 0; }}
+    p {{ color: var(--muted); line-height: 1.5; }}
+    button {{
+      min-height: 40px;
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      background: var(--accent);
+      color: #071512;
+      padding: 9px 14px;
+      font-weight: 800;
+      font-size: 13px;
+      cursor: pointer;
+    }}
+    button:hover {{ border-color: var(--accent-strong); background: var(--accent-strong); }}
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Opening the operations dashboard</h1>
+    <p>This one-time Discord login link is being used now. If nothing happens, continue manually.</p>
+    <form id="discord-link-consume" method="post" action="{form_action}">
+      <button type="submit">Continue now</button>
+    </form>
+  </main>
+  <script>
+    window.setTimeout(() => {{
+      document.getElementById("discord-link-consume")?.requestSubmit();
+    }}, 150);
+  </script>
+</body>
+</html>
+"""
+
+
+def discord_link_unavailable_html() -> str:
+    """Return a browser-friendly page for expired or already-used Discord links."""
+    return """<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="referrer" content="no-referrer">
+  <title>Dashboard Link Expired</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0f1110;
+      --panel: #181b19;
+      --text: #eceee8;
+      --muted: #9ca39a;
+      --line: #343a33;
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+        "Segoe UI", sans-serif;
+    }
+    * { box-sizing: border-box; }
+    body {
+      min-height: 100vh;
+      margin: 0;
+      display: grid;
+      place-items: center;
+      padding: 24px;
+      background: var(--bg);
+      color: var(--text);
+    }
+    main {
+      width: min(560px, 100%);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      background: var(--panel);
+      padding: 28px;
+      display: grid;
+      gap: 16px;
+    }
+    h1, p { margin: 0; }
+    h1 { font-size: 22px; letter-spacing: 0; }
+    p { color: var(--muted); line-height: 1.5; }
+    code {
+      color: var(--text);
+      background: #222720;
+      border: 1px solid var(--line);
+      border-radius: 6px;
+      padding: 2px 6px;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>This dashboard link is no longer available</h1>
+    <p>For security, Discord dashboard links are one-time use and expire quickly. In Discord, run <code>/dashboard-login</code> again and open the new link.</p>
   </main>
 </body>
 </html>

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -134,7 +134,9 @@ Relevant configuration:
   - Required role: validated by the backend against active CRM-linked Discord roles. Steering Committee+ can access CRM/onboarding dashboard views; Admin/Owner roles can receive admin permissions, with sensitive job/audit/sync views requiring SSO validation.
   - Behavior:
     - Calls backend `POST /auth/discord/links` using `API_SHARED_SECRET`.
+    - Sends the invoking member's Discord role names so local/dev/test backends can authorize links when the local people cache is empty.
     - Returns an ephemeral one-time URL with expiry.
+    - Opening the URL loads a short browser page that automatically continues with a POST. The link is not consumed by the initial GET, so normal Discord link previews and security scanners do not burn the token.
 
 - `/create-mailbox`
   - Description: Create a Migadu mailbox for a 508 user, optionally link it to a CRM contact, and sync `c508Email`.

--- a/apps/discord_bot/src/five08/discord_bot/cogs/admin_login.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/admin_login.py
@@ -34,8 +34,18 @@ class AdminLoginCog(DiscordAuditCogMixin, commands.Cog):
             "Content-Type": "application/json",
         }
 
-    async def _create_login_link(self, *, discord_user_id: str) -> tuple[str, int]:
-        payload = {"discord_user_id": discord_user_id}
+    async def _create_login_link(
+        self,
+        *,
+        discord_user_id: str,
+        discord_display_name: str | None = None,
+        discord_roles: list[str] | None = None,
+    ) -> tuple[str, int]:
+        payload = {
+            "discord_user_id": discord_user_id,
+            "discord_display_name": discord_display_name,
+            "discord_roles": discord_roles or [],
+        }
         async with aiohttp.ClientSession() as session:
             async with session.post(
                 self._backend_url("/auth/discord/links"),
@@ -107,8 +117,20 @@ class AdminLoginCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         try:
+            raw_roles = getattr(interaction.user, "roles", [])
+            discord_roles = [
+                str(getattr(role, "name", "")).strip()
+                for role in raw_roles
+                if str(getattr(role, "name", "")).strip()
+            ]
+            raw_display_name = getattr(interaction.user, "display_name", None)
+            discord_display_name = (
+                str(raw_display_name).strip() if raw_display_name is not None else None
+            )
             link_url, expires_in_seconds = await self._create_login_link(
                 discord_user_id=str(interaction.user.id),
+                discord_display_name=discord_display_name or None,
+                discord_roles=discord_roles,
             )
         except ValueError as exc:
             self._audit(

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -117,7 +117,8 @@ PY
 - `GET /auth/me`: Return active session identity.
 - `POST /auth/logout`: Clear active session cookie + server session.
 - `POST /auth/discord/links`: Create one-time dashboard deep link from Discord command context.
-- `GET /auth/discord/link/{token}`: Resolve Discord deep link into authenticated dashboard redirect.
+- `GET /auth/discord/link/{token}`: Show a no-store confirmation page for a Discord dashboard deep link without consuming the token.
+- `POST /auth/discord/link/{token}/consume`: Consume the one-time Discord dashboard deep link and redirect to the authenticated dashboard session.
 - Auth flows emit best-effort human audit events (`auth.login`, `auth.logout`) under source `admin_dashboard`.
 
 Discord deep-link identity policy:
@@ -126,8 +127,10 @@ Discord deep-link identity policy:
 - `DISCORD_ADMIN_ROLES` controls which Discord roles can receive admin dashboard permissions (`Admin,Owner` recommended).
 - `OIDC_ADMIN_GROUPS` controls normal OIDC dashboard admin membership (`authentik Admins` recommended).
 - `AUTH_SESSION_TTL_SECONDS` controls dashboard session lifetime after login (`86400`, one day, by default).
+- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=true` (default): Discord deep links also require OIDC email identity checks against the linked CRM/Discord dashboard user.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=false`: Discord deep links create a Discord-backed session directly after re-validating active CRM membership + Discord Steering Committee+ role, without forcing an OIDC roundtrip.
+- In local/dev/test only, the trusted Discord bot role context can create and consume a dashboard link when the local `people` cache has no matching CRM-linked row. Production still requires the normal CRM/people identity.
 - Jobs, reruns, people sync, and audit are sensitive admin permissions and require an SSO-validated dashboard session even when the user entered through a Discord link. Local/dev/test environments allow these permissions for development.
 
 ### Current API/Worker behavior

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -249,9 +249,9 @@ def main() -> int:
     env.setdefault("PYTHONUNBUFFERED", "1")
 
     print("Launching host-run services with shared worktree env:")
-    print(f"  Web:      {env.get('BACKEND_API_BASE_URL', '')}")
-    print(f"  Worker:   {env.get('WORKER_API_BASE_URL', '')}")
-    print(f"  Bot:      {env.get('DISCORD_BOT_INTERNAL_BASE_URL', '')}")
+    print(f"  Web/API listener:     {env.get('BACKEND_API_BASE_URL', '')}")
+    print(f"  Bot health listener:  {env.get('DISCORD_BOT_INTERNAL_BASE_URL', '')}")
+    print("  Worker listener:      none (queue consumer)")
     print()
 
     ports_ok, port_error = _ensure_ports_available(env)

--- a/tests/unit/test_admin_login_cog.py
+++ b/tests/unit/test_admin_login_cog.py
@@ -18,6 +18,7 @@ def mock_interaction() -> AsyncMock:
     interaction.followup.send = AsyncMock()
     interaction.user = Mock()
     interaction.user.id = 123456789
+    interaction.user.display_name = "Admin User"
     role = Mock()
     role.name = "Admin"
     interaction.user.roles = [role]
@@ -110,7 +111,11 @@ async def test_dashboard_login_command_defers_admin_check_to_backend(
         await cog.dashboard_login.callback(cog, mock_interaction)
 
     mock_interaction.response.defer.assert_awaited_once_with(ephemeral=True)
-    mock_create.assert_awaited_once_with(discord_user_id="123456789")
+    mock_create.assert_awaited_once_with(
+        discord_user_id="123456789",
+        discord_display_name="Admin User",
+        discord_roles=["Admin"],
+    )
     sent_message = mock_interaction.followup.send.call_args.args[0]
     assert "https://dash.508.dev/auth/discord/link/token" in sent_message
 

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -3206,6 +3206,41 @@ def test_auth_discord_link_create_returns_url_for_admin(
     assert payload["link_url"].startswith("https://dash.508.dev/auth/discord/link/")
 
 
+def test_auth_discord_link_create_allows_local_role_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "local")
+    fake_store = _FakeAuthStore()
+    fake_verifier = Mock()
+    fake_verifier.is_dashboard_discord_user = AsyncMock(return_value=False)
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=fake_store),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=fake_verifier,
+        ),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+    ):
+        response = client.post(
+            "/auth/discord/links",
+            json={
+                "discord_user_id": "123456",
+                "discord_display_name": "Local Admin",
+                "discord_roles": ["Admin"],
+            },
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 201
+    saved_link = next(iter(fake_store.saved_links.values()))
+    assert isinstance(saved_link, api.DiscordLinkGrant)
+    assert saved_link.discord_roles == ["Admin"]
+    assert saved_link.discord_display_name == "Local Admin"
+
+
 def test_auth_callback_success_writes_login_audit(client: TestClient) -> None:
     store = Mock()
     store.pop_oidc_state = AsyncMock(
@@ -3389,6 +3424,76 @@ def test_auth_callback_discord_link_uses_discord_session_after_oidc_checks(
     assert audit_payload.metadata["discord_link_identity_checks_enforced"] is True
 
 
+def test_auth_callback_discord_link_allows_local_role_fallback_with_oidc_checks(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "local")
+    monkeypatch.setattr(api.settings, "discord_link_require_oidc_identity_checks", True)
+    store = Mock()
+    store.pop_oidc_state = AsyncMock(
+        return_value=api.PendingOIDCState(
+            nonce="nonce-1",
+            code_verifier="verifier-1",
+            next_path="/dashboard",
+            discord_link_token="link-1",
+        )
+    )
+    store.get_discord_link = AsyncMock(
+        return_value=api.DiscordLinkGrant(
+            discord_user_id="123456789",
+            next_path="/dashboard",
+            discord_roles=["Admin"],
+            discord_display_name="Local Admin",
+        )
+    )
+    store.delete_discord_link = AsyncMock()
+    store.save_session = AsyncMock()
+    verifier = Mock()
+    verifier.is_dashboard_email_for_discord_user = AsyncMock(return_value=False)
+    verifier.resolve_dashboard_identity = AsyncMock(return_value=None)
+
+    oidc = Mock()
+    oidc.configured = True
+    oidc.exchange_code = AsyncMock(return_value={"id_token": "id-token-1"})
+    oidc.validate_id_token = AsyncMock(
+        return_value={
+            "sub": "authentik-user-local",
+            "email": "local@508.dev",
+            "name": "Local OIDC User",
+            "groups": ["Member"],
+            "exp": 4_102_444_800,
+        }
+    )
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch("five08.backend.api._oidc_client_from_app", return_value=oidc),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=verifier,
+        ),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        response = client.get(
+            "/auth/callback?code=code-1&state=state-1",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/dashboard"
+    saved_session = store.save_session.call_args.kwargs["payload"]
+    assert saved_session.subject == "123456789"
+    assert saved_session.actor_provider == api.ActorProvider.DISCORD.value
+    assert saved_session.crm_contact_id == ""
+    assert saved_session.email == "local@508.dev"
+    assert saved_session.display_name == "Local Admin"
+    assert saved_session.groups == ["Admin"]
+    assert saved_session.is_admin is True
+    store.delete_discord_link.assert_awaited_once_with("link-1")
+
+
 def test_auth_callback_discord_link_can_skip_oidc_identity_checks(
     monkeypatch: pytest.MonkeyPatch,
     client: TestClient,
@@ -3501,10 +3606,14 @@ def test_auth_discord_link_redirect_creates_discord_session_when_disabled(
         patch("five08.backend.api._http_client_from_app", return_value=Mock()),
         patch("five08.backend.api.insert_audit_event") as mock_insert,
     ):
-        response = client.get("/auth/discord/link/link-1", follow_redirects=False)
+        response = client.post(
+            "/auth/discord/link/link-1/consume",
+            follow_redirects=False,
+        )
 
     assert response.status_code == 302
     assert response.headers["location"] == "/dashboard"
+    assert f"{api.settings.auth_session_cookie_name}=" in response.headers["set-cookie"]
     store.delete_discord_link.assert_awaited_once_with("link-1")
     saved_session = store.save_session.call_args.kwargs["payload"]
     assert saved_session.subject == "123456789"
@@ -3520,6 +3629,127 @@ def test_auth_discord_link_redirect_creates_discord_session_when_disabled(
     assert audit_payload.actor_subject == "123456789"
     assert audit_payload.metadata is not None
     assert audit_payload.metadata["discord_link_identity_checks_enforced"] is False
+
+
+def test_auth_discord_link_consume_allows_local_role_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "local")
+    monkeypatch.setattr(
+        api.settings, "discord_link_require_oidc_identity_checks", False
+    )
+    store = Mock()
+    store.get_discord_link = AsyncMock(
+        return_value=api.DiscordLinkGrant(
+            discord_user_id="123456789",
+            next_path="/dashboard",
+            discord_roles=["Admin"],
+            discord_display_name="Local Admin",
+        )
+    )
+    store.save_session = AsyncMock()
+    store.delete_discord_link = AsyncMock()
+    verifier = Mock()
+    verifier.resolve_dashboard_identity = AsyncMock(return_value=None)
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=verifier,
+        ),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        response = client.post(
+            "/auth/discord/link/link-1/consume",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/dashboard"
+    saved_session = store.save_session.call_args.kwargs["payload"]
+    assert saved_session.subject == "123456789"
+    assert saved_session.display_name == "Local Admin"
+    assert saved_session.groups == ["Admin"]
+    assert saved_session.crm_contact_id == ""
+    assert saved_session.is_admin is True
+    assert "jobs:write" in saved_session.permissions
+
+
+def test_auth_discord_link_get_does_not_consume_token(
+    client: TestClient,
+) -> None:
+    store = Mock()
+    store.get_discord_link = AsyncMock(
+        return_value=api.DiscordLinkGrant(
+            discord_user_id="123456789",
+            next_path="/dashboard",
+        )
+    )
+    store.save_session = AsyncMock()
+    store.delete_discord_link = AsyncMock()
+
+    with patch("five08.backend.api._auth_store_from_app", return_value=store):
+        response = client.get("/auth/discord/link/link-1", follow_redirects=False)
+
+    assert response.status_code == 200
+    assert "/auth/discord/link/link-1/consume" in response.text
+    assert "Opening the operations dashboard" in response.text
+    assert "requestSubmit()" in response.text
+    assert response.headers["cache-control"] == "no-store"
+    store.save_session.assert_not_awaited()
+    store.delete_discord_link.assert_not_awaited()
+
+
+def test_auth_discord_link_missing_token_returns_friendly_html(
+    client: TestClient,
+) -> None:
+    store = Mock()
+    store.get_discord_link = AsyncMock(return_value=None)
+
+    with patch("five08.backend.api._auth_store_from_app", return_value=store):
+        response = client.get("/auth/discord/link/missing-link", follow_redirects=False)
+
+    assert response.status_code == 404
+    assert "This dashboard link is no longer available" in response.text
+    assert "/dashboard-login" in response.text
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_auth_discord_link_missing_token_can_return_json(
+    client: TestClient,
+) -> None:
+    store = Mock()
+    store.get_discord_link = AsyncMock(return_value=None)
+
+    with patch("five08.backend.api._auth_store_from_app", return_value=store):
+        response = client.get(
+            "/auth/discord/link/missing-link",
+            headers={"Accept": "application/json"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 404
+    assert response.json()["error"] == "link_not_found"
+
+
+def test_auth_discord_link_consume_missing_token_returns_friendly_html(
+    client: TestClient,
+) -> None:
+    store = Mock()
+    store.get_discord_link = AsyncMock(return_value=None)
+
+    with patch("five08.backend.api._auth_store_from_app", return_value=store):
+        response = client.post(
+            "/auth/discord/link/missing-link/consume",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 404
+    assert "This dashboard link is no longer available" in response.text
+    assert "/dashboard-login" in response.text
 
 
 def test_auth_discord_link_redirect_upgrades_existing_oidc_session(
@@ -3569,7 +3799,10 @@ def test_auth_discord_link_redirect_upgrades_existing_oidc_session(
         patch("five08.backend.api._http_client_from_app", return_value=Mock()),
         patch("five08.backend.api.insert_audit_event") as mock_insert,
     ):
-        response = client.get("/auth/discord/link/link-1", follow_redirects=False)
+        response = client.post(
+            "/auth/discord/link/link-1/consume",
+            follow_redirects=False,
+        )
 
     assert response.status_code == 302
     assert response.headers["location"] == "/dashboard"
@@ -3589,6 +3822,69 @@ def test_auth_discord_link_redirect_upgrades_existing_oidc_session(
     assert audit_payload.actor_subject == "123456789"
     assert audit_payload.metadata is not None
     assert audit_payload.metadata["upgraded_existing_session"] is True
+
+
+def test_auth_discord_link_existing_session_allows_local_role_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "local")
+    monkeypatch.setattr(api.settings, "discord_link_require_oidc_identity_checks", True)
+    store = Mock()
+    store.get_discord_link = AsyncMock(
+        return_value=api.DiscordLinkGrant(
+            discord_user_id="123456789",
+            next_path="/dashboard",
+            discord_roles=["Admin"],
+            discord_display_name="Local Admin",
+        )
+    )
+    store.save_session = AsyncMock()
+    store.delete_discord_link = AsyncMock()
+    session = api.AuthSession(
+        subject="authentik-user-1",
+        email="local@508.dev",
+        display_name="Local OIDC",
+        groups=["Member"],
+        is_admin=False,
+        id_token="id-token-1",
+        expires_at=4_102_444_800,
+    )
+    verifier = Mock()
+    verifier.is_dashboard_email_for_discord_user = AsyncMock(return_value=False)
+    verifier.resolve_dashboard_identity = AsyncMock(return_value=None)
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch(
+            "five08.backend.api._current_session",
+            new_callable=AsyncMock,
+            return_value=("session-1", session),
+        ),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=verifier,
+        ),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        response = client.post(
+            "/auth/discord/link/link-1/consume",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["location"] == "/dashboard"
+    saved_session = store.save_session.call_args.kwargs["payload"]
+    assert store.save_session.call_args.kwargs["session_id"] == "session-1"
+    assert saved_session.subject == "123456789"
+    assert saved_session.email is None
+    assert saved_session.display_name == "Local Admin"
+    assert saved_session.groups == ["Admin"]
+    assert saved_session.crm_contact_id == ""
+    assert saved_session.is_admin is True
+    assert "jobs:write" in saved_session.permissions
+    store.delete_discord_link.assert_awaited_once_with("link-1")
 
 
 def test_auth_logout_writes_logout_audit(client: TestClient) -> None:


### PR DESCRIPTION
## Summary

- Change Discord dashboard login links so the initial `GET /auth/discord/link/{token}` renders a no-store browser page and does not consume the one-time token.
- Add a JavaScript auto-POST to `/auth/discord/link/{token}/consume`, with a manual fallback button, so normal users continue without an extra click while Discord previews and basic link scanners do not burn the token.
- Replace raw `{"error":"link_not_found"}` browser failures with a friendly expired/used-link page that tells users to run `/dashboard-login` again.
- Add a local/dev/test-only fallback that trusts the Discord bot's gateway role context when the local `people` cache has no matching CRM-linked row; production still requires the normal CRM/people identity.
- Clean up the host dev launcher banner so it no longer prints `WORKER_API_BASE_URL` as if the worker were listening on the API port.

## Root Cause

The original one-time Discord dashboard link was consumed by a GET request. Link previews or security scanners could request the URL, follow the redirect without preserving the browser session cookie, and burn the token before the user opened it. Separately, local testing denied `/dashboard-login` when the local people cache lacked a CRM-linked row even if Discord roles were correct.

## Validation

- `uv run pytest tests/unit/test_backend_api.py tests/unit/test_admin_login_cog.py -q`
- `./scripts/lint.sh`
- `./scripts/mypy.sh`
- `python3 -m py_compile scripts/dev_mux.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Discord dashboard login links now display a confirmation page before completing authentication, with improved handling for expired or unavailable tokens.

* **Documentation**
  * Updated environment configuration documentation and authentication flow guides for Discord dashboard link generation and setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/508-dev/508-workflows/pull/287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->