### PR TITLE
[codex] Handle Discord link double submit

### DIFF
--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -83,6 +83,7 @@ from five08.backend.auth import (
     DASHBOARD_PERMISSION_PEOPLE_SYNC_DRY_RUN,
     DASHBOARD_SENSITIVE_PERMISSIONS,
     DASHBOARD_WORKFLOWS_ENGINEER_SENSITIVE_PERMISSIONS,
+    ConsumedDiscordLinkGrant,
     DiscordAdminVerifier,
     DiscordAdminIdentity,
     DiscordLinkGrant,
@@ -162,6 +163,7 @@ from five08.worker.models import (
 logger = logging.getLogger(__name__)
 _ULID_ALPHABET = "0123456789ABCDEFGHJKMNPQRSTVWXYZ"
 _PROJECT_ROSTER_USER_CANDIDATE_CACHE_TTL_SECONDS = 60.0
+_DISCORD_LINK_REPLAY_TTL_SECONDS = 10
 _PROJECT_ROSTER_USER_CANDIDATE_CACHE_MAX_SIZE = 128
 _PROJECT_ROSTER_USER_CANDIDATE_CACHE_LOCK = threading.RLock()
 _PROJECT_ROSTER_USER_CANDIDATE_CACHE: dict[str, tuple[float, list[dict[str, Any]]]] = {}
@@ -848,6 +850,66 @@ def _request_prefers_json(request: Request) -> bool:
     return _accept_quality(accept, "application/json") > _accept_quality(
         accept, "text/html"
     )
+
+
+def _discord_link_request_fingerprint(request: Request) -> str:
+    """Fingerprint the browser source for a short consumed-link replay window."""
+    forwarded_for = request.headers.get("x-forwarded-for", "")
+    client_ip = forwarded_for.split(",", 1)[0].strip()
+    if not client_ip:
+        client_ip = request.headers.get("x-real-ip", "").strip()
+    if not client_ip and request.client is not None:
+        client_ip = request.client.host
+    user_agent = request.headers.get("user-agent", "").strip()
+    fingerprint_source = f"{client_ip}\n{user_agent}"
+    return hashlib.sha256(fingerprint_source.encode("utf-8")).hexdigest()
+
+
+async def _discord_link_replay_from_request(
+    *,
+    store: RedisAuthStore,
+    token: str,
+    request: Request,
+) -> ConsumedDiscordLinkGrant | None:
+    if not isinstance(store, RedisAuthStore):
+        return None
+
+    replay = await store.get_consumed_discord_link(token)
+    if replay is None:
+        return None
+    if replay.request_fingerprint != _discord_link_request_fingerprint(request):
+        return None
+    return replay
+
+
+async def _save_discord_link_replay(
+    *,
+    store: RedisAuthStore,
+    token: str,
+    request: Request,
+    session_id: str,
+    next_path: str,
+) -> None:
+    if not isinstance(store, RedisAuthStore):
+        return
+
+    await store.save_consumed_discord_link(
+        token=token,
+        payload=ConsumedDiscordLinkGrant(
+            session_id=session_id,
+            next_path=next_path,
+            request_fingerprint=_discord_link_request_fingerprint(request),
+        ),
+        ttl_seconds=_DISCORD_LINK_REPLAY_TTL_SECONDS,
+    )
+
+
+def _discord_link_replay_redirect(
+    replay: ConsumedDiscordLinkGrant,
+) -> RedirectResponse:
+    response = RedirectResponse(url=replay.next_path, status_code=302)
+    _set_session_cookie(response, replay.session_id)
+    return response
 
 
 def _accept_quality(accept: str, media_type: str) -> float:
@@ -6708,6 +6770,13 @@ async def auth_discord_link_consume_handler(
 
     grant = await store.get_discord_link(token)
     if grant is None:
+        replay = await _discord_link_replay_from_request(
+            store=store,
+            token=token,
+            request=request,
+        )
+        if replay is not None:
+            return _discord_link_replay_redirect(replay)
         if _request_prefers_json(request):
             return JSONResponse({"error": "link_not_found"}, status_code=404)
         response = HTMLResponse(discord_link_unavailable_html(), status_code=404)
@@ -6762,6 +6831,13 @@ async def auth_discord_link_consume_handler(
                 ),
             ),
             ttl_seconds=settings.auth_session_ttl_seconds,
+        )
+        await _save_discord_link_replay(
+            store=store,
+            token=token,
+            request=request,
+            session_id=session_id,
+            next_path=grant.next_path,
         )
         await store.delete_discord_link(token)
 
@@ -6861,6 +6937,13 @@ async def auth_discord_link_consume_handler(
                 ),
             ),
             ttl_seconds=settings.auth_session_ttl_seconds,
+        )
+        await _save_discord_link_replay(
+            store=store,
+            token=token,
+            request=request,
+            session_id=session_id,
+            next_path=grant.next_path,
         )
         await store.delete_discord_link(token)
         await _write_auth_audit_event(

--- a/apps/api/src/five08/backend/auth.py
+++ b/apps/api/src/five08/backend/auth.py
@@ -154,6 +154,15 @@ class DiscordLinkGrant:
 
 
 @dataclass(frozen=True)
+class ConsumedDiscordLinkGrant:
+    """Short-lived replay data for a just-consumed Discord link."""
+
+    session_id: str
+    next_path: str
+    request_fingerprint: str
+
+
+@dataclass(frozen=True)
 class DiscordAdminIdentity:
     """Resolved CRM-backed Discord admin identity details."""
 
@@ -274,6 +283,37 @@ class RedisAuthStore:
             self._discord_link_key(token),
         )
 
+    async def save_consumed_discord_link(
+        self,
+        *,
+        token: str,
+        payload: ConsumedDiscordLinkGrant,
+        ttl_seconds: int,
+    ) -> None:
+        await self._set_json(
+            self._consumed_discord_link_key(token),
+            asdict(payload),
+            ttl_seconds=ttl_seconds,
+        )
+
+    async def get_consumed_discord_link(
+        self,
+        token: str,
+    ) -> ConsumedDiscordLinkGrant | None:
+        value = await self._get_json(self._consumed_discord_link_key(token))
+        if value is None:
+            return None
+
+        try:
+            return ConsumedDiscordLinkGrant(
+                session_id=str(value["session_id"]),
+                next_path=str(value["next_path"]),
+                request_fingerprint=str(value["request_fingerprint"]),
+            )
+        except Exception:
+            logger.warning("Invalid consumed discord-link payload in Redis")
+            return None
+
     async def _set_json(
         self, key: str, payload: dict[str, Any], *, ttl_seconds: int
     ) -> None:
@@ -329,6 +369,10 @@ class RedisAuthStore:
     @staticmethod
     def _discord_link_key(token: str) -> str:
         return f"auth:discord-link:{token}"
+
+    @staticmethod
+    def _consumed_discord_link_key(token: str) -> str:
+        return f"auth:discord-link-consumed:{token}"
 
 
 class OIDCProviderClient:

--- a/apps/api/src/five08/backend/dashboard.py
+++ b/apps/api/src/five08/backend/dashboard.py
@@ -268,8 +268,24 @@ def discord_link_continue_html(*, token: str) -> str:
     </form>
   </main>
   <script>
+    const form = document.getElementById("discord-link-consume");
+    const button = form?.querySelector("button");
+    let submitted = false;
+    form?.addEventListener("submit", (event) => {{
+      if (submitted) {{
+        event.preventDefault();
+        return;
+      }}
+      submitted = true;
+      if (button) {{
+        button.disabled = true;
+        button.textContent = "Continuing...";
+      }}
+    }});
     window.setTimeout(() => {{
-      document.getElementById("discord-link-consume")?.requestSubmit();
+      if (!submitted) {{
+        form?.requestSubmit();
+      }}
     }}, 150);
   </script>
 </body>

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -33,6 +33,8 @@ class _FailingRedis:
 class _FakeAuthStore(api.RedisAuthStore):
     def __init__(self) -> None:
         self.saved_links: dict[str, object] = {}
+        self.consumed_links: dict[str, object] = {}
+        self.saved_sessions: dict[str, object] = {}
 
     async def save_discord_link(
         self,
@@ -48,6 +50,27 @@ class _FakeAuthStore(api.RedisAuthStore):
 
     async def delete_discord_link(self, token: str) -> None:
         self.saved_links.pop(token, None)
+
+    async def save_consumed_discord_link(
+        self,
+        *,
+        token: str,
+        payload: object,
+        ttl_seconds: int,
+    ) -> None:
+        self.consumed_links[token] = payload
+
+    async def get_consumed_discord_link(self, token: str) -> object | None:
+        return self.consumed_links.get(token)
+
+    async def save_session(
+        self,
+        *,
+        session_id: str,
+        payload: object,
+        ttl_seconds: int,
+    ) -> None:
+        self.saved_sessions[session_id] = payload
 
     async def get_session(self, session_id: str) -> object | None:
         return None
@@ -6539,6 +6562,109 @@ def test_auth_discord_link_redirect_creates_discord_session_when_disabled(
     assert audit_payload.actor_subject == "123456789"
     assert audit_payload.metadata is not None
     assert audit_payload.metadata["discord_link_identity_checks_enforced"] is False
+
+
+def test_auth_discord_link_consume_replays_recent_same_browser_source(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "production")
+    monkeypatch.setattr(
+        api.settings, "discord_link_require_oidc_identity_checks", False
+    )
+    store = _FakeAuthStore()
+    store.saved_links["link-1"] = api.DiscordLinkGrant(
+        discord_user_id="123456789",
+        next_path="/dashboard",
+    )
+    verifier = Mock()
+    verifier.resolve_dashboard_identity = AsyncMock(
+        return_value=Mock(
+            discord_user_id="123456789",
+            crm_contact_id="contact-123",
+            email="admin@508.dev",
+            display_name="Discord Admin",
+            discord_roles=["Admin"],
+        )
+    )
+    headers = {"User-Agent": "discord-browser"}
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=verifier,
+        ),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        first = client.post(
+            "/auth/discord/link/link-1/consume",
+            headers=headers,
+            follow_redirects=False,
+        )
+        second = client.post(
+            "/auth/discord/link/link-1/consume",
+            headers=headers,
+            follow_redirects=False,
+        )
+
+    assert first.status_code == 302
+    assert second.status_code == 302
+    assert second.headers["location"] == "/dashboard"
+    assert first.headers["set-cookie"] == second.headers["set-cookie"]
+    assert "link-1" not in store.saved_links
+    assert "link-1" in store.consumed_links
+    assert len(store.saved_sessions) == 1
+
+
+def test_auth_discord_link_consume_replay_rejects_different_browser_source(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    monkeypatch.setattr(api.settings, "environment", "production")
+    monkeypatch.setattr(
+        api.settings, "discord_link_require_oidc_identity_checks", False
+    )
+    store = _FakeAuthStore()
+    store.saved_links["link-1"] = api.DiscordLinkGrant(
+        discord_user_id="123456789",
+        next_path="/dashboard",
+    )
+    verifier = Mock()
+    verifier.resolve_dashboard_identity = AsyncMock(
+        return_value=Mock(
+            discord_user_id="123456789",
+            crm_contact_id="contact-123",
+            email="admin@508.dev",
+            display_name="Discord Admin",
+            discord_roles=["Admin"],
+        )
+    )
+
+    with (
+        patch("five08.backend.api._auth_store_from_app", return_value=store),
+        patch(
+            "five08.backend.api._discord_admin_verifier_from_app",
+            return_value=verifier,
+        ),
+        patch("five08.backend.api._http_client_from_app", return_value=Mock()),
+        patch("five08.backend.api.insert_audit_event"),
+    ):
+        first = client.post(
+            "/auth/discord/link/link-1/consume",
+            headers={"User-Agent": "discord-browser"},
+            follow_redirects=False,
+        )
+        second = client.post(
+            "/auth/discord/link/link-1/consume",
+            headers={"User-Agent": "other-browser"},
+            follow_redirects=False,
+        )
+
+    assert first.status_code == 302
+    assert second.status_code == 404
+    assert "This dashboard link is no longer available" in second.text
 
 
 def test_auth_discord_link_consume_allows_local_role_fallback(


### PR DESCRIPTION
## Summary

- Prevent the Discord dashboard interstitial from submitting the consume form twice when a user clicks while the auto-submit timer is pending.
- Add a short consumed-link replay window so an immediate second consume request from the same browser source receives the same session redirect instead of an expired-link page.
- Keep replay scoped by IP/user-agent fingerprint and preserve one-time behavior for other browser sources.

## Root Cause

The interstitial GET was non-consuming, but the POST consume endpoint treated any second POST as a missing token after the first request created the session and deleted the link. A fast manual click during auto-submit could therefore abort the successful redirect and leave the retry on the expired-link page.

## Validation

- `uv run pytest tests/unit/test_backend_api.py tests/unit/test_admin_login_cog.py`
- `uv run ruff check apps/api/src/five08/backend/auth.py apps/api/src/five08/backend/api.py apps/api/src/five08/backend/dashboard.py tests/unit/test_backend_api.py`
- `uv run mypy apps/api/src/five08/ --ignore-missing-imports --explicit-package-bases`
- `git diff --check`
