### PR TITLE
[codex] Fix dashboard CSRF origin behind proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,7 +106,7 @@ AUTH_SESSION_COOKIE_NAME=five08_session
 # Dashboard session lifetime after a successful login link or OIDC login.
 AUTH_SESSION_TTL_SECONDS=86400
 DASHBOARD_DEFAULT_PATH=/dashboard
-# Optional external base URL for generated deep links
+# Optional external base URL for generated deep links and dashboard CSRF origin checks
 DASHBOARD_PUBLIC_BASE_URL=
 
 # Discord admin link checks (DB-first, Discord API fallback)

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -75,7 +75,7 @@ Discord deep-link identity policy:
 - `DISCORD_ADMIN_ROLES` controls which Discord roles can receive admin dashboard permissions (`Admin,Owner` recommended).
 - `OIDC_ADMIN_GROUPS` controls normal OIDC dashboard admin membership (`authentik Admins` recommended).
 - `AUTH_SESSION_TTL_SECONDS` controls dashboard session lifetime after login (`86400`, one day, by default).
-- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host.
+- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host and dashboard write CSRF checks can accept the public origin when the app is behind a proxy/tunnel.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=true` (default): Discord deep links also require OIDC email identity checks against the linked CRM/Discord dashboard user.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=false`: Discord deep links create a Discord-backed session directly after re-validating active CRM membership + Discord Steering Committee+ role, without forcing an OIDC roundtrip.
 - In local/dev/test only, the trusted Discord bot role context can create and consume a dashboard link when the local `people` cache has no matching CRM-linked row. Production still requires the normal CRM/people identity.

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -1213,18 +1213,32 @@ def _request_origin(request: Request) -> str | None:
     return _origin_from_url(str(request.base_url))
 
 
+def _dashboard_allowed_post_origins(request: Request) -> set[str]:
+    origins: set[str] = set()
+    request_origin = _request_origin(request)
+    if request_origin is not None:
+        origins.add(request_origin)
+
+    public_base_url = (settings.dashboard_public_base_url or "").strip().rstrip("/")
+    public_origin = _origin_from_url(public_base_url)
+    if public_origin is not None:
+        origins.add(public_origin)
+
+    return origins
+
+
 def _dashboard_same_origin_post_or_error(request: Request) -> JSONResponse | None:
-    expected_origin = _request_origin(request)
-    if expected_origin is None:
+    allowed_origins = _dashboard_allowed_post_origins(request)
+    if not allowed_origins:
         return JSONResponse({"error": "invalid_request_origin"}, status_code=403)
 
     origin = request.headers.get("origin")
-    if origin is not None and _origin_from_url(origin) != expected_origin:
+    if origin is not None and _origin_from_url(origin) not in allowed_origins:
         return JSONResponse({"error": "csrf_check_failed"}, status_code=403)
 
     referer = request.headers.get("referer")
     if origin is None and referer is not None:
-        if _origin_from_url(referer) != expected_origin:
+        if _origin_from_url(referer) not in allowed_origins:
             return JSONResponse({"error": "csrf_check_failed"}, status_code=403)
 
     return None

--- a/apps/worker/README.md
+++ b/apps/worker/README.md
@@ -127,7 +127,7 @@ Discord deep-link identity policy:
 - `DISCORD_ADMIN_ROLES` controls which Discord roles can receive admin dashboard permissions (`Admin,Owner` recommended).
 - `OIDC_ADMIN_GROUPS` controls normal OIDC dashboard admin membership (`authentik Admins` recommended).
 - `AUTH_SESSION_TTL_SECONDS` controls dashboard session lifetime after login (`86400`, one day, by default).
-- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host.
+- `DASHBOARD_PUBLIC_BASE_URL` should be set to the public dashboard origin in production, for example `https://workflows.508.dev`, so Discord-created links use the browser-accessible host and dashboard write CSRF checks can accept the public origin when the app is behind a proxy/tunnel.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=true` (default): Discord deep links also require OIDC email identity checks against the linked CRM/Discord dashboard user.
 - `DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=false`: Discord deep links create a Discord-backed session directly after re-validating active CRM membership + Discord Steering Committee+ role, without forcing an OIDC roundtrip.
 - In local/dev/test only, the trusted Discord bot role context can create and consume a dashboard link when the local `people` cache has no matching CRM-linked row. Production still requires the normal CRM/people identity.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,7 +67,7 @@ fields.
 - `WEB_HOST_BIND`
 - `WEB_HOST_PORT`
 - `DASHBOARD_DEFAULT_PATH`
-- `DASHBOARD_PUBLIC_BASE_URL`
+- `DASHBOARD_PUBLIC_BASE_URL` (public browser origin for generated dashboard links and dashboard write CSRF checks)
 
 Deprecated fallback names still work for now:
 

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -5891,6 +5891,48 @@ def test_dashboard_sync_projects_workflows_engineer_is_dry_run(
     mock_insert.assert_not_called()
 
 
+def test_dashboard_sync_projects_accepts_configured_public_origin(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(
+        api.settings, "dashboard_public_base_url", "  https://workflows.508.dev/  "
+    )
+    session = api.AuthSession(
+        subject="admin-1",
+        email="admin@508.dev",
+        display_name="Admin User",
+        groups=["Admins"],
+        is_admin=True,
+        id_token="id-token-1",
+        expires_at=4_102_444_800,
+    )
+
+    with (
+        patch(
+            "five08.backend.api._current_session",
+            new_callable=AsyncMock,
+            return_value=("session-1", session),
+        ),
+        patch(
+            "five08.backend.api._enqueue_erpnext_project_sync_job",
+            new_callable=AsyncMock,
+            return_value=Mock(id="job-sync-1", created=True),
+        ),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        response = client.post(
+            "/dashboard/api/sync/projects",
+            headers={
+                "Origin": "https://workflows.508.dev",
+                "Referer": "https://workflows.508.dev/dashboard/projects",
+            },
+        )
+
+    assert response.status_code == 202
+    assert response.json()["job_id"] == "job-sync-1"
+
+
 def test_dashboard_sync_people_rejects_cross_origin_post(client: TestClient) -> None:
     session = api.AuthSession(
         subject="admin-1",


### PR DESCRIPTION
## Summary
- Accept `DASHBOARD_PUBLIC_BASE_URL` as an allowed dashboard write origin for CSRF checks.
- Preserve the existing request-base-origin behavior for local and direct deployments.
- Document that `DASHBOARD_PUBLIC_BASE_URL` is used for generated links and dashboard CSRF origin checks.

## Root Cause
Dashboard mutating routes compared the browser `Origin` only to `request.base_url`. Behind Coolify and Cloudflare Tunnel, the ASGI app can see an internal HTTP base URL while the browser sends `https://workflows.508.dev`, causing same-site dashboard writes to fail with `csrf_check_failed`.

## Validation
- `git diff --check`
- `uv run pytest tests/unit/test_backend_api.py -k 'csrf or sync_projects_accepts_configured_public_origin or sync_people_rejects_cross_origin_post or rerun_rejects_cross_origin_post'`\n- pre-commit: `ruff`, `ruff format`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `DASHBOARD_PUBLIC_BASE_URL` configuration documentation across all resources to provide clearer guidance on its usage for dashboard links and security origin checks.

* **Improvements**
  * Enhanced dashboard CSRF origin validation to properly support deployments behind proxies and tunnels by accepting both local and configured public origins.

* **Tests**
  * Added unit test coverage for CSRF validation when using configured public origins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/508-dev/508-workflows/pull/299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->