### PR TITLE
[codex] Fix dashboard session and ERP project sync retention

### DIFF
--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -680,20 +680,47 @@ async def _sync_discord_gig_thread_status(
     return cast(dict[str, Any], payload)
 
 
+MAX_SESSION_COOKIE_CANDIDATES = 5
+
+
 async def _current_session(request: Request) -> tuple[str | None, AuthSession | None]:
     store = _auth_store_from_app(request.app)
     if store is None:
         return None, None
 
-    session_id = request.cookies.get(settings.auth_session_cookie_name)
-    if not session_id:
+    session_ids = _session_cookie_values(request)
+    if not session_ids:
         return None, None
 
-    session = await store.get_session(session_id)
-    if session is None:
-        return session_id, None
+    for session_id in session_ids:
+        session = await store.get_session(session_id)
+        if session is not None:
+            return session_id, session
 
-    return session_id, session
+    return session_ids[0], None
+
+
+def _session_cookie_values(request: Request) -> list[str]:
+    """Return bounded, de-duplicated session cookie values in browser order."""
+    cookie_name = settings.auth_session_cookie_name
+    values: list[str] = []
+
+    def append_candidate(value: str | None) -> None:
+        if (
+            value
+            and value not in values
+            and len(values) < MAX_SESSION_COOKIE_CANDIDATES
+        ):
+            values.append(value)
+
+    raw_cookie = request.headers.get("cookie", "")
+    for item in raw_cookie.split(";"):
+        name, separator, value = item.strip().partition("=")
+        if separator and name == cookie_name:
+            append_candidate(value)
+
+    append_candidate(request.cookies.get(cookie_name))
+    return values
 
 
 def _has_sso_validated_session(session: AuthSession) -> bool:
@@ -1907,6 +1934,7 @@ def _set_session_cookie(response: Response, session_id: str) -> None:
 
 def _clear_session_cookie(response: Response) -> None:
     response.delete_cookie(key=settings.auth_session_cookie_name, path="/")
+    response.delete_cookie(key=settings.auth_session_cookie_name, path="/dashboard")
 
 
 async def _write_auth_audit_event(
@@ -5056,12 +5084,7 @@ async def auth_callback_handler(
         await store.delete_discord_link(pending.discord_link_token)
 
     now = int(time.time())
-    max_session_expiry = now + max(1, settings.auth_session_ttl_seconds)
-    raw_exp = claims.get("exp")
-    token_expiry = max_session_expiry
-    if isinstance(raw_exp, int):
-        token_expiry = raw_exp
-    expires_at = min(token_expiry, max_session_expiry)
+    expires_at = now + max(1, settings.auth_session_ttl_seconds)
 
     session_id = secrets.token_urlsafe(32)
     await store.save_session(

--- a/apps/worker/src/five08/worker/erpnext_project_sync.py
+++ b/apps/worker/src/five08/worker/erpnext_project_sync.py
@@ -14,6 +14,9 @@ from five08.projects import (
 from five08.worker.config import settings
 
 logger = logging.getLogger(__name__)
+# ERPNext/Frappe list APIs commonly cap limit_page_length around 20. Matching
+# that cap keeps server-capped pages from looking like the final page early.
+PROJECT_LIST_PAGE_LIMIT = 20
 
 
 class ERPNextProjectSyncProcessor:
@@ -32,7 +35,7 @@ class ERPNextProjectSyncProcessor:
 
     def sync_open_projects(self) -> dict[str, Any]:
         """Sync all open ERPNext projects and their Project.users roster."""
-        project_limit = 500
+        project_limit = PROJECT_LIST_PAGE_LIMIT
         synced_count = 0
         failed_project_ids: list[str] = []
         roster_member_count = 0

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -502,13 +502,7 @@ def list_dashboard_projects(
                         or shaped_member.get("source_user_id")
                         or shaped_member.get("email"),
                     )
-                    supplier_id = source_payload.get(
-                        "supplier_erpnext_id"
-                    ) or _active_supplier_id_for_roster_member(
-                        settings,
-                        shaped_member,
-                        source_payload,
-                    )
+                    supplier_id = source_payload.get("supplier_erpnext_id")
                     shaped_member["supplier_erpnext_url"] = _erpnext_record_url(
                         settings,
                         "supplier",

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -1587,6 +1587,87 @@ def test_dashboard_clears_stale_session_cookie(client: TestClient) -> None:
     assert "Max-Age=0" in set_cookie
 
 
+def test_current_session_accepts_valid_duplicate_session_cookie(
+    app: api.FastAPI,
+) -> None:
+    valid_session = api.AuthSession(
+        subject="admin-user",
+        email="admin@508.dev",
+        display_name="Admin User",
+        groups=["Admin"],
+        is_admin=True,
+        id_token="id-token-1",
+        expires_at=4_102_444_800,
+    )
+
+    class Store(_FakeAuthStore):
+        async def get_session(self, session_id: str) -> api.AuthSession | None:
+            if session_id == "valid-session":
+                return valid_session
+            return None
+
+    app.state.auth_store = Store()
+    client = TestClient(app)
+
+    response = client.get(
+        "/dashboard/api/me",
+        headers={
+            "Cookie": (
+                f"{api.settings.auth_session_cookie_name}=stale-session; "
+                f"{api.settings.auth_session_cookie_name}=valid-session"
+            )
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["subject"] == "admin-user"
+
+
+def test_current_session_deduplicates_and_caps_duplicate_session_cookies(
+    app: api.FastAPI,
+) -> None:
+    class Store(_FakeAuthStore):
+        def __init__(self) -> None:
+            super().__init__()
+            self.session_ids: list[str] = []
+
+        async def get_session(self, session_id: str) -> api.AuthSession | None:
+            self.session_ids.append(session_id)
+            return None
+
+    store = Store()
+    app.state.auth_store = store
+    client = TestClient(app)
+
+    cookie_values = [
+        "stale-session-1",
+        "stale-session-1",
+        "stale-session-2",
+        "stale-session-3",
+        "stale-session-4",
+        "stale-session-5",
+        "stale-session-6",
+    ]
+    response = client.get(
+        "/dashboard/api/me",
+        headers={
+            "Cookie": "; ".join(
+                f"{api.settings.auth_session_cookie_name}={value}"
+                for value in cookie_values
+            )
+        },
+    )
+
+    assert response.status_code == 401
+    assert store.session_ids == [
+        "stale-session-1",
+        "stale-session-2",
+        "stale-session-3",
+        "stale-session-4",
+        "stale-session-5",
+    ]
+
+
 def test_dashboard_forbids_non_admin_session(client: TestClient) -> None:
     session = api.AuthSession(
         subject="member-1",
@@ -4357,6 +4438,53 @@ def test_auth_callback_success_writes_login_audit(client: TestClient) -> None:
     assert audit_payload.actor_subject == "admin@508.dev"
     assert audit_payload.metadata is not None
     assert "discord_link_identity_checks_enforced" not in audit_payload.metadata
+
+
+def test_auth_callback_uses_configured_session_ttl_not_id_token_expiry(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "auth_session_ttl_seconds", 3600)
+    store = Mock()
+    store.pop_oidc_state = AsyncMock(
+        return_value=api.PendingOIDCState(
+            nonce="nonce-1",
+            code_verifier="verifier-1",
+            next_path="/dashboard",
+            discord_link_token=None,
+        )
+    )
+    store.save_session = AsyncMock()
+
+    oidc = Mock()
+    oidc.configured = True
+    oidc.exchange_code = AsyncMock(return_value={"id_token": "id-token-1"})
+    oidc.validate_id_token = AsyncMock(
+        return_value={
+            "sub": "authentik-user-1",
+            "email": "Admin@508.dev",
+            "name": "Admin User",
+            "groups": ["Admin"],
+            "exp": 1010,
+        }
+    )
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch("five08.backend.api._oidc_client_from_app", return_value=oidc),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch("five08.backend.api.insert_audit_event"),
+        patch("five08.backend.api.time.time", return_value=1000),
+    ):
+        response = client.get(
+            "/auth/callback?code=code-1&state=state-1",
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    saved_session = store.save_session.call_args.kwargs["payload"]
+    assert saved_session.expires_at == 4600
+    assert store.save_session.call_args.kwargs["ttl_seconds"] == 3600
 
 
 def test_auth_callback_denied_writes_login_audit(client: TestClient) -> None:

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -251,7 +251,7 @@ def test_list_dashboard_projects_does_not_guess_supplier_link_from_full_name() -
     assert "source_payload" not in member
 
 
-def test_list_dashboard_projects_resolves_supplier_link_from_crm_email() -> None:
+def test_list_dashboard_projects_uses_stored_supplier_link() -> None:
     project_id = "11111111-1111-4111-8111-111111111111"
 
     class Cursor:
@@ -299,7 +299,7 @@ def test_list_dashboard_projects_resolves_supplier_link_from_crm_email() -> None
                     "email": "fabien@508.dev",
                     "full_name": "Fabien Rajaonarison",
                     "roster_kind": "erp_users",
-                    "source_payload": {},
+                    "source_payload": {"supplier_erpnext_id": "NAINA CONSULTING"},
                     "last_seen_at": None,
                     "crm_contact_id": "crm-fabien",
                     "crm_email": "fabien@naina.digital",
@@ -317,40 +317,18 @@ def test_list_dashboard_projects_resolves_supplier_link_from_crm_email() -> None
         def cursor(self, *args: object, **kwargs: object) -> Cursor:
             return Cursor()
 
-    class FakeERPNextClient:
-        def __init__(
-            self,
-            base_url: str,
-            api_key: str,
-            timeout_seconds: float,
-        ) -> None:
-            self.base_url = base_url
-
-        def search_suppliers(
-            self,
-            query: str,
-            *,
-            limit: int,
-        ) -> list[dict[str, object]]:
-            assert query == "fabien@naina.digital"
-            assert limit == 1
-            return [{"name": "NAINA CONSULTING"}]
-
-        def close(self) -> None:
-            return None
-
-    projects_module._SUPPLIER_EMAIL_CACHE.clear()
     settings = SharedSettings(
         erpnext_base_url="https://erp.example.test",
         erpnext_api_key="key:secret",
     )
     with (
         patch("five08.projects.get_postgres_connection", return_value=Connection()),
-        patch("five08.projects.ERPNextClient", FakeERPNextClient),
+        patch("five08.projects.ERPNextClient") as mock_erpnext_client,
     ):
         projects = list_dashboard_projects(settings, include_all=True)
 
     member = projects[0]["roster_members"][0]
+    mock_erpnext_client.assert_not_called()
     assert (
         member["supplier_erpnext_url"]
         == "https://erp.example.test/app/supplier/NAINA%20CONSULTING"

--- a/tests/unit/test_worker_erpnext_project_sync.py
+++ b/tests/unit/test_worker_erpnext_project_sync.py
@@ -19,7 +19,7 @@ class FakeERPNextClient:
         offset: int,
     ) -> list[dict[str, Any]]:
         assert status == "Open"
-        assert limit == 500
+        assert limit == erpnext_project_sync.PROJECT_LIST_PAGE_LIMIT
         self.list_offsets.append(offset)
         index = offset // limit
         if index >= len(self.pages):
@@ -71,10 +71,11 @@ def test_sync_open_projects_closes_client_and_marks_missing_open_projects(
 def test_sync_open_projects_paginates_until_short_page(
     monkeypatch,
 ) -> None:
+    page_limit = erpnext_project_sync.PROJECT_LIST_PAGE_LIMIT
     client = FakeERPNextClient(
         [
-            [{"name": f"PROJ-{index:03d}"} for index in range(500)],
-            [{"name": "PROJ-500"}],
+            [{"name": f"PROJ-{index:03d}"} for index in range(page_limit)],
+            [{"name": f"PROJ-{page_limit:03d}"}],
         ]
     )
     processor = erpnext_project_sync.ERPNextProjectSyncProcessor.__new__(
@@ -95,9 +96,10 @@ def test_sync_open_projects_paginates_until_short_page(
     result = processor.sync_open_projects()
 
     assert client.closed is True
-    assert result["seen_count"] == 501
+    assert result["seen_count"] == page_limit + 1
     assert result["stale_open_count"] == 0
-    assert client.list_offsets == [0, 500]
+    assert client.list_offsets == [0, page_limit]
     assert stale_mark_calls == [
-        [f"PROJ-{index:03d}" for index in range(500)] + ["PROJ-500"]
+        [f"PROJ-{index:03d}" for index in range(page_limit)]
+        + [f"PROJ-{page_limit:03d}"]
     ]


### PR DESCRIPTION
## Summary
- Make dashboard OIDC sessions honor `AUTH_SESSION_TTL_SECONDS` instead of shortening to the upstream ID token `exp` claim.
- Make dashboard session lookup tolerate duplicate/stale `five08_session` cookies, de-dupe and cap candidate lookups, and clear both root-path and `/dashboard` cookie variants.
- Lower ERPNext project sync pagination to a conservative documented page size so capped ERPNext list responses do not mark unseen open projects as `Not Open`.
- Stop dashboard project listing from doing synchronous ERPNext supplier lookups; it now uses supplier IDs already present in the local project cache.
- Add regression coverage for short OIDC token expiry, duplicate session cookies, capped duplicate-cookie lookup fanout, ERP project pagination, and cache-only project supplier URLs.

## Root Cause
Dashboard sessions were stored server-side with `expires_at` set to `min(id_token_exp, AUTH_SESSION_TTL_SECONDS)`, so short-lived OIDC ID tokens could force a fast logout. I could not reproduce session loss after API reload with a clean cookie jar: the same `five08_session` survived reload and `/dashboard/api/me` stayed 200. Given the browser-only report, I found a likely failure mode where duplicate cookies with the same name can make the framework read a stale `five08_session` value even while a valid one is also present. The session resolver now checks bounded, de-duplicated same-name cookie candidates against Redis and accepts the first valid server-side session.

ERP project sync also treated any page shorter than the requested 500 rows as the final page; if ERPNext capped page size below 500, projects outside the first capped page could be marked `Not Open` and disappear from the default Open dashboard filter. Separately, project listing performed per-roster-member ERPNext supplier lookups on cache miss; API reload cleared the in-process supplier cache, making the first project request after reload block on external ERP calls.

## Validation
- pre-commit hook during commit/amend: ruff, ruff format, mypy
- `uv run pytest tests/unit/test_backend_api.py`
- `uv run pytest tests/unit/test_worker_erpnext_project_sync.py tests/unit/test_projects.py`
- `uv run pytest tests/unit/test_backend_api.py tests/unit/test_projects.py tests/unit/test_worker_erpnext_project_sync.py` -> 178 passed
- live Conductor repro on `127.0.0.1:55165`: same dashboard cookie survived forced API reload; `/dashboard/api/me` stayed 200.
- live duplicate-cookie repro after forced API reload: both `stale, valid` and `valid, stale` `five08_session` cookie orderings returned 200 from `/dashboard/api/me`.
- live reload retest after user logged back in: forced API child reload from `84165` to `2756`; `/dashboard/api/me` stayed 200; `/dashboard` did not contain login-expired text; project API returned 15 open projects.
- live project reload repro on `127.0.0.1:55165`: first project request after reload returned 15 projects in 0.07s after removing synchronous supplier lookups; previous repro measured 17.4s.

## Notes
Conductor is serving this worktree on the expected host-run port range (`CONDUCTOR_PORT=55160`, dashboard on `127.0.0.1:55165`). The forced-reload touch used for manual QA left no tracked git diff.