### PR TITLE
[codex] Add self-service ERP payment info command

### DIFF
--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -138,6 +138,15 @@ Relevant configuration:
     - Returns an ephemeral one-time URL with expiry.
     - Opening the URL loads a short browser page that automatically continues with a POST. The link is not consumed by the initial GET, so normal Discord link previews and security scanners do not burn the token.
 
+- `/payment-info`
+  - Description: View masked ERPNext Supplier Details payment info and open a modal to update your own payment details.
+  - Behavior:
+    - Resolves only the invoking Discord user through CRM `cDiscordUserID`.
+    - Requires the linked CRM contact to have a matching `@508.dev` email and ERPNext User/Supplier identity.
+    - Stores updates in the Supplier `supplier_details` field.
+    - Sends all responses ephemerally.
+    - Does not accept a user/contact/supplier argument or provide an admin override path.
+
 - `/create-mailbox`
   - Description: Create a Migadu mailbox for a 508 user, optionally link it to a CRM contact, and sync `c508Email`.
   - Prerequisites: `MIGADU_API_USER` and `MIGADU_API_KEY` must be configured (configured in env; command will fail if missing).

--- a/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
@@ -26,6 +26,7 @@ from five08.payment_info import (
 )
 
 logger = logging.getLogger(__name__)
+NO_MENTIONS = discord.AllowedMentions.none()
 
 
 class PaymentInfoModal(discord.ui.Modal, title="Update Payment Info"):
@@ -48,6 +49,7 @@ class PaymentInfoModal(discord.ui.Modal, title="Update Payment Info"):
         if str(interaction.user.id) != self.owner_user_id:
             await interaction.response.send_message(
                 "This payment-info form belongs to another Discord user.",
+                allowed_mentions=NO_MENTIONS,
                 ephemeral=True,
             )
             return
@@ -82,6 +84,7 @@ class PaymentInfoView(discord.ui.View):
         if str(interaction.user.id) != self.owner_user_id:
             await interaction.response.send_message(
                 "This payment-info view belongs to another Discord user.",
+                allowed_mentions=NO_MENTIONS,
                 ephemeral=True,
             )
             return
@@ -202,7 +205,11 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
                 metadata={"error": str(exc)},
                 resource_type="erpnext_payment_info",
             )
-            await interaction.followup.send(f"⚠️ {exc}", ephemeral=True)
+            await interaction.followup.send(
+                f"⚠️ {exc}",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
             return
         except (ERPNextAPIError, EspoAPIError, ValueError) as exc:
             logger.error("Payment-info lookup failed: %s", exc)
@@ -215,6 +222,7 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
             )
             await interaction.followup.send(
                 "❌ Payment-info lookup failed. Please try again later.",
+                allowed_mentions=NO_MENTIONS,
                 ephemeral=True,
             )
             return
@@ -235,7 +243,7 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
         await interaction.followup.send(
             "\n".join(payment_info_summary(identity, supplier)),
             view=PaymentInfoView(self, str(interaction.user.id)),
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=NO_MENTIONS,
             ephemeral=True,
         )
 
@@ -264,7 +272,11 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
                 metadata={"error": str(exc)},
                 resource_type="erpnext_payment_info",
             )
-            await interaction.followup.send(f"⚠️ {exc}", ephemeral=True)
+            await interaction.followup.send(
+                f"⚠️ {exc}",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
             return
         except (ERPNextAPIError, EspoAPIError, ValueError) as exc:
             logger.error("Payment-info update failed: %s", exc)
@@ -277,6 +289,7 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
             )
             await interaction.followup.send(
                 "❌ Payment-info update failed. Please try again later.",
+                allowed_mentions=NO_MENTIONS,
                 ephemeral=True,
             )
             return
@@ -297,7 +310,7 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
         await interaction.followup.send(
             "✅ Payment info updated.\n"
             + "\n".join(payment_info_summary(identity, supplier)),
-            allowed_mentions=discord.AllowedMentions.none(),
+            allowed_mentions=NO_MENTIONS,
             ephemeral=True,
         )
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
@@ -31,35 +31,12 @@ logger = logging.getLogger(__name__)
 class PaymentInfoModal(discord.ui.Modal, title="Update Payment Info"):
     """Modal for self-service payment-info updates."""
 
-    account_name: discord.ui.TextInput = discord.ui.TextInput(
-        label="Account holder",
-        placeholder="Legal name on the account",
-        required=False,
-        max_length=140,
-    )
-    bank: discord.ui.TextInput = discord.ui.TextInput(
-        label="Bank name",
-        placeholder="Bank name in ERPNext",
-        required=False,
-        max_length=140,
-    )
-    branch_code: discord.ui.TextInput = discord.ui.TextInput(
-        label="Routing / SWIFT / branch code",
-        placeholder="Routing number, SWIFT, or branch code",
-        required=False,
-        max_length=80,
-    )
-    bank_account_no: discord.ui.TextInput = discord.ui.TextInput(
-        label="Account number",
-        placeholder="Full account number",
-        required=False,
-        max_length=120,
-    )
-    iban: discord.ui.TextInput = discord.ui.TextInput(
-        label="IBAN",
-        placeholder="Optional IBAN",
-        required=False,
-        max_length=120,
+    supplier_details: discord.ui.TextInput = discord.ui.TextInput(
+        label="Supplier Details",
+        placeholder="Paste the Supplier Details payment text here.",
+        required=True,
+        style=discord.TextStyle.paragraph,
+        max_length=4000,
     )
 
     def __init__(self, cog: "PaymentInfoCog", owner_user_id: str) -> None:
@@ -79,11 +56,7 @@ class PaymentInfoModal(discord.ui.Modal, title="Update Payment Info"):
         await self.cog.handle_payment_info_update(
             interaction,
             PaymentInfoInput(
-                account_name=str(self.account_name.value or ""),
-                bank=str(self.bank.value or ""),
-                bank_account_no=str(self.bank_account_no.value or ""),
-                branch_code=str(self.branch_code.value or ""),
-                iban=str(self.iban.value or ""),
+                supplier_details=str(self.supplier_details.value or ""),
             ),
         )
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
@@ -1,0 +1,356 @@
+"""Self-service ERPNext payment-info Discord command."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from five08.clients.erpnext import ERPNextAPIError, ERPNextClient
+from five08.clients.espo import EspoAPIError, EspoClient
+from five08.discord_bot.config import settings
+from five08.discord_bot.utils.audit import DiscordAuditCogMixin
+from five08.payment_info import (
+    PaymentIdentity,
+    PaymentInfoError,
+    PaymentInfoInput,
+    get_supplier_payment_details,
+    normalize_508_email,
+    payment_info_summary,
+    resolve_payment_identity,
+    update_supplier_payment_details,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class PaymentInfoModal(discord.ui.Modal, title="Update Payment Info"):
+    """Modal for self-service payment-info updates."""
+
+    account_name: discord.ui.TextInput = discord.ui.TextInput(
+        label="Account holder",
+        placeholder="Legal name on the account",
+        required=False,
+        max_length=140,
+    )
+    bank: discord.ui.TextInput = discord.ui.TextInput(
+        label="Bank name",
+        placeholder="Bank name in ERPNext",
+        required=False,
+        max_length=140,
+    )
+    branch_code: discord.ui.TextInput = discord.ui.TextInput(
+        label="Routing / SWIFT / branch code",
+        placeholder="Routing number, SWIFT, or branch code",
+        required=False,
+        max_length=80,
+    )
+    bank_account_no: discord.ui.TextInput = discord.ui.TextInput(
+        label="Account number",
+        placeholder="Full account number",
+        required=False,
+        max_length=120,
+    )
+    iban: discord.ui.TextInput = discord.ui.TextInput(
+        label="IBAN",
+        placeholder="Optional IBAN",
+        required=False,
+        max_length=120,
+    )
+
+    def __init__(self, cog: "PaymentInfoCog", owner_user_id: str) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.owner_user_id = owner_user_id
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "This payment-info form belongs to another Discord user.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await self.cog.handle_payment_info_update(
+            interaction,
+            PaymentInfoInput(
+                account_name=str(self.account_name.value or ""),
+                bank=str(self.bank.value or ""),
+                bank_account_no=str(self.bank_account_no.value or ""),
+                branch_code=str(self.branch_code.value or ""),
+                iban=str(self.iban.value or ""),
+            ),
+        )
+
+
+class PaymentInfoView(discord.ui.View):
+    """Ephemeral view with a self-only update button."""
+
+    def __init__(self, cog: "PaymentInfoCog", owner_user_id: str) -> None:
+        super().__init__(timeout=300)
+        self.cog = cog
+        self.owner_user_id = owner_user_id
+
+    @discord.ui.button(
+        label="Update Payment Info",
+        style=discord.ButtonStyle.primary,
+        custom_id="payment_info_update_self",
+    )
+    async def update_payment_info(
+        self,
+        interaction: discord.Interaction,
+        _button: discord.ui.Button["PaymentInfoView"],
+    ) -> None:
+        if str(interaction.user.id) != self.owner_user_id:
+            await interaction.response.send_message(
+                "This payment-info view belongs to another Discord user.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(
+            PaymentInfoModal(self.cog, self.owner_user_id)
+        )
+
+
+class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
+    """Cog for users to view and update their own ERPNext payment info."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.crm = EspoClient(
+            settings.espo_base_url,
+            settings.espo_api_key,
+            timeout_seconds=20.0,
+        )
+        self._init_audit_logger()
+        logger.info("Payment Info cog initialized")
+
+    def _erpnext_client(self) -> ERPNextClient:
+        base_url = (settings.erpnext_base_url or "").strip()
+        api_key = (settings.erpnext_api_key or "").strip()
+        if not base_url or not api_key:
+            raise ValueError("ERPNext API settings are required.")
+        return ERPNextClient(
+            base_url=base_url,
+            api_key=api_key,
+            timeout_seconds=settings.erpnext_api_timeout_seconds,
+        )
+
+    def _crm_contact_for_discord_user(
+        self,
+        discord_user_id: str,
+    ) -> dict[str, Any]:
+        response = self.crm.list_contacts(
+            {
+                "where": [
+                    {
+                        "type": "equals",
+                        "attribute": "cDiscordUserID",
+                        "value": discord_user_id,
+                    }
+                ],
+                "maxSize": 2,
+                "select": "id,name,emailAddress,c508Email,cDiscordUserID",
+            }
+        )
+        contacts = response.get("list", [])
+        if not isinstance(contacts, list) or not contacts:
+            raise PaymentInfoError(
+                "Your Discord account is not linked to a CRM contact yet."
+            )
+        if len(contacts) > 1:
+            raise PaymentInfoError(
+                "Your Discord account is linked to multiple CRM contacts. "
+                "Ask the operations team to fix the CRM links first."
+            )
+        contact = contacts[0]
+        if not isinstance(contact, dict):
+            raise PaymentInfoError("CRM returned an invalid contact record.")
+        linked_discord_id = str(contact.get("cDiscordUserID") or "").strip()
+        if linked_discord_id != discord_user_id:
+            raise PaymentInfoError("CRM Discord link did not match your Discord user.")
+        return contact
+
+    def _resolve_self_identity(
+        self,
+        discord_user_id: str,
+    ) -> tuple[dict[str, Any], PaymentIdentity]:
+        contact = self._crm_contact_for_discord_user(discord_user_id)
+        email = normalize_508_email(contact.get("c508Email"))
+        client = self._erpnext_client()
+        try:
+            identity = resolve_payment_identity(client, email)
+        finally:
+            client.close()
+        return contact, identity
+
+    def _read_self_payment_info(
+        self,
+        discord_user_id: str,
+    ) -> tuple[dict[str, Any], PaymentIdentity, dict[str, Any]]:
+        contact = self._crm_contact_for_discord_user(discord_user_id)
+        email = normalize_508_email(contact.get("c508Email"))
+        client = self._erpnext_client()
+        try:
+            identity = resolve_payment_identity(client, email)
+            supplier = get_supplier_payment_details(client, identity)
+        finally:
+            client.close()
+        return contact, identity, supplier
+
+    def _update_self_payment_info(
+        self,
+        discord_user_id: str,
+        payment_info: PaymentInfoInput,
+    ) -> tuple[dict[str, Any], PaymentIdentity, dict[str, Any], list[str]]:
+        contact = self._crm_contact_for_discord_user(discord_user_id)
+        email = normalize_508_email(contact.get("c508Email"))
+        client = self._erpnext_client()
+        try:
+            identity = resolve_payment_identity(client, email)
+            supplier, changed_fields = update_supplier_payment_details(
+                client,
+                identity,
+                payment_info,
+            )
+        finally:
+            client.close()
+        return contact, identity, supplier, changed_fields
+
+    @app_commands.command(
+        name="payment-info",
+        description="View or update your own ERPNext payment info.",
+    )
+    async def payment_info_command(self, interaction: discord.Interaction) -> None:
+        """Show the invoking user's own payment info, masked."""
+        await interaction.response.defer(ephemeral=True)
+        try:
+            contact, identity, supplier = await asyncio.to_thread(
+                self._read_self_payment_info,
+                str(interaction.user.id),
+            )
+        except PaymentInfoError as exc:
+            self._audit_command_safe(
+                interaction=interaction,
+                action="erpnext.payment_info_view",
+                result="denied",
+                metadata={"error": str(exc)},
+                resource_type="erpnext_payment_info",
+            )
+            await interaction.followup.send(f"⚠️ {exc}", ephemeral=True)
+            return
+        except (ERPNextAPIError, EspoAPIError, ValueError) as exc:
+            logger.error("Payment-info lookup failed: %s", exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="erpnext.payment_info_view",
+                result="error",
+                metadata={"error": str(exc)},
+                resource_type="erpnext_payment_info",
+            )
+            await interaction.followup.send(
+                "❌ Payment-info lookup failed. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        self._audit_command_safe(
+            interaction=interaction,
+            action="erpnext.payment_info_view",
+            result="success",
+            metadata={
+                "crm_contact_id": contact.get("id"),
+                "erpnext_user": identity.email,
+                "supplier_id": identity.supplier_id,
+                "has_supplier_details": bool(supplier.get("supplier_details")),
+            },
+            resource_type="erpnext_supplier",
+            resource_id=identity.supplier_id,
+        )
+        await interaction.followup.send(
+            "\n".join(payment_info_summary(identity, supplier)),
+            view=PaymentInfoView(self, str(interaction.user.id)),
+            ephemeral=True,
+        )
+
+    async def handle_payment_info_update(
+        self,
+        interaction: discord.Interaction,
+        payment_info: PaymentInfoInput,
+    ) -> None:
+        """Apply a modal payment-info update for the invoking user."""
+        try:
+            (
+                contact,
+                identity,
+                supplier,
+                changed_fields,
+            ) = await asyncio.to_thread(
+                self._update_self_payment_info,
+                str(interaction.user.id),
+                payment_info,
+            )
+        except PaymentInfoError as exc:
+            self._audit_command_safe(
+                interaction=interaction,
+                action="erpnext.payment_info_update",
+                result="denied",
+                metadata={"error": str(exc)},
+                resource_type="erpnext_payment_info",
+            )
+            await interaction.followup.send(f"⚠️ {exc}", ephemeral=True)
+            return
+        except (ERPNextAPIError, EspoAPIError, ValueError) as exc:
+            logger.error("Payment-info update failed: %s", exc)
+            self._audit_command_safe(
+                interaction=interaction,
+                action="erpnext.payment_info_update",
+                result="error",
+                metadata={"error": str(exc)},
+                resource_type="erpnext_payment_info",
+            )
+            await interaction.followup.send(
+                "❌ Payment-info update failed. Please try again later.",
+                ephemeral=True,
+            )
+            return
+
+        self._audit_command_safe(
+            interaction=interaction,
+            action="erpnext.payment_info_update",
+            result="success",
+            metadata={
+                "crm_contact_id": contact.get("id"),
+                "erpnext_user": identity.email,
+                "supplier_id": identity.supplier_id,
+                "changed_fields": changed_fields,
+            },
+            resource_type="erpnext_supplier",
+            resource_id=identity.supplier_id,
+        )
+        await interaction.followup.send(
+            "✅ Payment info updated.\n"
+            + "\n".join(payment_info_summary(identity, supplier)),
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    if not all(
+        [
+            settings.espo_base_url,
+            settings.espo_api_key,
+            settings.erpnext_base_url,
+            settings.erpnext_api_key,
+        ]
+    ):
+        logger.warning(
+            "Payment Info cog not loaded: missing CRM or ERPNext API settings"
+        )
+        return
+    await bot.add_cog(PaymentInfoCog(bot))

--- a/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/payment_info.py
@@ -149,19 +149,6 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
             raise PaymentInfoError("CRM Discord link did not match your Discord user.")
         return contact
 
-    def _resolve_self_identity(
-        self,
-        discord_user_id: str,
-    ) -> tuple[dict[str, Any], PaymentIdentity]:
-        contact = self._crm_contact_for_discord_user(discord_user_id)
-        email = normalize_508_email(contact.get("c508Email"))
-        client = self._erpnext_client()
-        try:
-            identity = resolve_payment_identity(client, email)
-        finally:
-            client.close()
-        return contact, identity
-
     def _read_self_payment_info(
         self,
         discord_user_id: str,
@@ -248,6 +235,7 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
         await interaction.followup.send(
             "\n".join(payment_info_summary(identity, supplier)),
             view=PaymentInfoView(self, str(interaction.user.id)),
+            allowed_mentions=discord.AllowedMentions.none(),
             ephemeral=True,
         )
 
@@ -309,18 +297,19 @@ class PaymentInfoCog(DiscordAuditCogMixin, commands.Cog, name="Payment Info"):
         await interaction.followup.send(
             "✅ Payment info updated.\n"
             + "\n".join(payment_info_summary(identity, supplier)),
+            allowed_mentions=discord.AllowedMentions.none(),
             ephemeral=True,
         )
 
 
 async def setup(bot: commands.Bot) -> None:
     if not all(
-        [
-            settings.espo_base_url,
-            settings.espo_api_key,
-            settings.erpnext_base_url,
-            settings.erpnext_api_key,
-        ]
+        (
+            (settings.espo_base_url or "").strip(),
+            (settings.espo_api_key or "").strip(),
+            (settings.erpnext_base_url or "").strip(),
+            (settings.erpnext_api_key or "").strip(),
+        )
     ):
         logger.warning(
             "Payment Info cog not loaded: missing CRM or ERPNext API settings"

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -117,7 +117,7 @@ def update_supplier_payment_details(
     payment_info: PaymentInfoInput,
 ) -> tuple[dict[str, Any], list[str]]:
     """Replace the managed payment block inside Supplier.supplier_details."""
-    payment_details = _text(payment_info.supplier_details)
+    payment_details = _normalize_payment_details(payment_info.supplier_details)
     if payment_details is None:
         raise PaymentInfoError("Enter Supplier Details to update.")
 
@@ -172,15 +172,42 @@ def _replace_payment_info_block(existing_details: str, payment_details: str) -> 
     if not existing_details:
         return payment_block
 
-    pattern = re.compile(
-        rf"{re.escape(_PAYMENT_INFO_BLOCK_START)}.*?"
-        rf"{re.escape(_PAYMENT_INFO_BLOCK_END)}",
-        flags=re.DOTALL,
-    )
-    if pattern.search(existing_details):
-        return pattern.sub(payment_block, existing_details).strip()
+    unmanaged_details = _remove_payment_info_blocks(existing_details)
+    if unmanaged_details:
+        return f"{unmanaged_details}\n\n{payment_block}".strip()
 
-    return f"{existing_details}\n\n{payment_block}".strip()
+    return payment_block
+
+
+def _normalize_payment_details(payment_details: str | None) -> str | None:
+    text = _text(payment_details)
+    if text is None:
+        return None
+
+    lines = [
+        line
+        for line in text.splitlines()
+        if line.strip() not in {_PAYMENT_INFO_BLOCK_START, _PAYMENT_INFO_BLOCK_END}
+    ]
+    return _text("\n".join(lines))
+
+
+def _remove_payment_info_blocks(existing_details: str) -> str:
+    output_lines: list[str] = []
+    block_depth = 0
+    for line in existing_details.splitlines():
+        marker = line.strip()
+        if marker == _PAYMENT_INFO_BLOCK_START:
+            block_depth += 1
+            continue
+        if marker == _PAYMENT_INFO_BLOCK_END:
+            if block_depth > 0:
+                block_depth -= 1
+            continue
+        if block_depth == 0:
+            output_lines.append(line)
+
+    return "\n".join(output_lines).strip()
 
 
 def _payment_info_block(payment_details: str) -> str:
@@ -232,8 +259,19 @@ def _supplier_for_email(client: ERPNextClient, email: str) -> dict[str, Any] | N
             return detail
     for supplier in client.list_records(
         "Supplier",
-        fields=["name", "supplier_name", "email_id", "portal_users"],
-        filters=[["Supplier", "portal_users.user", "=", email]],
+        fields=[
+            "name",
+            "supplier_name",
+            "email_id",
+            "disabled",
+            "is_frozen",
+            "portal_users",
+        ],
+        filters=[
+            ["Supplier", "disabled", "=", 0],
+            ["Supplier", "is_frozen", "=", 0],
+            ["Supplier", "portal_users.user", "=", email],
+        ],
         limit=10,
     ):
         supplier_id = _text(supplier.get("name"))

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -230,6 +230,20 @@ def _supplier_for_email(client: ERPNextClient, email: str) -> dict[str, Any] | N
             employee_supplier_id=None,
         ):
             return detail
+    for supplier in client.list_records(
+        "Supplier",
+        fields=["name", "supplier_name", "email_id", "portal_users"],
+        filters=[["Supplier", "portal_users.user", "=", email]],
+        limit=10,
+    ):
+        supplier_id = _text(supplier.get("name"))
+        detail = _supplier_by_id(client, supplier_id) if supplier_id else supplier
+        if detail and _supplier_owned_by_email_or_employee(
+            supplier=detail,
+            email=email,
+            employee_supplier_id=None,
+        ):
+            return detail
     return None
 
 

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -1,0 +1,315 @@
+"""Self-service ERPNext Supplier payment-info helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+from five08.clients.erpnext import ERPNextAPIError, ERPNextClient
+
+
+class PaymentInfoError(RuntimeError):
+    """Raised when a self-service payment-info request cannot be completed."""
+
+
+@dataclass(frozen=True, slots=True)
+class PaymentIdentity:
+    """ERPNext identity resolved from one 508.dev email."""
+
+    email: str
+    user_id: str
+    employee_id: str | None
+    supplier_id: str
+    supplier_name: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class PaymentInfoInput:
+    """User-submitted payment information."""
+
+    account_name: str | None = None
+    bank: str | None = None
+    bank_account_no: str | None = None
+    branch_code: str | None = None
+    iban: str | None = None
+
+
+PAYMENT_INFO_BLOCK_START = "=== 508 Payment Info ==="
+PAYMENT_INFO_BLOCK_END = "=== End 508 Payment Info ==="
+_ACCOUNT_NUMBER_LABELS = (
+    "account number",
+    "account no",
+    "account #",
+    "acct number",
+    "acct no",
+    "iban",
+)
+_MASKABLE_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 -]{3,}[A-Za-z0-9]")
+
+
+def normalize_508_email(value: str | None) -> str:
+    """Return a normalized 508.dev email or raise PaymentInfoError."""
+    email = str(value or "").strip().lower()
+    if not email or not email.endswith("@508.dev"):
+        raise PaymentInfoError("A linked @508.dev email is required.")
+    return email
+
+
+def resolve_payment_identity(client: ERPNextClient, email: str) -> PaymentIdentity:
+    """Resolve the ERPNext User, Employee, and Supplier for one 508.dev email."""
+    normalized_email = normalize_508_email(email)
+
+    try:
+        user = client.get_record("User", normalized_email)
+    except ERPNextAPIError as exc:
+        if exc.status_code == 404:
+            raise PaymentInfoError(
+                f"No ERPNext User exists for {normalized_email}."
+            ) from exc
+        raise
+
+    user_id = _text(user.get("name") or user.get("email")) or normalized_email
+    user_email = _text(user.get("email") or user.get("name"))
+    if user_email and user_email.casefold() != normalized_email.casefold():
+        raise PaymentInfoError("ERPNext User email did not match the linked CRM email.")
+
+    employee = _employee_for_user(client, normalized_email)
+    supplier_id = _text((employee or {}).get("supplier"))
+    if supplier_id:
+        supplier = _supplier_by_id(client, supplier_id)
+    else:
+        supplier = _supplier_for_email(client, normalized_email)
+        supplier_id = _text((supplier or {}).get("name"))
+
+    if not supplier or not supplier_id:
+        raise PaymentInfoError(
+            "No ERPNext Supplier is linked to your ERP user yet. "
+            "Ask the operations team to finish ERP onboarding first."
+        )
+
+    if not _supplier_owned_by_email_or_employee(
+        supplier=supplier,
+        email=normalized_email,
+        employee_supplier_id=_text((employee or {}).get("supplier")),
+    ):
+        raise PaymentInfoError(
+            "The linked ERP Supplier could not be verified for your ERP user."
+        )
+
+    return PaymentIdentity(
+        email=normalized_email,
+        user_id=user_id,
+        employee_id=_text((employee or {}).get("name")),
+        supplier_id=supplier_id,
+        supplier_name=_text(supplier.get("supplier_name") or supplier.get("name")),
+    )
+
+
+def get_supplier_payment_details(
+    client: ERPNextClient,
+    identity: PaymentIdentity,
+) -> dict[str, Any]:
+    """Return the resolved Supplier record that stores payment details."""
+    supplier = client.get_record("Supplier", identity.supplier_id)
+    supplier_id = _text(supplier.get("name"))
+    if supplier_id != identity.supplier_id:
+        raise PaymentInfoError("ERPNext Supplier lookup returned the wrong record.")
+    return supplier
+
+
+def update_supplier_payment_details(
+    client: ERPNextClient,
+    identity: PaymentIdentity,
+    payment_info: PaymentInfoInput,
+) -> tuple[dict[str, Any], list[str]]:
+    """Replace the managed payment block inside Supplier.supplier_details."""
+    fields = _payment_info_fields(payment_info)
+    if not fields:
+        raise PaymentInfoError("Enter at least one payment-info field to update.")
+
+    supplier = get_supplier_payment_details(client, identity)
+    existing_details = str(supplier.get("supplier_details") or "").strip()
+    payment_block = _format_payment_info_block(fields)
+    updated_details = _replace_managed_payment_block(existing_details, payment_block)
+    updated_supplier = client.update_record(
+        "Supplier",
+        identity.supplier_id,
+        {"supplier_details": updated_details},
+    )
+    return updated_supplier, list(fields)
+
+
+def payment_info_summary(
+    identity: PaymentIdentity, supplier: dict[str, Any]
+) -> list[str]:
+    """Return safe-to-display, masked Supplier payment-info summary lines."""
+    details = str(supplier.get("supplier_details") or "").strip()
+    lines = [
+        f"ERP user: `{identity.email}`",
+        f"Supplier: `{identity.supplier_name or identity.supplier_id}`",
+    ]
+    if not details:
+        lines.append("Supplier Details: not set")
+        return lines
+
+    masked_details = mask_payment_details_for_display(details)
+    if len(masked_details) > 1500:
+        masked_details = masked_details[:1497].rstrip() + "..."
+    lines.append("Supplier Details:")
+    lines.append(f"```text\n{masked_details}\n```")
+    return lines
+
+
+def mask_payment_details_for_display(details: str) -> str:
+    """Mask account-number style lines while leaving bank and routing text readable."""
+    output_lines: list[str] = []
+    for line in details.splitlines():
+        label, separator, value = line.partition(":")
+        if separator and _is_account_number_label(label):
+            output_lines.append(f"{label}{separator}{_mask_payment_token(value)}")
+        else:
+            output_lines.append(line)
+    return "\n".join(output_lines)
+
+
+def _replace_managed_payment_block(existing_details: str, payment_block: str) -> str:
+    if not existing_details:
+        return payment_block
+
+    pattern = re.compile(
+        rf"{re.escape(PAYMENT_INFO_BLOCK_START)}.*?"
+        rf"{re.escape(PAYMENT_INFO_BLOCK_END)}",
+        flags=re.DOTALL,
+    )
+    if pattern.search(existing_details):
+        return pattern.sub(payment_block, existing_details).strip()
+
+    return f"{existing_details}\n\n{payment_block}".strip()
+
+
+def _format_payment_info_block(fields: dict[str, str]) -> str:
+    lines = [PAYMENT_INFO_BLOCK_START]
+    for field, label in (
+        ("account_name", "Account holder"),
+        ("bank", "Bank"),
+        ("branch_code", "Routing / SWIFT / branch"),
+        ("bank_account_no", "Account number"),
+        ("iban", "IBAN"),
+    ):
+        value = fields.get(field)
+        if value:
+            lines.append(f"{label}: {value}")
+    lines.append(PAYMENT_INFO_BLOCK_END)
+    return "\n".join(lines)
+
+
+def _employee_for_user(
+    client: ERPNextClient,
+    email: str,
+) -> dict[str, Any] | None:
+    employees = client.list_records(
+        "Employee",
+        fields=["name", "employee_name", "user_id", "supplier"],
+        filters=[["Employee", "user_id", "=", email]],
+        limit=1,
+    )
+    if not employees:
+        return None
+    employee_id = _text(employees[0].get("name"))
+    if employee_id is None:
+        return employees[0]
+    return client.get_record("Employee", employee_id)
+
+
+def _supplier_by_id(client: ERPNextClient, supplier_id: str) -> dict[str, Any] | None:
+    try:
+        return client.get_record("Supplier", supplier_id)
+    except ERPNextAPIError as exc:
+        if exc.status_code == 404:
+            return None
+        raise
+
+
+def _supplier_for_email(client: ERPNextClient, email: str) -> dict[str, Any] | None:
+    for supplier in client.search_suppliers(email, limit=10):
+        supplier_id = _text(supplier.get("name"))
+        detail = _supplier_by_id(client, supplier_id) if supplier_id else supplier
+        if detail and _supplier_owned_by_email_or_employee(
+            supplier=detail,
+            email=email,
+            employee_supplier_id=None,
+        ):
+            return detail
+    return None
+
+
+def _supplier_owned_by_email_or_employee(
+    *,
+    supplier: dict[str, Any],
+    email: str,
+    employee_supplier_id: str | None,
+) -> bool:
+    supplier_id = _text(supplier.get("name"))
+    if employee_supplier_id and supplier_id == employee_supplier_id:
+        return True
+    supplier_email = _text(supplier.get("email_id"))
+    if supplier_email and supplier_email.casefold() == email.casefold():
+        return True
+    portal_users = supplier.get("portal_users")
+    if not isinstance(portal_users, list):
+        return False
+    for row in portal_users:
+        if not isinstance(row, dict):
+            continue
+        portal_user = _text(row.get("user"))
+        if portal_user and portal_user.casefold() == email.casefold():
+            return True
+    return False
+
+
+def _payment_info_fields(payment_info: PaymentInfoInput) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for field in (
+        "account_name",
+        "bank",
+        "bank_account_no",
+        "branch_code",
+        "iban",
+    ):
+        value = _text(getattr(payment_info, field))
+        if value:
+            fields[field] = value
+    return fields
+
+
+def _is_account_number_label(label: str) -> bool:
+    normalized = label.strip().casefold()
+    return any(token in normalized for token in _ACCOUNT_NUMBER_LABELS)
+
+
+def _mask_payment_token(value: str) -> str:
+    leading_space = value[: len(value) - len(value.lstrip())]
+    trailing_space = value[len(value.rstrip()) :]
+    core = value.strip()
+    if not core:
+        return value
+    masked = _MASKABLE_TOKEN_RE.sub(
+        lambda match: _mask_token(match.group(0)),
+        core,
+    )
+    return f"{leading_space}{masked}{trailing_space}"
+
+
+def _mask_token(value: str) -> str:
+    compact = re.sub(r"\s+", "", value.strip())
+    if len(compact) <= 4:
+        return compact
+    return f"{compact[:2]}****{compact[-2:]}"
+
+
+def _text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -28,24 +28,15 @@ class PaymentIdentity:
 class PaymentInfoInput:
     """User-submitted payment information."""
 
-    account_name: str | None = None
-    bank: str | None = None
-    bank_account_no: str | None = None
-    branch_code: str | None = None
-    iban: str | None = None
+    supplier_details: str | None = None
 
 
-PAYMENT_INFO_BLOCK_START = "=== 508 Payment Info ==="
-PAYMENT_INFO_BLOCK_END = "=== End 508 Payment Info ==="
-_ACCOUNT_NUMBER_LABELS = (
-    "account number",
-    "account no",
-    "account #",
-    "acct number",
-    "acct no",
-    "iban",
+_ACCOUNT_LINE_TOKENS = ("account", "acct", "iban")
+_ACCOUNT_LINE_EXCLUSIONS = ("account holder", "account name", "account manager")
+_MASKABLE_ACCOUNT_TOKEN_RE = re.compile(
+    r"\b[A-Z]{0,4}\d[A-Za-z0-9]*(?:[ -]+[A-Za-z0-9]*\d[A-Za-z0-9]*)*\b",
+    flags=re.IGNORECASE,
 )
-_MASKABLE_TOKEN_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9 -]{3,}[A-Za-z0-9]")
 
 
 def normalize_508_email(value: str | None) -> str:
@@ -123,21 +114,17 @@ def update_supplier_payment_details(
     identity: PaymentIdentity,
     payment_info: PaymentInfoInput,
 ) -> tuple[dict[str, Any], list[str]]:
-    """Replace the managed payment block inside Supplier.supplier_details."""
-    fields = _payment_info_fields(payment_info)
-    if not fields:
-        raise PaymentInfoError("Enter at least one payment-info field to update.")
+    """Replace Supplier.supplier_details with the user-submitted text."""
+    supplier_details = _text(payment_info.supplier_details)
+    if supplier_details is None:
+        raise PaymentInfoError("Enter Supplier Details to update.")
 
-    supplier = get_supplier_payment_details(client, identity)
-    existing_details = str(supplier.get("supplier_details") or "").strip()
-    payment_block = _format_payment_info_block(fields)
-    updated_details = _replace_managed_payment_block(existing_details, payment_block)
     updated_supplier = client.update_record(
         "Supplier",
         identity.supplier_id,
-        {"supplier_details": updated_details},
+        {"supplier_details": supplier_details},
     )
-    return updated_supplier, list(fields)
+    return updated_supplier, ["supplier_details"]
 
 
 def payment_info_summary(
@@ -162,46 +149,11 @@ def payment_info_summary(
 
 
 def mask_payment_details_for_display(details: str) -> str:
-    """Mask account-number style lines while leaving bank and routing text readable."""
+    """Mask account-number lines while leaving bank and routing text readable."""
     output_lines: list[str] = []
     for line in details.splitlines():
-        label, separator, value = line.partition(":")
-        if separator and _is_account_number_label(label):
-            output_lines.append(f"{label}{separator}{_mask_payment_token(value)}")
-        else:
-            output_lines.append(line)
+        output_lines.append(_mask_account_line(line))
     return "\n".join(output_lines)
-
-
-def _replace_managed_payment_block(existing_details: str, payment_block: str) -> str:
-    if not existing_details:
-        return payment_block
-
-    pattern = re.compile(
-        rf"{re.escape(PAYMENT_INFO_BLOCK_START)}.*?"
-        rf"{re.escape(PAYMENT_INFO_BLOCK_END)}",
-        flags=re.DOTALL,
-    )
-    if pattern.search(existing_details):
-        return pattern.sub(payment_block, existing_details).strip()
-
-    return f"{existing_details}\n\n{payment_block}".strip()
-
-
-def _format_payment_info_block(fields: dict[str, str]) -> str:
-    lines = [PAYMENT_INFO_BLOCK_START]
-    for field, label in (
-        ("account_name", "Account holder"),
-        ("bank", "Bank"),
-        ("branch_code", "Routing / SWIFT / branch"),
-        ("bank_account_no", "Account number"),
-        ("iban", "IBAN"),
-    ):
-        value = fields.get(field)
-        if value:
-            lines.append(f"{label}: {value}")
-    lines.append(PAYMENT_INFO_BLOCK_END)
-    return "\n".join(lines)
 
 
 def _employee_for_user(
@@ -268,37 +220,32 @@ def _supplier_owned_by_email_or_employee(
     return False
 
 
-def _payment_info_fields(payment_info: PaymentInfoInput) -> dict[str, str]:
-    fields: dict[str, str] = {}
-    for field in (
-        "account_name",
-        "bank",
-        "bank_account_no",
-        "branch_code",
-        "iban",
-    ):
-        value = _text(getattr(payment_info, field))
-        if value:
-            fields[field] = value
-    return fields
+def _mask_account_line(line: str) -> str:
+    if not _is_account_number_line(line):
+        return line
+    label, separator, value = line.partition(":")
+    if separator:
+        return f"{label}{separator}{_mask_account_value(value)}"
+    return _MASKABLE_ACCOUNT_TOKEN_RE.sub(
+        lambda match: _mask_token(match.group(0)),
+        line,
+    )
 
 
-def _is_account_number_label(label: str) -> bool:
-    normalized = label.strip().casefold()
-    return any(token in normalized for token in _ACCOUNT_NUMBER_LABELS)
+def _is_account_number_line(line: str) -> bool:
+    normalized = line.casefold()
+    if any(exclusion in normalized for exclusion in _ACCOUNT_LINE_EXCLUSIONS):
+        return False
+    return any(token in normalized for token in _ACCOUNT_LINE_TOKENS)
 
 
-def _mask_payment_token(value: str) -> str:
+def _mask_account_value(value: str) -> str:
     leading_space = value[: len(value) - len(value.lstrip())]
     trailing_space = value[len(value.rstrip()) :]
     core = value.strip()
     if not core:
         return value
-    masked = _MASKABLE_TOKEN_RE.sub(
-        lambda match: _mask_token(match.group(0)),
-        core,
-    )
-    return f"{leading_space}{masked}{trailing_space}"
+    return f"{leading_space}{_mask_token(core)}{trailing_space}"
 
 
 def _mask_token(value: str) -> str:

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -197,20 +197,39 @@ def _normalize_payment_details(payment_details: str | None) -> str | None:
 
 def _remove_payment_info_blocks(existing_details: str) -> str:
     output_lines: list[str] = []
+    pending_block_lines: list[str] = []
     block_depth = 0
     for line in existing_details.splitlines():
         marker = line.strip()
         if marker == _PAYMENT_INFO_BLOCK_START:
+            pending_block_lines.append(line)
             block_depth += 1
             continue
         if marker == _PAYMENT_INFO_BLOCK_END:
             if block_depth > 0:
+                pending_block_lines.append(line)
                 block_depth -= 1
-            continue
-        if block_depth == 0:
+                if block_depth == 0:
+                    pending_block_lines = []
+                continue
             output_lines.append(line)
+            continue
+        if block_depth > 0:
+            pending_block_lines.append(line)
+            continue
+        output_lines.append(line)
+
+    if block_depth > 0:
+        output_lines.extend(pending_block_lines)
 
     return "\n".join(output_lines)
+
+
+def _mask_account_tokens(value: str) -> str:
+    return _MASKABLE_ACCOUNT_TOKEN_RE.sub(
+        lambda match: _mask_token(match.group(0)),
+        value,
+    )
 
 
 def _payment_info_block(payment_details: str) -> str:
@@ -341,11 +360,8 @@ def _mask_account_line(line: str) -> str:
         return line
     label, separator, value = line.partition(":")
     if separator:
-        return f"{label}{separator}{_mask_account_value(value)}"
-    return _MASKABLE_ACCOUNT_TOKEN_RE.sub(
-        lambda match: _mask_token(match.group(0)),
-        line,
-    )
+        return f"{_mask_account_tokens(label)}{separator}{_mask_account_value(value)}"
+    return _mask_account_tokens(line)
 
 
 def _is_account_number_line(line: str) -> bool:

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -71,6 +71,9 @@ def resolve_payment_identity(client: ERPNextClient, email: str) -> PaymentIdenti
     supplier_id = _text((employee or {}).get("supplier"))
     if supplier_id:
         supplier = _supplier_by_id(client, supplier_id)
+        if supplier and not _supplier_is_active(supplier):
+            supplier = _supplier_for_email(client, normalized_email)
+            supplier_id = _text((supplier or {}).get("name"))
     else:
         supplier = _supplier_for_email(client, normalized_email)
         supplier_id = _text((supplier or {}).get("name"))
@@ -122,7 +125,7 @@ def update_supplier_payment_details(
         raise PaymentInfoError("Enter Supplier Details to update.")
 
     supplier = get_supplier_payment_details(client, identity)
-    existing_details = str(supplier.get("supplier_details") or "").strip()
+    existing_details = str(supplier.get("supplier_details") or "")
     supplier_details = _replace_payment_info_block(existing_details, payment_details)
     updated_supplier = client.update_record(
         "Supplier",
@@ -169,12 +172,12 @@ def _sanitize_code_block_text(value: str) -> str:
 
 def _replace_payment_info_block(existing_details: str, payment_details: str) -> str:
     payment_block = _payment_info_block(payment_details)
-    if not existing_details:
+    if not existing_details.strip():
         return payment_block
 
     unmanaged_details = _remove_payment_info_blocks(existing_details)
-    if unmanaged_details:
-        return f"{unmanaged_details}\n\n{payment_block}".strip()
+    if unmanaged_details.strip():
+        return f"{unmanaged_details}\n\n{payment_block}"
 
     return payment_block
 
@@ -207,7 +210,7 @@ def _remove_payment_info_blocks(existing_details: str) -> str:
         if block_depth == 0:
             output_lines.append(line)
 
-    return "\n".join(output_lines).strip()
+    return "\n".join(output_lines)
 
 
 def _payment_info_block(payment_details: str) -> str:
@@ -247,14 +250,24 @@ def _supplier_by_id(client: ERPNextClient, supplier_id: str) -> dict[str, Any] |
         raise
 
 
+def _supplier_is_active(supplier: dict[str, Any]) -> bool:
+    return not _is_enabled_flag(supplier.get("disabled")) and not _is_enabled_flag(
+        supplier.get("is_frozen")
+    )
+
+
 def _supplier_for_email(client: ERPNextClient, email: str) -> dict[str, Any] | None:
     for supplier in client.search_suppliers(email, limit=10):
         supplier_id = _text(supplier.get("name"))
         detail = _supplier_by_id(client, supplier_id) if supplier_id else supplier
-        if detail and _supplier_owned_by_email_or_employee(
-            supplier=detail,
-            email=email,
-            employee_supplier_id=None,
+        if (
+            detail
+            and _supplier_is_active(detail)
+            and _supplier_owned_by_email_or_employee(
+                supplier=detail,
+                email=email,
+                employee_supplier_id=None,
+            )
         ):
             return detail
     for supplier in client.list_records(
@@ -276,13 +289,27 @@ def _supplier_for_email(client: ERPNextClient, email: str) -> dict[str, Any] | N
     ):
         supplier_id = _text(supplier.get("name"))
         detail = _supplier_by_id(client, supplier_id) if supplier_id else supplier
-        if detail and _supplier_owned_by_email_or_employee(
-            supplier=detail,
-            email=email,
-            employee_supplier_id=None,
+        if (
+            detail
+            and _supplier_is_active(detail)
+            and _supplier_owned_by_email_or_employee(
+                supplier=detail,
+                email=email,
+                employee_supplier_id=None,
+            )
         ):
             return detail
     return None
+
+
+def _is_enabled_flag(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().casefold() in {"1", "true", "yes", "on"}
+    return False
 
 
 def _supplier_owned_by_email_or_employee(

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -393,7 +393,7 @@ def _mask_account_value(value: str) -> str:
 def _mask_token(value: str) -> str:
     compact = re.sub(r"\s+", "", value.strip())
     if len(compact) <= 4:
-        return compact
+        return "****"
     return f"{compact[:2]}****{compact[-2:]}"
 
 

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -37,6 +37,8 @@ _MASKABLE_ACCOUNT_TOKEN_RE = re.compile(
     r"\b[A-Z]{0,4}\d[A-Za-z0-9]*(?:[ -]+[A-Za-z0-9]*\d[A-Za-z0-9]*)*\b",
     flags=re.IGNORECASE,
 )
+_PAYMENT_INFO_BLOCK_START = "=== 508 Payment Info ==="
+_PAYMENT_INFO_BLOCK_END = "=== End 508 Payment Info ==="
 
 
 def normalize_508_email(value: str | None) -> str:
@@ -114,11 +116,14 @@ def update_supplier_payment_details(
     identity: PaymentIdentity,
     payment_info: PaymentInfoInput,
 ) -> tuple[dict[str, Any], list[str]]:
-    """Replace Supplier.supplier_details with the user-submitted text."""
-    supplier_details = _text(payment_info.supplier_details)
-    if supplier_details is None:
+    """Replace the managed payment block inside Supplier.supplier_details."""
+    payment_details = _text(payment_info.supplier_details)
+    if payment_details is None:
         raise PaymentInfoError("Enter Supplier Details to update.")
 
+    supplier = get_supplier_payment_details(client, identity)
+    existing_details = str(supplier.get("supplier_details") or "").strip()
+    supplier_details = _replace_payment_info_block(existing_details, payment_details)
     updated_supplier = client.update_record(
         "Supplier",
         identity.supplier_id,
@@ -160,6 +165,32 @@ def mask_payment_details_for_display(details: str) -> str:
 
 def _sanitize_code_block_text(value: str) -> str:
     return value.replace("```", "'''")
+
+
+def _replace_payment_info_block(existing_details: str, payment_details: str) -> str:
+    payment_block = _payment_info_block(payment_details)
+    if not existing_details:
+        return payment_block
+
+    pattern = re.compile(
+        rf"{re.escape(_PAYMENT_INFO_BLOCK_START)}.*?"
+        rf"{re.escape(_PAYMENT_INFO_BLOCK_END)}",
+        flags=re.DOTALL,
+    )
+    if pattern.search(existing_details):
+        return pattern.sub(payment_block, existing_details).strip()
+
+    return f"{existing_details}\n\n{payment_block}".strip()
+
+
+def _payment_info_block(payment_details: str) -> str:
+    return "\n".join(
+        [
+            _PAYMENT_INFO_BLOCK_START,
+            payment_details.strip(),
+            _PAYMENT_INFO_BLOCK_END,
+        ]
+    )
 
 
 def _employee_for_user(
@@ -251,7 +282,11 @@ def _mask_account_value(value: str) -> str:
     core = value.strip()
     if not core:
         return value
-    return f"{leading_space}{_mask_token(core)}{trailing_space}"
+    masked = _MASKABLE_ACCOUNT_TOKEN_RE.sub(
+        lambda match: _mask_token(match.group(0)),
+        core,
+    )
+    return f"{leading_space}{masked}{trailing_space}"
 
 
 def _mask_token(value: str) -> str:

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -31,8 +31,10 @@ class PaymentInfoInput:
     supplier_details: str | None = None
 
 
-_ACCOUNT_LINE_TOKENS = ("account", "acct", "iban")
+_508_EMAIL_RE = re.compile(r"^[^\s@]+@508\.dev$", flags=re.IGNORECASE)
+_ACCOUNT_LINE_TOKENS = ("account", "acct", "iban", "wire")
 _ACCOUNT_LINE_EXCLUSIONS = ("account holder", "account name", "account manager")
+_ROUTING_LINE_TOKENS = ("routing", "swift", "branch")
 _MASKABLE_ACCOUNT_TOKEN_RE = re.compile(
     r"\b[A-Z]{0,4}\d[A-Za-z0-9]*(?:[ -]+[A-Za-z0-9]*\d[A-Za-z0-9]*)*\b",
     flags=re.IGNORECASE,
@@ -44,7 +46,7 @@ _PAYMENT_INFO_BLOCK_END = "=== End 508 Payment Info ==="
 def normalize_508_email(value: str | None) -> str:
     """Return a normalized 508.dev email or raise PaymentInfoError."""
     email = str(value or "").strip().lower()
-    if not email or not email.endswith("@508.dev"):
+    if not _508_EMAIL_RE.fullmatch(email):
         raise PaymentInfoError("A linked @508.dev email is required.")
     return email
 
@@ -71,7 +73,7 @@ def resolve_payment_identity(client: ERPNextClient, email: str) -> PaymentIdenti
     supplier_id = _text((employee or {}).get("supplier"))
     if supplier_id:
         supplier = _supplier_by_id(client, supplier_id)
-        if supplier and not _supplier_is_active(supplier):
+        if not supplier or not _supplier_is_active(supplier):
             supplier = _supplier_for_email(client, normalized_email)
             supplier_id = _text((supplier or {}).get("name"))
     else:
@@ -367,6 +369,10 @@ def _mask_account_line(line: str) -> str:
 def _is_account_number_line(line: str) -> bool:
     normalized = line.casefold()
     if any(exclusion in normalized for exclusion in _ACCOUNT_LINE_EXCLUSIONS):
+        return False
+    if any(token in normalized for token in _ROUTING_LINE_TOKENS) and not any(
+        token in normalized for token in ("account", "acct", "iban")
+    ):
         return False
     return any(token in normalized for token in _ACCOUNT_LINE_TOKENS)
 

--- a/packages/shared/src/five08/payment_info.py
+++ b/packages/shared/src/five08/payment_info.py
@@ -140,7 +140,9 @@ def payment_info_summary(
         lines.append("Supplier Details: not set")
         return lines
 
-    masked_details = mask_payment_details_for_display(details)
+    masked_details = _sanitize_code_block_text(
+        mask_payment_details_for_display(details)
+    )
     if len(masked_details) > 1500:
         masked_details = masked_details[:1497].rstrip() + "..."
     lines.append("Supplier Details:")
@@ -154,6 +156,10 @@ def mask_payment_details_for_display(details: str) -> str:
     for line in details.splitlines():
         output_lines.append(_mask_account_line(line))
     return "\n".join(output_lines)
+
+
+def _sanitize_code_block_text(value: str) -> str:
+    return value.replace("```", "'''")
 
 
 def _employee_for_user(

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -121,11 +121,11 @@ def test_get_supplier_payment_details_reads_supplier_details_field() -> None:
     assert supplier["supplier_details"] == "Bank: Test Bank"
 
 
-def test_update_supplier_payment_details_requires_some_payment_info() -> None:
+def test_update_supplier_payment_details_requires_supplier_details() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
 
-    with pytest.raises(PaymentInfoError, match="at least one"):
+    with pytest.raises(PaymentInfoError, match="Supplier Details"):
         update_supplier_payment_details(
             client,
             identity,
@@ -133,9 +133,7 @@ def test_update_supplier_payment_details_requires_some_payment_info() -> None:
         )
 
 
-def test_update_supplier_payment_details_appends_managed_supplier_details_block() -> (
-    None
-):
+def test_update_supplier_payment_details_replaces_supplier_details() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
     client.records["Supplier"]["SUP-0001"]["supplier_details"] = "Tax ID: 12-3456789"
@@ -144,52 +142,22 @@ def test_update_supplier_payment_details_appends_managed_supplier_details_block(
         client,
         identity,
         PaymentInfoInput(
-            account_name="Jane Engineer",
-            bank="Test Bank",
-            bank_account_no="123456789",
-            branch_code="011000015",
+            supplier_details="\n".join(
+                [
+                    "Bank: Test Bank",
+                    "Routing / SWIFT / branch: 011000015",
+                    "Account number: 123456789",
+                ]
+            )
         ),
     )
 
-    details = supplier["supplier_details"]
-    assert "Tax ID: 12-3456789" in details
-    assert "=== 508 Payment Info ===" in details
-    assert "Bank: Test Bank" in details
-    assert "Routing / SWIFT / branch: 011000015" in details
-    assert "Account number: 123456789" in details
-    assert changed_fields == [
-        "account_name",
-        "bank",
-        "bank_account_no",
-        "branch_code",
-    ]
-
-
-def test_update_supplier_payment_details_replaces_existing_managed_block() -> None:
-    client = FakeERPNextClient()
-    identity = resolve_payment_identity(client, "jane@508.dev")
-    client.records["Supplier"]["SUP-0001"]["supplier_details"] = (
-        "Tax ID: 12-3456789\n\n"
-        "=== 508 Payment Info ===\n"
-        "Bank: Old Bank\n"
-        "Account number: 999999999\n"
-        "=== End 508 Payment Info ==="
+    assert supplier["supplier_details"] == (
+        "Bank: Test Bank\n"
+        "Routing / SWIFT / branch: 011000015\n"
+        "Account number: 123456789"
     )
-
-    supplier, _changed_fields = update_supplier_payment_details(
-        client,
-        identity,
-        PaymentInfoInput(
-            bank="New Bank",
-            bank_account_no="123456789",
-        ),
-    )
-
-    details = supplier["supplier_details"]
-    assert "Tax ID: 12-3456789" in details
-    assert "New Bank" in details
-    assert "Old Bank" not in details
-    assert "999999999" not in details
+    assert changed_fields == ["supplier_details"]
 
 
 def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() -> None:
@@ -230,6 +198,38 @@ def test_mask_payment_details_for_display_leaves_routing_numbers_readable() -> N
     masked = mask_payment_details_for_display(details)
 
     assert "Routing / SWIFT / branch: 011000015" in masked
+    assert "Account number: 12****90" in masked
+
+
+def test_mask_payment_details_handles_account_lines_without_colons() -> None:
+    details = "\n".join(
+        [
+            "Bank Test Bank",
+            "ACH Account 1234567890",
+            "Account # 9876543210",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "Bank Test Bank" in masked
+    assert "1234567890" not in masked
+    assert "9876543210" not in masked
+    assert "12****90" in masked
+    assert "98****10" in masked
+
+
+def test_mask_payment_details_does_not_mask_account_holder() -> None:
+    details = "\n".join(
+        [
+            "Account holder: Jane Engineer",
+            "Account number: 1234567890",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "Account holder: Jane Engineer" in masked
     assert "Account number: 12****90" in masked
 
 
@@ -327,10 +327,13 @@ async def test_payment_info_update_is_ephemeral_and_does_not_echo_full_account(
     await payment_cog.handle_payment_info_update(
         interaction,
         PaymentInfoInput(
-            account_name="Jane Engineer",
-            bank="Test Bank",
-            bank_account_no="123456789",
-            branch_code="011000015",
+            supplier_details="\n".join(
+                [
+                    "Bank: Test Bank",
+                    "Routing / SWIFT / branch: 011000015",
+                    "ACH Account 123456789",
+                ]
+            ),
         ),
     )
 
@@ -338,5 +341,5 @@ async def test_payment_info_update_is_ephemeral_and_does_not_echo_full_account(
     assert "Payment info updated" in sent
     assert "123456789" not in sent
     assert "Routing / SWIFT / branch: 011000015" in sent
-    assert "Account number: 12****89" in sent
+    assert "ACH Account 12****89" in sent
     assert interaction.followup.send.call_args.kwargs["ephemeral"] is True

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -164,6 +164,35 @@ def test_resolve_payment_identity_skips_inactive_portal_user_suppliers() -> None
     assert identity.supplier_id == "SUP-0002"
 
 
+def test_resolve_payment_identity_falls_back_from_inactive_employee_supplier() -> None:
+    client = FakeERPNextClient()
+    client.records["Supplier"]["SUP-0001"]["disabled"] = 1
+    client.records["Supplier"]["SUP-0002"] = {
+        "name": "SUP-0002",
+        "supplier_name": "Jane Active",
+        "email_id": "",
+        "disabled": 0,
+        "is_frozen": 0,
+        "portal_users": [{"user": "jane@508.dev"}],
+        "supplier_details": "",
+    }
+
+    identity = resolve_payment_identity(client, "jane@508.dev")
+
+    assert identity.employee_id == "HR-EMP-0001"
+    assert identity.supplier_id == "SUP-0002"
+
+
+def test_resolve_payment_identity_rejects_inactive_employee_supplier_without_fallback() -> (
+    None
+):
+    client = FakeERPNextClient()
+    client.records["Supplier"]["SUP-0001"]["is_frozen"] = 1
+
+    with pytest.raises(PaymentInfoError, match="No ERPNext Supplier"):
+        resolve_payment_identity(client, "jane@508.dev")
+
+
 def test_get_supplier_payment_details_reads_supplier_details_field() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
@@ -215,6 +244,22 @@ def test_update_supplier_payment_details_preserves_unrelated_supplier_details() 
     assert "=== End 508 Payment Info ===" in details
     assert details.startswith("Tax ID: 12-3456789")
     assert changed_fields == ["supplier_details"]
+
+
+def test_update_supplier_payment_details_preserves_unrelated_leading_formatting() -> (
+    None
+):
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = "  Tax ID: 12-3456789"
+
+    supplier, _changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(supplier_details="Bank: Test Bank"),
+    )
+
+    assert supplier["supplier_details"].startswith("  Tax ID: 12-3456789")
 
 
 def test_update_supplier_payment_details_replaces_existing_payment_block() -> None:

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -13,6 +13,7 @@ from five08.payment_info import (
     PaymentInfoInput,
     get_supplier_payment_details,
     mask_payment_details_for_display,
+    normalize_508_email,
     payment_info_summary,
     resolve_payment_identity,
     update_supplier_payment_details,
@@ -124,6 +125,11 @@ def test_resolve_payment_identity_rejects_non_508_email() -> None:
         resolve_payment_identity(client, "jane@example.com")
 
 
+def test_normalize_508_email_rejects_internal_whitespace() -> None:
+    with pytest.raises(PaymentInfoError, match="@508.dev"):
+        normalize_508_email("jane\n@508.dev")
+
+
 def test_resolve_payment_identity_finds_supplier_by_portal_user() -> None:
     client = FakeERPNextClient()
     client.records["Employee"] = {}
@@ -191,6 +197,25 @@ def test_resolve_payment_identity_rejects_inactive_employee_supplier_without_fal
 
     with pytest.raises(PaymentInfoError, match="No ERPNext Supplier"):
         resolve_payment_identity(client, "jane@508.dev")
+
+
+def test_resolve_payment_identity_falls_back_from_deleted_employee_supplier() -> None:
+    client = FakeERPNextClient()
+    client.records["Supplier"].pop("SUP-0001")
+    client.records["Supplier"]["SUP-0002"] = {
+        "name": "SUP-0002",
+        "supplier_name": "Jane Active",
+        "email_id": "",
+        "disabled": 0,
+        "is_frozen": 0,
+        "portal_users": [{"user": "jane@508.dev"}],
+        "supplier_details": "",
+    }
+
+    identity = resolve_payment_identity(client, "jane@508.dev")
+
+    assert identity.employee_id == "HR-EMP-0001"
+    assert identity.supplier_id == "SUP-0002"
 
 
 def test_get_supplier_payment_details_reads_supplier_details_field() -> None:
@@ -473,6 +498,21 @@ def test_mask_payment_details_masks_account_tokens_before_colon() -> None:
     assert "Account 12****89: primary payroll" in masked
 
 
+def test_mask_payment_details_masks_wire_account_lines() -> None:
+    details = "\n".join(
+        [
+            "Wire: 1234567890",
+            "Routing / SWIFT / branch: 011000015",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "Wire: 12****90" in masked
+    assert "1234567890" not in masked
+    assert "Routing / SWIFT / branch: 011000015" in masked
+
+
 def _make_interaction(user_id: int = 123456789) -> AsyncMock:
     interaction = AsyncMock()
     interaction.response = AsyncMock()
@@ -557,6 +597,24 @@ async def test_payment_info_command_denies_when_crm_email_is_not_508(
     sent = interaction.followup.send.call_args.args[0]
     assert "@508.dev" in sent
     assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_payment_info_command_generic_error_disables_mentions(
+    payment_cog: PaymentInfoCog,
+) -> None:
+    payment_cog._read_self_payment_info = Mock(  # type: ignore[method-assign]
+        side_effect=ValueError("bad <@123>")
+    )
+    interaction = _make_interaction()
+
+    await payment_cog.payment_info_command.callback(payment_cog, interaction)
+
+    sent = interaction.followup.send.call_args.args[0]
+    assert "lookup failed" in sent
+    assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
 
 
 @pytest.mark.asyncio
@@ -585,6 +643,26 @@ async def test_payment_info_update_is_ephemeral_and_does_not_echo_full_account(
     assert "ACH Account 12****89" in sent
     assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
     assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_payment_info_update_error_disables_mentions(
+    payment_cog: PaymentInfoCog,
+) -> None:
+    payment_cog._update_self_payment_info = Mock(  # type: ignore[method-assign]
+        side_effect=PaymentInfoError("bad <@123>")
+    )
+    interaction = _make_interaction()
+
+    await payment_cog.handle_payment_info_update(
+        interaction,
+        PaymentInfoInput(supplier_details="Bank: Test Bank"),
+    )
+
+    sent = interaction.followup.send.call_args.args[0]
+    assert "bad <@123>" in sent
+    assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -134,7 +134,7 @@ def test_update_supplier_payment_details_requires_supplier_details() -> None:
         )
 
 
-def test_update_supplier_payment_details_replaces_supplier_details() -> None:
+def test_update_supplier_payment_details_preserves_unrelated_supplier_details() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
     client.records["Supplier"]["SUP-0001"]["supplier_details"] = "Tax ID: 12-3456789"
@@ -153,12 +153,48 @@ def test_update_supplier_payment_details_replaces_supplier_details() -> None:
         ),
     )
 
-    assert supplier["supplier_details"] == (
-        "Bank: Test Bank\n"
-        "Routing / SWIFT / branch: 011000015\n"
-        "Account number: 123456789"
-    )
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "=== 508 Payment Info ===" in details
+    assert "Bank: Test Bank" in details
+    assert "Routing / SWIFT / branch: 011000015" in details
+    assert "Account number: 123456789" in details
+    assert "=== End 508 Payment Info ===" in details
+    assert details.startswith("Tax ID: 12-3456789")
     assert changed_fields == ["supplier_details"]
+
+
+def test_update_supplier_payment_details_replaces_existing_payment_block() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = (
+        "Tax ID: 12-3456789\n\n"
+        "=== 508 Payment Info ===\n"
+        "Bank: Old Bank\n"
+        "Account number: 999999999\n"
+        "=== End 508 Payment Info ==="
+    )
+
+    supplier, _changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(
+            supplier_details="\n".join(
+                [
+                    "Bank: New Bank",
+                    "Account number: 123456789",
+                ]
+            )
+        ),
+    )
+
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "Bank: New Bank" in details
+    assert "Account number: 123456789" in details
+    assert "Old Bank" not in details
+    assert "999999999" not in details
+    assert details.count("=== 508 Payment Info ===") == 1
 
 
 def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() -> None:
@@ -253,6 +289,20 @@ def test_mask_payment_details_does_not_mask_account_holder() -> None:
     masked = mask_payment_details_for_display(details)
 
     assert "Account holder: Jane Engineer" in masked
+    assert "Account number: 12****90" in masked
+
+
+def test_mask_payment_details_keeps_bank_account_text_without_digits() -> None:
+    details = "\n".join(
+        [
+            "Bank account: Test Bank",
+            "Account number: 1234567890",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "Bank account: Test Bank" in masked
     assert "Account number: 12****90" in masked
 
 

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -513,6 +513,22 @@ def test_mask_payment_details_masks_wire_account_lines() -> None:
     assert "Routing / SWIFT / branch: 011000015" in masked
 
 
+def test_mask_payment_details_redacts_short_account_tokens() -> None:
+    details = "\n".join(
+        [
+            "Account number: 1234",
+            "Wire: 987",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "1234" not in masked
+    assert "987" not in masked
+    assert "Account number: ****" in masked
+    assert "Wire: ****" in masked
+
+
 def _make_interaction(user_id: int = 123456789) -> AsyncMock:
     interaction = AsyncMock()
     interaction.response = AsyncMock()

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -40,6 +40,8 @@ class FakeERPNextClient:
                     "name": "SUP-0001",
                     "supplier_name": "Jane Engineer",
                     "email_id": "",
+                    "disabled": 0,
+                    "is_frozen": 0,
                     "portal_users": [],
                     "supplier_details": "",
                 }
@@ -133,6 +135,35 @@ def test_resolve_payment_identity_finds_supplier_by_portal_user() -> None:
     assert identity.supplier_id == "SUP-0001"
 
 
+def test_resolve_payment_identity_skips_inactive_portal_user_suppliers() -> None:
+    client = FakeERPNextClient()
+    client.records["Employee"] = {}
+    client.records["Supplier"]["SUP-0001"]["portal_users"] = []
+    client.records["Supplier"]["SUP-OLD"] = {
+        "name": "SUP-OLD",
+        "supplier_name": "Jane Old",
+        "email_id": "",
+        "disabled": 1,
+        "is_frozen": 0,
+        "portal_users": [{"user": "jane@508.dev"}],
+        "supplier_details": "",
+    }
+    client.records["Supplier"]["SUP-0002"] = {
+        "name": "SUP-0002",
+        "supplier_name": "Jane Active",
+        "email_id": "",
+        "disabled": 0,
+        "is_frozen": 0,
+        "portal_users": [{"user": "jane@508.dev"}],
+        "supplier_details": "",
+    }
+
+    identity = resolve_payment_identity(client, "jane@508.dev")
+
+    assert identity.employee_id is None
+    assert identity.supplier_id == "SUP-0002"
+
+
 def test_get_supplier_payment_details_reads_supplier_details_field() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
@@ -217,6 +248,46 @@ def test_update_supplier_payment_details_replaces_existing_payment_block() -> No
     assert "Old Bank" not in details
     assert "999999999" not in details
     assert details.count("=== 508 Payment Info ===") == 1
+
+
+def test_update_supplier_payment_details_removes_pasted_and_nested_markers() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = (
+        "Tax ID: 12-3456789\n\n"
+        "=== 508 Payment Info ===\n"
+        "Bank: Old Bank\n"
+        "=== 508 Payment Info ===\n"
+        "Account number: 999999999\n"
+        "=== End 508 Payment Info ===\n"
+        "=== End 508 Payment Info ===\n\n"
+        "VAT: JP123"
+    )
+
+    supplier, _changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(
+            supplier_details="\n".join(
+                [
+                    "=== 508 Payment Info ===",
+                    "Bank: New Bank",
+                    "Account number: 123456789",
+                    "=== End 508 Payment Info ===",
+                ]
+            )
+        ),
+    )
+
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "VAT: JP123" in details
+    assert "Bank: New Bank" in details
+    assert "Account number: 123456789" in details
+    assert "Old Bank" not in details
+    assert "999999999" not in details
+    assert details.count("=== 508 Payment Info ===") == 1
+    assert details.count("=== End 508 Payment Info ===") == 1
 
 
 def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() -> None:

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -69,7 +69,18 @@ class FakeERPNextClient:
         for raw_filter in filters or []:
             _doctype, field, operator, value = raw_filter
             if operator == "=":
-                rows = [row for row in rows if row.get(field) == value]
+                if field == "portal_users.user":
+                    rows = [
+                        row
+                        for row in rows
+                        if any(
+                            isinstance(portal_user, dict)
+                            and portal_user.get("user") == value
+                            for portal_user in row.get("portal_users", [])
+                        )
+                    ]
+                else:
+                    rows = [row for row in rows if row.get(field) == value]
         return [dict(row) for row in rows[:limit]]
 
     def search_suppliers(self, query: str, *, limit: int = 10) -> list[dict[str, Any]]:
@@ -109,6 +120,17 @@ def test_resolve_payment_identity_rejects_non_508_email() -> None:
 
     with pytest.raises(PaymentInfoError, match="@508.dev"):
         resolve_payment_identity(client, "jane@example.com")
+
+
+def test_resolve_payment_identity_finds_supplier_by_portal_user() -> None:
+    client = FakeERPNextClient()
+    client.records["Employee"] = {}
+    client.records["Supplier"]["SUP-0001"]["portal_users"] = [{"user": "jane@508.dev"}]
+
+    identity = resolve_payment_identity(client, "jane@508.dev")
+
+    assert identity.employee_id is None
+    assert identity.supplier_id == "SUP-0001"
 
 
 def test_get_supplier_payment_details_reads_supplier_details_field() -> None:

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from five08.clients.erpnext import ERPNextAPIError
+from five08.discord_bot.cogs import payment_info as payment_info_cog
 from five08.discord_bot.cogs.payment_info import PaymentInfoCog
 from five08.payment_info import (
     PaymentInfoError,
@@ -186,6 +187,28 @@ def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() ->
     assert "GB****32" in summary
 
 
+def test_payment_info_summary_sanitizes_nested_code_fences() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    supplier = {
+        "supplier_details": "\n".join(
+            [
+                "Bank: Test Bank",
+                "```",
+                "@everyone",
+                "Account number: 1234567890",
+            ]
+        )
+    }
+
+    summary = "\n".join(payment_info_summary(identity, supplier))
+
+    assert summary.count("```") == 2
+    assert "'''" in summary
+    assert "1234567890" not in summary
+    assert "12****90" in summary
+
+
 def test_mask_payment_details_for_display_leaves_routing_numbers_readable() -> None:
     details = "\n".join(
         [
@@ -298,6 +321,7 @@ async def test_payment_info_command_is_ephemeral_and_self_scoped(
     assert params["select"] == "id,name,emailAddress,c508Email,cDiscordUserID"
     assert interaction.response.defer.call_args.kwargs["ephemeral"] is True
     assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
     assert "jane@508.dev" in interaction.followup.send.call_args.args[0]
 
 
@@ -342,4 +366,22 @@ async def test_payment_info_update_is_ephemeral_and_does_not_echo_full_account(
     assert "123456789" not in sent
     assert "Routing / SWIFT / branch: 011000015" in sent
     assert "ACH Account 12****89" in sent
+    assert "allowed_mentions" in interaction.followup.send.call_args.kwargs
     assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_setup_rejects_whitespace_only_config() -> None:
+    bot = Mock()
+    bot.add_cog = AsyncMock()
+    fake_settings = Mock(
+        espo_base_url="https://crm.test",
+        espo_api_key="   ",
+        erpnext_base_url="https://erp.test",
+        erpnext_api_key="key:secret",
+    )
+
+    with patch.object(payment_info_cog, "settings", fake_settings):
+        await payment_info_cog.setup(bot)
+
+    bot.add_cog.assert_not_called()

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -335,6 +335,26 @@ def test_update_supplier_payment_details_removes_pasted_and_nested_markers() -> 
     assert details.count("=== End 508 Payment Info ===") == 1
 
 
+def test_update_supplier_payment_details_preserves_tail_after_malformed_block() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = (
+        "Tax ID: 12-3456789\n\n=== 508 Payment Info ===\nBank: Old Bank\nVAT: JP123"
+    )
+
+    supplier, _changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(supplier_details="Bank: New Bank"),
+    )
+
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "Bank: Old Bank" in details
+    assert "VAT: JP123" in details
+    assert "Bank: New Bank" in details
+
+
 def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() -> None:
     client = FakeERPNextClient()
     identity = resolve_payment_identity(client, "jane@508.dev")
@@ -442,6 +462,15 @@ def test_mask_payment_details_keeps_bank_account_text_without_digits() -> None:
 
     assert "Bank account: Test Bank" in masked
     assert "Account number: 12****90" in masked
+
+
+def test_mask_payment_details_masks_account_tokens_before_colon() -> None:
+    details = "Account 123456789: primary payroll"
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "123456789" not in masked
+    assert "Account 12****89: primary payroll" in masked
 
 
 def _make_interaction(user_id: int = 123456789) -> AsyncMock:

--- a/tests/unit/test_payment_info.py
+++ b/tests/unit/test_payment_info.py
@@ -1,0 +1,342 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from five08.clients.erpnext import ERPNextAPIError
+from five08.discord_bot.cogs.payment_info import PaymentInfoCog
+from five08.payment_info import (
+    PaymentInfoError,
+    PaymentInfoInput,
+    get_supplier_payment_details,
+    mask_payment_details_for_display,
+    payment_info_summary,
+    resolve_payment_identity,
+    update_supplier_payment_details,
+)
+
+
+class FakeERPNextClient:
+    def __init__(self) -> None:
+        self.records: dict[str, dict[str, dict[str, Any]]] = {
+            "User": {
+                "jane@508.dev": {
+                    "name": "jane@508.dev",
+                    "email": "jane@508.dev",
+                }
+            },
+            "Employee": {
+                "HR-EMP-0001": {
+                    "name": "HR-EMP-0001",
+                    "user_id": "jane@508.dev",
+                    "supplier": "SUP-0001",
+                }
+            },
+            "Supplier": {
+                "SUP-0001": {
+                    "name": "SUP-0001",
+                    "supplier_name": "Jane Engineer",
+                    "email_id": "",
+                    "portal_users": [],
+                    "supplier_details": "",
+                }
+            },
+        }
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def get_record(self, doctype: str, record_id: str) -> dict[str, Any]:
+        try:
+            return dict(self.records[doctype][record_id])
+        except KeyError as exc:
+            raise ERPNextAPIError("not found", status_code=404) from exc
+
+    def list_records(
+        self,
+        doctype: str,
+        *,
+        fields: list[str],
+        filters: list[Any] | None = None,
+        or_filters: list[Any] | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        rows = list(self.records.get(doctype, {}).values())
+        for raw_filter in filters or []:
+            _doctype, field, operator, value = raw_filter
+            if operator == "=":
+                rows = [row for row in rows if row.get(field) == value]
+        return [dict(row) for row in rows[:limit]]
+
+    def search_suppliers(self, query: str, *, limit: int = 10) -> list[dict[str, Any]]:
+        normalized = query.strip().casefold()
+        rows = []
+        for supplier in self.records["Supplier"].values():
+            if (
+                supplier.get("name", "").casefold() == normalized
+                or supplier.get("email_id", "").casefold() == normalized
+            ):
+                rows.append(dict(supplier))
+        return rows[:limit]
+
+    def update_record(
+        self,
+        doctype: str,
+        record_id: str,
+        fields: dict[str, Any],
+    ) -> dict[str, Any]:
+        self.records[doctype][record_id].update(fields)
+        return dict(self.records[doctype][record_id])
+
+
+def test_resolve_payment_identity_uses_discord_linked_508_email_only() -> None:
+    client = FakeERPNextClient()
+
+    identity = resolve_payment_identity(client, " Jane@508.dev ")
+
+    assert identity.email == "jane@508.dev"
+    assert identity.user_id == "jane@508.dev"
+    assert identity.employee_id == "HR-EMP-0001"
+    assert identity.supplier_id == "SUP-0001"
+
+
+def test_resolve_payment_identity_rejects_non_508_email() -> None:
+    client = FakeERPNextClient()
+
+    with pytest.raises(PaymentInfoError, match="@508.dev"):
+        resolve_payment_identity(client, "jane@example.com")
+
+
+def test_get_supplier_payment_details_reads_supplier_details_field() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = "Bank: Test Bank"
+
+    supplier = get_supplier_payment_details(client, identity)
+
+    assert supplier["name"] == "SUP-0001"
+    assert supplier["supplier_details"] == "Bank: Test Bank"
+
+
+def test_update_supplier_payment_details_requires_some_payment_info() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+
+    with pytest.raises(PaymentInfoError, match="at least one"):
+        update_supplier_payment_details(
+            client,
+            identity,
+            PaymentInfoInput(),
+        )
+
+
+def test_update_supplier_payment_details_appends_managed_supplier_details_block() -> (
+    None
+):
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = "Tax ID: 12-3456789"
+
+    supplier, changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(
+            account_name="Jane Engineer",
+            bank="Test Bank",
+            bank_account_no="123456789",
+            branch_code="011000015",
+        ),
+    )
+
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "=== 508 Payment Info ===" in details
+    assert "Bank: Test Bank" in details
+    assert "Routing / SWIFT / branch: 011000015" in details
+    assert "Account number: 123456789" in details
+    assert changed_fields == [
+        "account_name",
+        "bank",
+        "bank_account_no",
+        "branch_code",
+    ]
+
+
+def test_update_supplier_payment_details_replaces_existing_managed_block() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    client.records["Supplier"]["SUP-0001"]["supplier_details"] = (
+        "Tax ID: 12-3456789\n\n"
+        "=== 508 Payment Info ===\n"
+        "Bank: Old Bank\n"
+        "Account number: 999999999\n"
+        "=== End 508 Payment Info ==="
+    )
+
+    supplier, _changed_fields = update_supplier_payment_details(
+        client,
+        identity,
+        PaymentInfoInput(
+            bank="New Bank",
+            bank_account_no="123456789",
+        ),
+    )
+
+    details = supplier["supplier_details"]
+    assert "Tax ID: 12-3456789" in details
+    assert "New Bank" in details
+    assert "Old Bank" not in details
+    assert "999999999" not in details
+
+
+def test_payment_info_summary_masks_account_numbers_but_not_bank_or_routing() -> None:
+    client = FakeERPNextClient()
+    identity = resolve_payment_identity(client, "jane@508.dev")
+    supplier = {
+        "supplier_details": "\n".join(
+            [
+                "Account holder: Jane Engineer",
+                "Bank: Test Bank",
+                "Routing / SWIFT / branch: 011000015",
+                "Account number: 1234567890",
+                "IBAN: GB82WEST12345698765432",
+            ]
+        )
+    }
+
+    lines = payment_info_summary(identity, supplier)
+
+    summary = "\n".join(lines)
+    assert "Bank: Test Bank" in summary
+    assert "Routing / SWIFT / branch: 011000015" in summary
+    assert "1234567890" not in summary
+    assert "GB82WEST12345698765432" not in summary
+    assert "12****90" in summary
+    assert "GB****32" in summary
+
+
+def test_mask_payment_details_for_display_leaves_routing_numbers_readable() -> None:
+    details = "\n".join(
+        [
+            "Bank: Test Bank",
+            "Routing / SWIFT / branch: 011000015",
+            "Account number: 1234567890",
+        ]
+    )
+
+    masked = mask_payment_details_for_display(details)
+
+    assert "Routing / SWIFT / branch: 011000015" in masked
+    assert "Account number: 12****90" in masked
+
+
+def _make_interaction(user_id: int = 123456789) -> AsyncMock:
+    interaction = AsyncMock()
+    interaction.response = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = Mock()
+    interaction.user.id = user_id
+    return interaction
+
+
+@pytest.fixture
+def fake_erp_client() -> FakeERPNextClient:
+    return FakeERPNextClient()
+
+
+@pytest.fixture
+def fake_crm_client() -> Mock:
+    crm = Mock()
+    crm.list_contacts.return_value = {
+        "list": [
+            {
+                "id": "contact-1",
+                "name": "Jane Engineer",
+                "c508Email": "jane@508.dev",
+                "cDiscordUserID": "123456789",
+            }
+        ]
+    }
+    return crm
+
+
+@pytest.fixture
+def payment_cog(
+    fake_crm_client: Mock,
+    fake_erp_client: FakeERPNextClient,
+) -> PaymentInfoCog:
+    with (
+        patch(
+            "five08.discord_bot.cogs.payment_info.EspoClient",
+            return_value=fake_crm_client,
+        ),
+        patch.object(PaymentInfoCog, "_init_audit_logger", return_value=None),
+    ):
+        cog = PaymentInfoCog(Mock())
+    cog.audit_logger = Mock()
+    cog._erpnext_client = Mock(return_value=fake_erp_client)  # type: ignore[method-assign]
+    return cog
+
+
+@pytest.mark.asyncio
+async def test_payment_info_command_is_ephemeral_and_self_scoped(
+    payment_cog: PaymentInfoCog,
+    fake_crm_client: Mock,
+) -> None:
+    interaction = _make_interaction()
+
+    await payment_cog.payment_info_command.callback(payment_cog, interaction)
+
+    fake_crm_client.list_contacts.assert_called_once()
+    params = fake_crm_client.list_contacts.call_args.args[0]
+    assert params["where"][0]["value"] == "123456789"
+    assert params["select"] == "id,name,emailAddress,c508Email,cDiscordUserID"
+    assert interaction.response.defer.call_args.kwargs["ephemeral"] is True
+    assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+    assert "jane@508.dev" in interaction.followup.send.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_payment_info_command_denies_when_crm_email_is_not_508(
+    payment_cog: PaymentInfoCog,
+    fake_crm_client: Mock,
+) -> None:
+    fake_crm_client.list_contacts.return_value["list"][0]["c508Email"] = (
+        "jane@example.com"
+    )
+    interaction = _make_interaction()
+
+    await payment_cog.payment_info_command.callback(payment_cog, interaction)
+
+    sent = interaction.followup.send.call_args.args[0]
+    assert "@508.dev" in sent
+    assert interaction.followup.send.call_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_payment_info_update_is_ephemeral_and_does_not_echo_full_account(
+    payment_cog: PaymentInfoCog,
+) -> None:
+    interaction = _make_interaction()
+
+    await payment_cog.handle_payment_info_update(
+        interaction,
+        PaymentInfoInput(
+            account_name="Jane Engineer",
+            bank="Test Bank",
+            bank_account_no="123456789",
+            branch_code="011000015",
+        ),
+    )
+
+    sent = interaction.followup.send.call_args.args[0]
+    assert "Payment info updated" in sent
+    assert "123456789" not in sent
+    assert "Routing / SWIFT / branch: 011000015" in sent
+    assert "Account number: 12****89" in sent
+    assert interaction.followup.send.call_args.kwargs["ephemeral"] is True


### PR DESCRIPTION
## Summary
- Add `/payment-info` Discord command for users to view and update only their own ERPNext payment info.
- Resolve access through Discord user ID -> CRM contact -> matching `@508.dev` email -> ERPNext User/Supplier.
- Store updates in the Supplier `supplier_details` field, preserving unrelated Supplier Details text by replacing/appending a managed payment-info block.
- Display Supplier Details ephemerally with account-number style lines masked as first-two/last-two while leaving bank name and routing/SWIFT/branch values readable.

## Security
- No admin override or target-user argument is exposed.
- All responses are ephemeral.
- Updates are scoped to the invoking Discord user's CRM-linked ERP identity.

## Validation
- `uv run pytest tests/unit/test_payment_info.py tests/unit/test_discord_command_metadata.py`
- `./scripts/mypy.sh`
- `./scripts/test.sh` (`1616 passed, 20 skipped`)
- `./scripts/lint.sh`
- pre-commit hooks during commit: ruff, ruff format, mypy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a self-service /payment-info command to view masked supplier payment details and update your own payment info via an interactive modal; interactions are ephemeral and require verified identity.

* **Documentation**
  * Updated README to document the /payment-info command behavior and usage.

* **Tests**
  * Added comprehensive unit tests for identity resolution, display masking, update flows, and command behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/508-dev/508-workflows/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->