### PR TITLE
[codex] fix: update security job uv version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,7 +232,7 @@ jobs:
     - name: Install uv
       uses: astral-sh/setup-uv@v7
       with:
-        version: "0.6.6"
+        version: "0.9.17"
 
     - name: Set up Python
       run: uv python install 3.12


### PR DESCRIPTION
## Description
Updates the remaining security CI job to install uv 0.9.17, matching the other workflow jobs after the dependency cooldown change. This addresses the PR #307 review feedback that `uv 0.6.6` may not parse the relative `exclude-newer = "7 days"` setting.

## Related Issue
None found in GitHub issue search for security uv cooldown exclude-newer CI.

## How Has This Been Tested?
Validated all workflow uv setup versions with `rg` and parsed `.github/workflows/test.yml` as YAML with Ruby.