### PR TITLE
[codex] Apply devkit quality gate conventions

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,8 +169,8 @@ service Dockerfiles use BuildKit cache mounts.
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
-./scripts/typecheck.sh
-./scripts/mypy.sh
+./scripts/typecheck.sh # Python mypy + dashboard TypeScript
+./scripts/mypy.sh      # Python-only typecheck
 ./scripts/check-all.sh
 ```
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,10 +169,13 @@ service Dockerfiles use BuildKit cache mounts.
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
+./scripts/typecheck.sh
 ./scripts/mypy.sh
+./scripts/check-all.sh
 ```
 
-For dashboard-only checks:
+These top-level scripts include the admin dashboard where applicable. For
+dashboard-only checks:
 
 ```bash
 cd apps/admin_dashboard

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ To run the Discord bot too:
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
+./scripts/typecheck.sh
 ./scripts/mypy.sh
+./scripts/check-all.sh
 ```
 
 For workspace archival, stop host-run dev processes and Docker Compose together:

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ To run the Discord bot too:
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
-./scripts/typecheck.sh
-./scripts/mypy.sh
+./scripts/typecheck.sh # Python mypy + dashboard TypeScript
+./scripts/mypy.sh      # Python-only typecheck
 ./scripts/check-all.sh
 ```
 

--- a/apps/admin_dashboard/bunfig.toml
+++ b/apps/admin_dashboard/bunfig.toml
@@ -1,2 +1,8 @@
 [install]
-minimumReleaseAge = 604800 # 7 days
+# Seven days, in seconds. Bun filters newly published direct and transitive
+# package versions during resolution.
+minimumReleaseAge = 604800
+minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
+
+# Isolated installs reduce accidental reliance on undeclared dependencies.
+linker = "isolated"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.7
-# Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
-FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
+# Python pinned from python:3.12-slim-bookworm and uv pinned from ghcr.io/astral-sh/uv:0.11.18 (verified 2026-06-03).
+FROM ghcr.io/astral-sh/uv@sha256:78bc42400d77b0678ba95765305c826652ed5431f399257271dda681d0318f03 AS uv
+FROM python@sha256:93ab4b7fa528b25124c97bcc755415e60eb671a86b4dbe0328df2fe2d1c1193d
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 ENV UV_LINK_MODE=copy

--- a/apps/discord_bot/Dockerfile
+++ b/apps/discord_bot/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.7
-# Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
-FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
+# Python pinned from python:3.12-slim-bookworm and uv pinned from ghcr.io/astral-sh/uv:0.11.18 (verified 2026-06-03).
+FROM ghcr.io/astral-sh/uv@sha256:78bc42400d77b0678ba95765305c826652ed5431f399257271dda681d0318f03 AS uv
+FROM python@sha256:93ab4b7fa528b25124c97bcc755415e60eb671a86b4dbe0328df2fe2d1c1193d
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 ENV UV_LINK_MODE=copy

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1.7
-# Pinned from ghcr.io/astral-sh/uv:python3.12-bookworm-slim (verified 2026-02-21).
-FROM ghcr.io/astral-sh/uv@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
+# Python pinned from python:3.12-slim-bookworm and uv pinned from ghcr.io/astral-sh/uv:0.11.18 (verified 2026-06-03).
+FROM ghcr.io/astral-sh/uv@sha256:78bc42400d77b0678ba95765305c826652ed5431f399257271dda681d0318f03 AS uv
+FROM python@sha256:93ab4b7fa528b25124c97bcc755415e60eb671a86b4dbe0328df2fe2d1c1193d
+COPY --from=uv /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 ENV UV_LINK_MODE=copy

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -18,9 +18,15 @@ echo
 echo
 
 echo "Building admin dashboard..."
+dashboard_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/five08-dashboard-build.XXXXXX")
+cleanup_dashboard_build_dir() {
+  rm -rf "$dashboard_build_dir"
+}
+trap cleanup_dashboard_build_dir EXIT HUP INT TERM
 (
   cd apps/admin_dashboard
-  bun run build
+  bun run typecheck
+  bun run vite build --outDir "$dashboard_build_dir"
 )
 if [ -n "$(git status --porcelain -- apps/api/src/five08/backend/static/dashboard)" ]; then
   echo

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -1,16 +1,27 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env sh
+set -eu
 
 echo "Running all checks..."
-echo
-
-./scripts/format.sh
 echo
 
 ./scripts/lint.sh
 echo
 
-./scripts/mypy.sh
+echo "Checking Python formatting..."
+uv run ruff format --check apps packages tests
 echo
 
-echo "✅ All checks passed!"
+./scripts/typecheck.sh
+echo
+
+./scripts/test.sh
+echo
+
+echo "Building admin dashboard..."
+(
+  cd apps/admin_dashboard
+  bun run build
+)
+echo
+
+echo "All checks passed."

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -11,7 +11,7 @@ echo "Checking Python formatting..."
 uv run ruff format --check apps/api/src/five08 apps/discord_bot/src/five08 apps/worker/src/five08 packages/shared/src/five08 tests
 echo
 
-./scripts/typecheck.sh
+./scripts/mypy.sh
 echo
 
 ./scripts/test.sh
@@ -26,7 +26,7 @@ cleanup_dashboard_build_dir() {
 trap cleanup_dashboard_build_dir EXIT HUP INT TERM
 (
   cd apps/admin_dashboard
-  bun run vite build --outDir "$dashboard_build_dir"
+  bun run build -- --outDir "$dashboard_build_dir"
 )
 if ! diff_output=$(diff -qr "$dashboard_static_dir" "$dashboard_build_dir"); then
   echo

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -24,7 +24,7 @@ echo "Building admin dashboard..."
 )
 if [ -n "$(git status --porcelain -- apps/api/src/five08/backend/static/dashboard)" ]; then
   echo
-  echo "Dashboard build output is stale. Run apps/admin_dashboard build and commit the generated static assets."
+  echo "Dashboard build output is stale. Run 'cd apps/admin_dashboard && bun run build' and commit the generated static assets."
   git status --short -- apps/api/src/five08/backend/static/dashboard
   exit 1
 fi

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -22,6 +22,12 @@ echo "Building admin dashboard..."
   cd apps/admin_dashboard
   bun run build
 )
+if [ -n "$(git status --porcelain -- apps/api/src/five08/backend/static/dashboard)" ]; then
+  echo
+  echo "Dashboard build output is stale. Run apps/admin_dashboard build and commit the generated static assets."
+  git status --short -- apps/api/src/five08/backend/static/dashboard
+  exit 1
+fi
 echo
 
 echo "All checks passed."

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -25,7 +25,6 @@ cleanup_dashboard_build_dir() {
 trap cleanup_dashboard_build_dir EXIT HUP INT TERM
 (
   cd apps/admin_dashboard
-  bun run typecheck
   bun run vite build --outDir "$dashboard_build_dir"
 )
 if [ -n "$(git status --porcelain -- apps/api/src/five08/backend/static/dashboard)" ]; then

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -18,6 +18,7 @@ echo
 echo
 
 echo "Building admin dashboard..."
+dashboard_static_dir="apps/api/src/five08/backend/static/dashboard"
 dashboard_build_dir=$(mktemp -d "${TMPDIR:-/tmp}/five08-dashboard-build.XXXXXX")
 cleanup_dashboard_build_dir() {
   rm -rf "$dashboard_build_dir"
@@ -27,10 +28,16 @@ trap cleanup_dashboard_build_dir EXIT HUP INT TERM
   cd apps/admin_dashboard
   bun run vite build --outDir "$dashboard_build_dir"
 )
-if [ -n "$(git status --porcelain -- apps/api/src/five08/backend/static/dashboard)" ]; then
+if ! diff_output=$(diff -qr "$dashboard_static_dir" "$dashboard_build_dir"); then
   echo
   echo "Dashboard build output is stale. Run 'cd apps/admin_dashboard && bun run build' and commit the generated static assets."
-  git status --short -- apps/api/src/five08/backend/static/dashboard
+  echo "$diff_output"
+  exit 1
+fi
+if [ -n "$(git status --porcelain -- "$dashboard_static_dir")" ]; then
+  echo
+  echo "Dashboard build output is stale. Run 'cd apps/admin_dashboard && bun run build' and commit the generated static assets."
+  git status --short -- "$dashboard_static_dir"
   exit 1
 fi
 echo

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -8,7 +8,7 @@ echo
 echo
 
 echo "Checking Python formatting..."
-uv run ruff format --check apps packages tests
+uv run ruff format --check apps/api/src/five08 apps/discord_bot/src/five08 apps/worker/src/five08 packages/shared/src/five08 tests
 echo
 
 ./scripts/typecheck.sh

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,6 +5,9 @@ script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
 . "$script_dir/worktree-env.sh"
 worktree_env_load "$script_dir"
 
+UV_BIN=${UV_BIN:-$(command -v uv)}
+export UV_BIN
+
 # dev.sh owns host-run service URLs so every launched process shares the same
 # worktree-local infra and app ports.
 export REDIS_URL="redis://127.0.0.1:${REDIS_HOST_PORT}/0"
@@ -41,7 +44,7 @@ start_infra() {
 }
 
 run_migrations() {
-  uv run --package worker python3 -c 'from five08.worker.db_migrations import run_job_migrations; run_job_migrations()'
+  "$UV_BIN" run --package worker python3 -c 'from five08.worker.db_migrations import run_job_migrations; run_job_migrations()'
 }
 
 reclaim_service_port() {
@@ -220,7 +223,7 @@ EOF
   web|api)
     reclaim_service_port web
     run_migrations
-    exec uv run --package api uvicorn five08.backend.api:create_app \
+    exec "$UV_BIN" run --package api uvicorn five08.backend.api:create_app \
       --factory \
       --host "${WEB_HOST:-${WEBHOOK_INGEST_HOST:-0.0.0.0}}" \
       --port "$WEB_PORT" \
@@ -231,11 +234,12 @@ EOF
     ;;
   worker)
     run_migrations
-    exec uv run watchfiles \
+    worker_command="$(shell_quote "$UV_BIN") run --package worker worker-consumer"
+    exec "$UV_BIN" run watchfiles \
       --filter python \
       --sigint-timeout 5 \
       --sigkill-timeout 10 \
-      'uv run --package worker worker-consumer' \
+      "$worker_command" \
       apps/worker/src \
       packages/shared/src
     ;;

--- a/scripts/dev_mux.py
+++ b/scripts/dev_mux.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import os
+import shlex
+import shutil
 import signal
 import socket
 import subprocess
@@ -33,11 +35,13 @@ def _service_commands(
     env: dict[str, str], selected_services: set[str] | None = None
 ) -> list[tuple[str, list[str]]]:
     selected_services = selected_services or set(ALL_SERVICES)
+    uv_bin = env.get("UV_BIN") or shutil.which("uv") or "uv"
+    uv_command = shlex.quote(uv_bin)
     commands = [
         (
             "web",
             [
-                "uv",
+                uv_bin,
                 "run",
                 "--package",
                 "api",
@@ -60,7 +64,7 @@ def _service_commands(
         (
             "worker",
             [
-                "uv",
+                uv_bin,
                 "run",
                 "watchfiles",
                 "--filter",
@@ -69,7 +73,7 @@ def _service_commands(
                 "5",
                 "--sigkill-timeout",
                 "10",
-                "uv run --package worker worker-consumer",
+                f"{uv_command} run --package worker worker-consumer",
                 "apps/worker/src",
                 "packages/shared/src",
             ],
@@ -77,7 +81,7 @@ def _service_commands(
         (
             "discord-bot",
             [
-                "uv",
+                uv_bin,
                 "run",
                 "watchfiles",
                 "--filter",
@@ -86,7 +90,7 @@ def _service_commands(
                 "5",
                 "--sigkill-timeout",
                 "10",
-                "uv run --package discord_bot discord-bot",
+                f"{uv_command} run --package discord_bot discord-bot",
                 "apps/discord_bot/src",
                 "packages/shared/src",
             ],

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -2,7 +2,7 @@
 set -eu
 
 echo "Running ruff format..."
-uv run ruff format apps packages tests
+uv run ruff format apps/api/src/five08 apps/discord_bot/src/five08 apps/worker/src/five08 packages/shared/src/five08 tests
 
 echo
 echo "Running admin dashboard format..."

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,5 +1,12 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env sh
+set -eu
 
 echo "Running ruff format..."
-uv run ruff format apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
+uv run ruff format apps packages tests
+
+echo
+echo "Running admin dashboard format..."
+(
+  cd apps/admin_dashboard
+  bun run format
+)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,5 +1,12 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env sh
+set -eu
 
 echo "Running ruff check..."
-uv run ruff check apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
+uv run ruff check apps packages tests
+
+echo
+echo "Running admin dashboard lint..."
+(
+  cd apps/admin_dashboard
+  bun run lint
+)

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,7 +2,7 @@
 set -eu
 
 echo "Running ruff check..."
-uv run ruff check apps packages tests
+uv run ruff check apps/api/src/five08 apps/discord_bot/src/five08 apps/worker/src/five08 packages/shared/src/five08 tests
 
 echo
 echo "Running admin dashboard lint..."

--- a/scripts/mypy.sh
+++ b/scripts/mypy.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env sh
+set -eu
 
 echo "Running mypy..."
 uv run mypy apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ --ignore-missing-imports --explicit-package-bases

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,12 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env sh
+set -eu
 
 echo "Running tests..."
 uv run pytest tests/ -v --tb=short
+
+echo
+echo "Running admin dashboard tests..."
+(
+  cd apps/admin_dashboard
+  bun run test
+)

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+set -eu
+
+./scripts/mypy.sh
+
+echo
+echo "Running admin dashboard typecheck..."
+(
+  cd apps/admin_dashboard
+  bun run typecheck
+)

--- a/tests/integration/test_dashboard_playwright.py
+++ b/tests/integration/test_dashboard_playwright.py
@@ -427,6 +427,10 @@ def test_dashboard_interactivity_with_playwright(dashboard_server: str) -> None:
             gig_application_requested.set()
             body = route.request.post_data_json
             assert body["status"] == "unavailable"
+            for application in gigs_list_payload[0]["applications"]:
+                if application["id"] == "22222222-2222-4222-8222-222222222222":
+                    application["status"] = "unavailable"
+                    break
             route.fulfill(
                 status=200,
                 content_type="application/json",
@@ -643,7 +647,7 @@ def test_dashboard_interactivity_with_playwright(dashboard_server: str) -> None:
             ):
                 casey_status.select_option("unavailable")
             assert gig_application_requested.wait(timeout=5)
-            expect(casey_status).to_have_value(re.compile("suggested|unavailable"))
+            expect(casey_status).to_have_value("unavailable")
             assert gig_detail_requests
 
             gigs_list_payload = []

--- a/tests/integration/test_dashboard_playwright.py
+++ b/tests/integration/test_dashboard_playwright.py
@@ -627,10 +627,23 @@ def test_dashboard_interactivity_with_playwright(dashboard_server: str) -> None:
             page.get_by_role("button", name="Add candidate").click()
             assert gig_application_add_requested.wait(timeout=5)
             page.get_by_text("Devon Candidate").wait_for()
-            page.get_by_label("Candidate status for Casey Candidate").select_option(
-                "unavailable"
-            )
+            casey_status = page.get_by_label("Candidate status for Casey Candidate")
+            expect(casey_status).to_be_enabled()
+            expect(casey_status).to_have_value("suggested")
+            with page.expect_request(
+                lambda request: (
+                    request.method == "POST"
+                    and request.url.endswith(
+                        "/dashboard/api/gigs/"
+                        "11111111-1111-4111-8111-111111111111"
+                        "/applications/"
+                        "22222222-2222-4222-8222-222222222222/status"
+                    )
+                )
+            ):
+                casey_status.select_option("unavailable")
             assert gig_application_requested.wait(timeout=5)
+            expect(casey_status).to_have_value(re.compile("suggested|unavailable"))
             assert gig_detail_requests
 
             gigs_list_payload = []

--- a/tests/integration/test_dashboard_playwright.py
+++ b/tests/integration/test_dashboard_playwright.py
@@ -427,16 +427,21 @@ def test_dashboard_interactivity_with_playwright(dashboard_server: str) -> None:
             gig_application_requested.set()
             body = route.request.post_data_json
             assert body["status"] == "unavailable"
+            casey_application_id = "22222222-2222-4222-8222-222222222222"
             for application in gigs_list_payload[0]["applications"]:
-                if application["id"] == "22222222-2222-4222-8222-222222222222":
+                if application["id"] == casey_application_id:
                     application["status"] = "unavailable"
                     break
+            else:
+                raise AssertionError(
+                    f"Expected Casey Candidate application fixture {casey_application_id}"
+                )
             route.fulfill(
                 status=200,
                 content_type="application/json",
                 body=json.dumps(
                     {
-                        "id": "22222222-2222-4222-8222-222222222222",
+                        "id": casey_application_id,
                         "status": "unavailable",
                     }
                 ),


### PR DESCRIPTION
## Summary

- Align top-level quality scripts with useful 508-devkit conventions.
- Add `scripts/typecheck.sh` and make `check-all` a non-mutating gate that runs lint, Python format check, typecheck, tests, and dashboard build.
- Extend top-level lint/format/test wrappers to include the admin dashboard where applicable.
- Align dashboard Bun install policy with devkit cooldown exclusions and isolated linker.
- Update README and DEVELOPMENT command references.

## Validation

- `./scripts/check-all.sh`

Result: Ruff, Biome, Python formatting check, mypy, dashboard TypeScript, Python tests, dashboard tests, and dashboard build all passed. Python tests reported `1651 passed, 20 skipped`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup and common commands documentation with refined quality-check instructions.

* **Tests**
  * Enhanced dashboard application status change testing with dynamic payload handling.

* **Chores**
  * Refactored development scripts for consistency and improved error handling.
  * Updated Bun configuration to exclude specific packages from dependency age filtering and reduce accidental dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->