### PR TITLE
[codex] Harden dashboard and Discord security boundaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,9 @@ WEB_HOST_BIND=127.0.0.1
 # WEBHOOK_INGEST_HOST_BIND, WEBHOOK_INGEST_HOST_PORT.
 # Required: ingest requests are rejected when unset
 API_SHARED_SECRET=
+# Optional: separate secret for external /webhooks/* callers. When unset,
+# webhook routes fall back to API_SHARED_SECRET for compatibility.
+WEBHOOK_SHARED_SECRET=
 # Authentik admin API (required for /create-sso-user and /create-user-accounts)
 # Base URL can omit /api/v3; the client adds it automatically.
 AUTHENTIK_API_BASE_URL=

--- a/.env.example
+++ b/.env.example
@@ -66,10 +66,11 @@ WEB_HOST_BIND=127.0.0.1
 # `WEB_PORT` with a deterministic per-worktree port automatically.
 # Deprecated fallback names still work: WEBHOOK_INGEST_HOST, WEBHOOK_INGEST_PORT,
 # WEBHOOK_INGEST_HOST_BIND, WEBHOOK_INGEST_HOST_PORT.
-# Required: ingest requests are rejected when unset
+# Required for protected non-dashboard API routes. Webhook routes use this only
+# when WEBHOOK_SHARED_SECRET is unset.
 API_SHARED_SECRET=
-# Optional: separate secret for external /webhooks/* callers. When unset,
-# webhook routes fall back to API_SHARED_SECRET for compatibility.
+# Optional: separate secret for external /webhooks/* callers. When unset or
+# blank, webhook routes fall back to API_SHARED_SECRET for compatibility.
 WEBHOOK_SHARED_SECRET=
 # Authentik admin API (required for /create-sso-user and /create-user-accounts)
 # Base URL can omit /api/v3; the client adds it automatically.

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -410,17 +410,47 @@ def _get_agent_orchestrator() -> AgentOrchestrator:
     return _AGENT_ORCHESTRATOR
 
 
-def _is_authorized(request: Request) -> bool:
-    """Validate shared API secret."""
-    if not settings.api_shared_secret:
-        logger.error("Rejecting request: API_SHARED_SECRET is not configured")
+def _is_authorized_with_secret(
+    request: Request,
+    *,
+    configured_secret: str | None,
+    setting_name: str,
+) -> bool:
+    """Validate an X-API-Secret header against one configured secret."""
+    if not configured_secret:
+        logger.error("Rejecting request: %s is not configured", setting_name)
         return False
 
     provided_secret = request.headers.get("X-API-Secret", "")
-    if secrets.compare_digest(provided_secret, settings.api_shared_secret):
+    if secrets.compare_digest(provided_secret, configured_secret):
         return True
-    logger.warning("Rejecting request: invalid X-API-Secret")
+    logger.warning("Rejecting request: invalid X-API-Secret for %s", setting_name)
     return False
+
+
+def _is_authorized(request: Request) -> bool:
+    """Validate the internal shared API secret."""
+    return _is_authorized_with_secret(
+        request,
+        configured_secret=settings.api_shared_secret,
+        setting_name="API_SHARED_SECRET",
+    )
+
+
+def _is_webhook_authorized(request: Request) -> bool:
+    """Validate the external webhook secret, with legacy API secret fallback."""
+    if settings.webhook_shared_secret:
+        return _is_authorized_with_secret(
+            request,
+            configured_secret=settings.webhook_shared_secret,
+            setting_name="WEBHOOK_SHARED_SECRET",
+        )
+
+    return _is_authorized_with_secret(
+        request,
+        configured_secret=settings.api_shared_secret,
+        setting_name="API_SHARED_SECRET",
+    )
 
 
 def _agent_request_rate_limited(discord_user_id: str) -> bool:
@@ -2411,7 +2441,7 @@ async def health_handler(request: Request) -> JSONResponse:
 
 async def ingest_handler(request: Request, source: str) -> JSONResponse:
     """Validate and enqueue incoming webhook payloads."""
-    if not _is_authorized(request):
+    if not _is_webhook_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     try:
@@ -2446,7 +2476,7 @@ async def ingest_handler(request: Request, source: str) -> JSONResponse:
 
 async def espocrm_webhook_handler(request: Request) -> JSONResponse:
     """Validate EspoCRM webhook payload and enqueue per-contact jobs."""
-    if not _is_authorized(request):
+    if not _is_webhook_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     try:
@@ -5856,7 +5886,7 @@ async def dashboard_sync_people_handler(request: Request) -> JSONResponse:
 
 async def espocrm_people_sync_webhook_handler(request: Request) -> JSONResponse:
     """Queue per-contact people cache sync jobs from CRM webhook events."""
-    if not _is_authorized(request):
+    if not _is_webhook_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     try:
@@ -5910,7 +5940,7 @@ async def docuseal_webhook_handler(request: Request) -> JSONResponse:
     Job payload contract for the queue is:
     completed_at = "YYYY-MM-DD HH:mm:ss" in UTC.
     """
-    if not _is_authorized(request):
+    if not _is_webhook_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     try:
@@ -6027,7 +6057,7 @@ async def docuseal_webhook_handler(request: Request) -> JSONResponse:
 
 async def google_forms_intake_webhook_handler(request: Request) -> JSONResponse:
     """Validate a Google Forms intake submission and enqueue a processing job."""
-    if not _is_authorized(request):
+    if not _is_webhook_authorized(request):
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     try:

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -417,12 +417,13 @@ def _is_authorized_with_secret(
     setting_name: str,
 ) -> bool:
     """Validate an X-API-Secret header against one configured secret."""
-    if not configured_secret:
+    secret = (configured_secret or "").strip()
+    if not secret:
         logger.error("Rejecting request: %s is not configured", setting_name)
         return False
 
     provided_secret = request.headers.get("X-API-Secret", "")
-    if secrets.compare_digest(provided_secret, configured_secret):
+    if secrets.compare_digest(provided_secret, secret):
         return True
     logger.warning("Rejecting request: invalid X-API-Secret for %s", setting_name)
     return False
@@ -439,10 +440,11 @@ def _is_authorized(request: Request) -> bool:
 
 def _is_webhook_authorized(request: Request) -> bool:
     """Validate the external webhook secret, with legacy API secret fallback."""
-    if settings.webhook_shared_secret:
+    webhook_secret = (settings.webhook_shared_secret or "").strip()
+    if webhook_secret:
         return _is_authorized_with_secret(
             request,
-            configured_secret=settings.webhook_shared_secret,
+            configured_secret=webhook_secret,
             setting_name="WEBHOOK_SHARED_SECRET",
         )
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -1084,7 +1084,7 @@ class ResumeConfirmationView(discord.ui.View):
         button: discord.ui.Button["ResumeConfirmationView"],
     ) -> None:
         """Proceed with the upload despite duplicate."""
-        await interaction.response.defer()
+        await interaction.response.defer(ephemeral=True)
 
         try:
             # Download file content from Discord

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm.py
@@ -351,7 +351,7 @@ class ContactSelectionButton(discord.ui.Button[ContactSelectionView]):
 
             # Get the CRM cog to perform the linking
             if not self.view:
-                await interaction.followup.send("❌ View not found.")
+                await interaction.followup.send("❌ View not found.", ephemeral=True)
                 return
 
             from discord.ext import commands
@@ -360,7 +360,7 @@ class ContactSelectionButton(discord.ui.Button[ContactSelectionView]):
             assert isinstance(bot, commands.Bot)
             cog = bot.get_cog("CRMCog")
             if not cog or not isinstance(cog, CRMCog):
-                await interaction.followup.send("❌ CRM cog not found.")
+                await interaction.followup.send("❌ CRM cog not found.", ephemeral=True)
                 return
 
             # Perform the Discord linking
@@ -397,7 +397,8 @@ class ContactSelectionButton(discord.ui.Button[ContactSelectionView]):
         except Exception as e:
             logger.error(f"Error in contact selection callback: {e}")
             await interaction.followup.send(
-                "❌ An error occurred while linking the contact."
+                "❌ An error occurred while linking the contact.",
+                ephemeral=True,
             )
 
 
@@ -768,7 +769,8 @@ class MarkIdVerifiedSelectionButton(discord.ui.Button["MarkIdVerifiedSelectionVi
         except Exception as exc:
             logger.error(f"Error in ID verified selection callback: {exc}")
             await interaction.followup.send(
-                "❌ An error occurred while marking ID verification."
+                "❌ An error occurred while marking ID verification.",
+                ephemeral=True,
             )
 
 
@@ -876,7 +878,8 @@ class ReprocessResumeSelectionButton(discord.ui.Button["ReprocessResumeSelection
         except Exception as exc:
             logger.error("Error in reprocess resume selection callback: %s", exc)
             await interaction.followup.send(
-                "❌ An error occurred while handling the selection."
+                "❌ An error occurred while handling the selection.",
+                ephemeral=True,
             )
 
 
@@ -1098,7 +1101,9 @@ class ResumeConfirmationView(discord.ui.View):
 
             attachment_id = attachment.get("id")
             if not attachment_id:
-                await interaction.followup.send("❌ Failed to upload file to CRM.")
+                await interaction.followup.send(
+                    "❌ Failed to upload file to CRM.", ephemeral=True
+                )
                 return
 
             # Update contact's resume field (use original overwrite setting)
@@ -1125,7 +1130,7 @@ class ResumeConfirmationView(discord.ui.View):
                     inline=False,
                 )
 
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
                 logger.info(
                     f"Resume uploaded for {self.contact_name} (ID: {self.contact_id}) "
@@ -1133,13 +1138,15 @@ class ResumeConfirmationView(discord.ui.View):
                 )
             else:
                 await interaction.followup.send(
-                    "⚠️ File uploaded but failed to link to contact. Please check CRM manually."
+                    "⚠️ File uploaded but failed to link to contact. Please check CRM manually.",
+                    ephemeral=True,
                 )
 
         except Exception as e:
             logger.error(f"Error during confirmed resume upload: {e}")
             await interaction.followup.send(
-                "❌ An error occurred while uploading the resume."
+                "❌ An error occurred while uploading the resume.",
+                ephemeral=True,
             )
 
         # Disable all buttons
@@ -5260,7 +5267,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"reason": "missing_query_and_skills"},
                 )
                 await interaction.followup.send(
-                    "❌ Please provide a search term or `skills:...` to search by."
+                    "❌ Please provide a search term or `skills:...` to search by.",
+                    ephemeral=True,
                 )
                 return
 
@@ -5319,7 +5327,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         "❌ Your Discord account is not linked to a CRM contact. "
-                        "Please ask a Steering Committee member to link your account first."
+                        "Please ask a Steering Committee member to link your account first.",
+                        ephemeral=True,
                     )
                     return
 
@@ -5403,7 +5412,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    f"🔍 No contacts found for: {search_summary}"
+                    f"🔍 No contacts found for: {search_summary}",
+                    ephemeral=True,
                 )
                 return
 
@@ -5422,7 +5432,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                             "error": "missing_contact_id",
                         },
                     )
-                    await interaction.followup.send("❌ Contact ID not found.")
+                    await interaction.followup.send(
+                        "❌ Contact ID not found.", ephemeral=True
+                    )
                     return
 
                 full_contact = self.espo_api.request("GET", f"Contact/{contact_id}")
@@ -5436,10 +5448,11 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
                 if skills_count == 0:
                     await interaction.followup.send(
-                        f"ℹ️ No skills found for **{contact_name}**."
+                        f"ℹ️ No skills found for **{contact_name}**.",
+                        ephemeral=True,
                     )
                 else:
-                    await interaction.followup.send(embed=skill_embed)
+                    await interaction.followup.send(embed=skill_embed, ephemeral=True)
 
                 self._audit_command_safe(
                     interaction=interaction,
@@ -5510,9 +5523,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
             # Send embed with view only if there are buttons
             if view.children:
-                await interaction.followup.send(embed=embed, view=view)
+                await interaction.followup.send(embed=embed, view=view, ephemeral=True)
             else:
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
             self._audit_command(
                 interaction=interaction,
@@ -5536,7 +5549,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in CRM search: {e}")
             self._audit_command(
@@ -5546,7 +5561,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while searching the CRM."
+                "❌ An unexpected error occurred while searching the CRM.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -5577,7 +5593,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
                 await interaction.followup.send(
                     "❌ Could not resolve a valid 508 onboarder username. "
-                    "Use a 508 username directly or a linked Discord mention."
+                    "Use a 508 username directly or a linked Discord mention.",
+                    ephemeral=True,
                 )
                 return
 
@@ -5589,7 +5606,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     result="error",
                     metadata={"contact": contact, "onboarder": onboarder_username},
                 )
-                await interaction.followup.send(f"❌ No contact found for: `{contact}`")
+                await interaction.followup.send(
+                    f"❌ No contact found for: `{contact}`", ephemeral=True
+                )
                 return
 
             if len(contacts) > 1:
@@ -5615,7 +5634,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         value=contact_info,
                         inline=False,
                     )
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
                 self._audit_command(
                     interaction=interaction,
                     action="crm.assign_onboarder",
@@ -5637,7 +5656,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     result="error",
                     metadata={"contact": contact, "onboarder": onboarder_username},
                 )
-                await interaction.followup.send("❌ Selected contact is missing an ID.")
+                await interaction.followup.send(
+                    "❌ Selected contact is missing an ID.", ephemeral=True
+                )
                 return
 
             full_contact = self.espo_api.request("GET", f"Contact/{contact_id}")
@@ -5655,7 +5676,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     resource_id=str(contact_id),
                 )
                 await interaction.followup.send(
-                    "❌ Could not locate the `cOnboarder` field for this CRM contact."
+                    "❌ Could not locate the `cOnboarder` field for this CRM contact.",
+                    ephemeral=True,
                 )
                 return
 
@@ -5679,7 +5701,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 f"✅ Assigned **{onboarder_username}** as onboarder for "
-                f"**{contact_name}** (`{contact_id}`); {status_line}."
+                f"**{contact_name}** (`{contact_id}`); {status_line}.",
+                ephemeral=True,
             )
             self._audit_command(
                 interaction=interaction,
@@ -5704,7 +5727,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"contact": contact, "onboarder": onboarder, "error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in assign_onboarder: {e}")
             self._audit_command(
@@ -5714,7 +5739,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"contact": contact, "onboarder": onboarder, "error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while assigning the onboarder."
+                "❌ An unexpected error occurred while assigning the onboarder.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -5757,7 +5783,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"count": 0},
                 )
                 await interaction.followup.send(
-                    "✅ No contacts found in onboarding queue."
+                    "✅ No contacts found in onboarding queue.",
+                    ephemeral=True,
                 )
                 return
 
@@ -5785,11 +5812,14 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             if view.total_pages > 1:
                 message = await interaction.followup.send(
-                    embed=embed, view=view, wait=True
+                    embed=embed,
+                    view=view,
+                    wait=True,
+                    ephemeral=True,
                 )
                 view._set_message(message)
             else:
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
         except EspoAPIError as e:
             logger.error(f"EspoCRM API error in view_onboarding_queue: {e}")
@@ -5799,7 +5829,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in view_onboarding_queue: {e}")
             self._audit_command(
@@ -5809,7 +5841,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while loading onboarding queue."
+                "❌ An unexpected error occurred while loading onboarding queue.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -5832,7 +5865,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             embed.add_field(name="Connected as", value=user_name, inline=True)
             embed.add_field(name="Base URL", value=settings.espo_base_url, inline=True)
 
-            await interaction.followup.send(embed=embed)
+            await interaction.followup.send(embed=embed, ephemeral=True)
             self._audit_command(
                 interaction=interaction,
                 action="crm.status",
@@ -5853,7 +5886,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 description=f"Failed to connect to EspoCRM: {str(e)}",
                 color=0xFF0000,
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.followup.send(embed=embed, ephemeral=True)
         except Exception as e:
             logger.error(f"Unexpected error in CRM status: {e}")
             self._audit_command(
@@ -5867,7 +5900,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 description="An unexpected error occurred while checking CRM status.",
                 color=0xFF0000,
             )
-            await interaction.followup.send(embed=embed)
+            await interaction.followup.send(embed=embed, ephemeral=True)
 
     @app_commands.command(
         name="get-resume", description="Download and send a contact's resume"
@@ -5894,7 +5927,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     result="success",
                     metadata={"query": query, "contact_found": False},
                 )
-                await interaction.followup.send(f"❌ No contact found for: `{query}`")
+                await interaction.followup.send(
+                    f"❌ No contact found for: `{query}`", ephemeral=True
+                )
                 return
 
             contact = contacts[0]
@@ -5916,7 +5951,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    f"❌ No resume found for {contact_name}"
+                    f"❌ No resume found for {contact_name}",
+                    ephemeral=True,
                 )
                 return
 
@@ -5954,7 +5990,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"query": query, "error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in get_resume: {e}")
             self._audit_command(
@@ -5964,7 +6002,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"query": query, "error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while fetching the resume."
+                "❌ An unexpected error occurred while fetching the resume.",
+                ephemeral=True,
             )
 
     def _is_hex_string(self, s: str) -> bool:
@@ -6268,7 +6307,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             await interaction.followup.send(
                 "❌ Invalid file type. "
                 f"Upload a {resume_config.allowed_file_extensions_label} file.\n"
-                f"You uploaded: `{attachment.filename}`"
+                f"You uploaded: `{attachment.filename}`",
+                ephemeral=True,
             )
             return False
 
@@ -6285,7 +6325,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 f"❌ File too large. Maximum size is {resume_config.max_file_size_mb}MB.\n"
-                f"Your file: {attachment.size / (1024 * 1024):.1f}MB"
+                f"Your file: {attachment.size / (1024 * 1024):.1f}MB",
+                ephemeral=True,
             )
             return False
 
@@ -6997,7 +7038,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
                 await interaction.followup.send(
                     f"ℹ️ Nothing changed. **{contact_name}** is already linked to "
-                    f"{user.mention} ({discord_display})."
+                    f"{user.mention} ({discord_display}).",
+                    ephemeral=True,
                 )
                 return True
 
@@ -7032,6 +7074,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         user=user,
                         requester_id=interaction.user.id,
                     ),
+                    ephemeral=True,
                 )
                 return False
 
@@ -7077,7 +7120,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         inline=True,
                     )
 
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
                 logger.info(
                     f"Discord user {user.name} (ID: {user.id}) linked to CRM contact "
@@ -7110,7 +7153,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     resource_id=str(contact_id),
                 )
                 await interaction.followup.send(
-                    "❌ Failed to update contact in CRM. Please try again."
+                    "❌ Failed to update contact in CRM. Please try again.",
+                    ephemeral=True,
                 )
                 return False
 
@@ -7122,7 +7166,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"linked_user_id": str(user.id), "error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
             return False
         except Exception as e:
             logger.error(f"Unexpected error in _perform_discord_linking: {e}")
@@ -7133,7 +7179,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"linked_user_id": str(user.id), "error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while linking the user."
+                "❌ An unexpected error occurred while linking the user.",
+                ephemeral=True,
             )
             return False
 
@@ -7174,7 +7221,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             inline=False,
         )
 
-        await interaction.followup.send(embed=embed, view=view)
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
     def _normalize_508_username(self, value: str | None) -> str | None:
         """Normalize a 508 username candidate."""
@@ -7389,7 +7436,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "error": "contact_id_missing",
                 },
             )
-            await interaction.followup.send("❌ Contact ID not found.")
+            await interaction.followup.send("❌ Contact ID not found.", ephemeral=True)
             return False
 
         try:
@@ -7412,7 +7459,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_id=str(contact_id),
             )
             await interaction.followup.send(
-                "❌ Failed to load current verification data from CRM."
+                "❌ Failed to load current verification data from CRM.",
+                ephemeral=True,
             )
             return False
 
@@ -7470,6 +7518,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "Select **Overwrite** only if you want to replace existing values."
                 ),
                 view=confirm_view,
+                ephemeral=True,
             )
             return False
 
@@ -7500,7 +7549,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     value=f"[View in CRM]({profile_url})",
                     inline=True,
                 )
-                await interaction.followup.send(embed=embed)
+                await interaction.followup.send(embed=embed, ephemeral=True)
 
                 self._audit_command(
                     interaction=interaction,
@@ -7530,7 +7579,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_id=str(contact_id),
             )
             await interaction.followup.send(
-                "❌ Failed to update contact in CRM. Please try again."
+                "❌ Failed to update contact in CRM. Please try again.",
+                ephemeral=True,
             )
             return False
 
@@ -7549,7 +7599,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_type="crm_contact",
                 resource_id=str(contact_id),
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(exc)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(exc)}", ephemeral=True
+            )
             return False
         except Exception as exc:
             logger.error(f"Unexpected error marking ID verification: {exc}")
@@ -7567,7 +7619,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_id=str(contact_id),
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while marking ID verification."
+                "❌ An unexpected error occurred while marking ID verification.",
+                ephemeral=True,
             )
             return False
 
@@ -7615,7 +7668,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             inline=False,
         )
 
-        await interaction.followup.send(embed=embed, view=view)
+        await interaction.followup.send(embed=embed, view=view, ephemeral=True)
 
     async def _show_create_sso_user_contact_choices(
         self,
@@ -8659,7 +8712,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ Unable to resolve verifier from `verified_by`."
+                    "❌ Unable to resolve verifier from `verified_by`.",
+                    ephemeral=True,
                 )
                 return
 
@@ -8690,7 +8744,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    f"❌ No contact found for: `{search_term}`"
+                    f"❌ No contact found for: `{search_term}`",
+                    ephemeral=True,
                 )
                 return
 
@@ -8748,7 +8803,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="denied",
                 metadata={"verified_at": verified_at, "reason": str(exc)},
             )
-            await interaction.followup.send(f"❌ {exc}")
+            await interaction.followup.send(f"❌ {exc}", ephemeral=True)
         except Exception as exc:
             logger.error(f"Unexpected error in mark_id_verified: {exc}")
             self._audit_command(
@@ -8758,7 +8813,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"search_term": search_term, "error": str(exc)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while marking ID verification."
+                "❌ An unexpected error occurred while marking ID verification.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -8986,7 +9042,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"search_term": search_term, "contacts_found": 0},
                 )
                 await interaction.followup.send(
-                    f"❌ No contact found for: `{search_term}`"
+                    f"❌ No contact found for: `{search_term}`",
+                    ephemeral=True,
                 )
                 return
 
@@ -9015,7 +9072,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 await interaction.followup.send(
                     "⚠️ Multiple contacts found. Please refine your search:\n"
                     + "\n".join(lines)
-                    + suffix
+                    + suffix,
+                    ephemeral=True,
                 )
                 return
 
@@ -9044,7 +9102,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
                 await interaction.followup.send(
                     f"⚠️ **{contact_name}** already signed the member agreement at "
-                    f"`{signed_at}`. No DocuSeal submission was sent."
+                    f"`{signed_at}`. No DocuSeal submission was sent.",
+                    ephemeral=True,
                 )
                 return
 
@@ -9062,7 +9121,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     resource_id=contact_id,
                 )
                 await interaction.followup.send(
-                    f"❌ **{contact_name}** does not have an email address in CRM."
+                    f"❌ **{contact_name}** does not have an email address in CRM.",
+                    ephemeral=True,
                 )
                 return
 
@@ -9091,7 +9151,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 f"✅ Sent the member agreement to **{contact_name}** at `{contact_email}`."
-                f"{submission_label}"
+                f"{submission_label}",
+                ephemeral=True,
             )
         except ValueError as exc:
             logger.error("Member agreement command configuration/input error: %s", exc)
@@ -9101,7 +9162,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"search_term": search_term, "error": str(exc)},
             )
-            await interaction.followup.send(f"❌ {exc}")
+            await interaction.followup.send(f"❌ {exc}", ephemeral=True)
         except DocusealAPIError as exc:
             logger.error("DocuSeal API error in send_member_agreement: %s", exc)
             sanitized_error = self._sanitize_error_message_for_discord(exc)
@@ -9111,7 +9172,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"search_term": search_term, "error": sanitized_error},
             )
-            await interaction.followup.send(f"❌ DocuSeal API error: {sanitized_error}")
+            await interaction.followup.send(
+                f"❌ DocuSeal API error: {sanitized_error}", ephemeral=True
+            )
         except Exception as exc:
             logger.error("Unexpected error in send_member_agreement: %s", exc)
             self._audit_command(
@@ -9121,7 +9184,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"search_term": search_term, "error": str(exc)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while sending the member agreement."
+                "❌ An unexpected error occurred while sending the member agreement.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -9158,7 +9222,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    f"❌ No contact found for: `{search_term}`"
+                    f"❌ No contact found for: `{search_term}`",
+                    ephemeral=True,
                 )
                 return
 
@@ -9209,7 +9274,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "error": str(e),
                 },
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in link_discord_user: {e}")
             self._audit_command(
@@ -9223,7 +9290,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while linking the Discord user."
+                "❌ An unexpected error occurred while linking the Discord user.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -9244,7 +9312,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"reason": "not_in_guild"},
                 )
                 await interaction.followup.send(
-                    "❌ This command can only be used in a server."
+                    "❌ This command can only be used in a server.",
+                    ephemeral=True,
                 )
                 return
 
@@ -9272,7 +9341,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     metadata={"unlinked_count": 0},
                 )
                 await interaction.followup.send(
-                    "✅ **All Members Linked**\nAll Discord users with Member role are linked in the CRM!"
+                    "✅ **All Members Linked**\nAll Discord users with Member role are linked in the CRM!",
+                    ephemeral=True,
                 )
                 return
 
@@ -9293,7 +9363,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in unlinked_discord_users: {e}")
             self._audit_command(
@@ -9303,7 +9375,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while checking unlinked users."
+                "❌ An unexpected error occurred while checking unlinked users.",
+                ephemeral=True,
             )
 
     async def _get_linked_discord_user_ids(self) -> set[str]:
@@ -9348,7 +9421,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
         # Discord message limit is 2000 characters, split if needed
         if len(message) <= 2000:
-            await interaction.followup.send(message)
+            await interaction.followup.send(message, ephemeral=True)
         else:
             # Split into multiple messages if too long
             messages = []
@@ -9369,7 +9442,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
             # Send all messages
             for message in messages:
-                await interaction.followup.send(message)
+                await interaction.followup.send(message, ephemeral=True)
 
     async def _find_contact_by_discord_id(
         self,
@@ -9823,7 +9896,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "You must have Steering Committee role or higher to run this."
+                "You must have Steering Committee role or higher to run this.",
+                ephemeral=True,
             )
             return
 
@@ -9848,7 +9922,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
             )
             await interaction.followup.send(
                 "No contacts found with missing country/timezone, skills/roles, "
-                "or seniority and reprocessable profile inputs."
+                "or seniority and reprocessable profile inputs.",
+                ephemeral=True,
             )
             return
 
@@ -10041,7 +10116,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "reason": "contact_id_missing",
                 },
             )
-            await interaction.followup.send("❌ Contact ID not found.")
+            await interaction.followup.send("❌ Contact ID not found.", ephemeral=True)
             return
 
         contact_name = str(contact.get("name", "Unknown"))
@@ -10065,7 +10140,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_id=contact_id,
             )
             await interaction.followup.send(
-                f"❌ No resume found for `{contact_name}`. Upload a resume first."
+                f"❌ No resume found for `{contact_name}`. Upload a resume first.",
+                ephemeral=True,
             )
             return
 
@@ -10113,7 +10189,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "reason": "contact_id_missing",
                 },
             )
-            await interaction.followup.send("❌ Contact ID not found.")
+            await interaction.followup.send("❌ Contact ID not found.", ephemeral=True)
             return
 
         contact_name = str(contact.get("name", "Unknown"))
@@ -10167,7 +10243,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "stage": "upload_resume_prompt",
                 },
             )
-            await interaction.followup.send("❌ Contact ID not found.")
+            await interaction.followup.send("❌ Contact ID not found.", ephemeral=True)
             return
 
         contact_name = str(contact.get("name", "Unknown"))
@@ -10247,7 +10323,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 )
                 await interaction.followup.send(
                     "❌ Provide at least one of `github`, `linkedin`, `skills`, `rate_range`, "
-                    "`desired_hours`, `website`, `location`, or `resume`."
+                    "`desired_hours`, `website`, `location`, or `resume`.",
+                    ephemeral=True,
                 )
                 return
 
@@ -10276,7 +10353,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ You must have Steering Committee role or higher to update another contact."
+                    "❌ You must have Steering Committee role or higher to update another contact.",
+                    ephemeral=True,
                 )
                 return
 
@@ -10297,7 +10375,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        f"❌ No contact found for: `{search_term}`"
+                        f"❌ No contact found for: `{search_term}`",
+                        ephemeral=True,
                     )
                     return
 
@@ -10314,7 +10393,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        f"❌ Multiple contacts found for `{search_term}`. Please be more specific or use the contact ID."
+                        f"❌ Multiple contacts found for `{search_term}`. Please be more specific or use the contact ID.",
+                        ephemeral=True,
                     )
                     return
 
@@ -10336,7 +10416,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         "❌ Your Discord account is not linked to a CRM contact. "
-                        "Please ask a Steering Committee member to link your account first."
+                        "Please ask a Steering Committee member to link your account first.",
+                        ephemeral=True,
                     )
                     return
 
@@ -10352,7 +10433,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         "error": "contact_id_missing",
                     },
                 )
-                await interaction.followup.send("❌ Contact ID not found.")
+                await interaction.followup.send(
+                    "❌ Contact ID not found.", ephemeral=True
+                )
                 return
 
             contact_name = target_contact.get("name", "Unknown")
@@ -10394,7 +10477,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        "❌ Invalid desired_hours. Use a number between 0-60 or a range like `0-60`."
+                        "❌ Invalid desired_hours. Use a number between 0-60 or a range like `0-60`.",
+                        ephemeral=True,
                     )
                     return
 
@@ -10419,7 +10503,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         f"❌ Invalid website entries: {invalid_message}. "
-                        "Provide comma-separated URLs (e.g. `https://example.com, github.com/name`)."
+                        "Provide comma-separated URLs (e.g. `https://example.com, github.com/name`).",
+                        ephemeral=True,
                     )
                     return
                 if website_links:
@@ -10437,7 +10522,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        "❌ Invalid website list. Provide comma-separated URLs (e.g. `https://example.com, github.com/name`)."
+                        "❌ Invalid website list. Provide comma-separated URLs (e.g. `https://example.com, github.com/name`).",
+                        ephemeral=True,
                     )
                     return
 
@@ -10458,7 +10544,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        "❌ Unable to parse location. Try `City, State, Country` and optionally include `UTC-05:00` or `PST`."
+                        "❌ Unable to parse location. Try `City, State, Country` and optionally include `UTC-05:00` or `PST`.",
+                        ephemeral=True,
                     )
                     return
 
@@ -10480,7 +10567,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         f"❌ Invalid skill entries: {invalid_message}. "
-                        "Use `skill` or `skill:1-5` (e.g. `go`, `python:4`)."
+                        "Use `skill` or `skill:1-5` (e.g. `go`, `python:4`).",
+                        ephemeral=True,
                     )
                     return
 
@@ -10503,7 +10591,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ No valid updatable fields were provided."
+                    "❌ No valid updatable fields were provided.",
+                    ephemeral=True,
                 )
                 return
 
@@ -10603,7 +10692,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         value=f"[View in CRM]({profile_url})",
                         inline=True,
                     )
-                    await interaction.followup.send(embed=embed)
+                    await interaction.followup.send(embed=embed, ephemeral=True)
 
                     logger.info(
                         f"Contact updated for {contact_name} (ID: {contact_id}) fields={requested_updates} by {interaction.user.name}"
@@ -10634,7 +10723,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         resource_id=str(contact_id),
                     )
                     await interaction.followup.send(
-                        "❌ Failed to update contact in CRM. Please try again."
+                        "❌ Failed to update contact in CRM. Please try again.",
+                        ephemeral=True,
                     )
                     return
 
@@ -10661,7 +10751,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 result="error",
                 metadata={"search_term": search_term, "error": str(e)},
             )
-            await interaction.followup.send(f"❌ CRM API error: {str(e)}")
+            await interaction.followup.send(
+                f"❌ CRM API error: {str(e)}", ephemeral=True
+            )
         except Exception as e:
             logger.error(f"Unexpected error in update_contact: {e}")
             self._audit_command(
@@ -10671,7 +10763,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 metadata={"search_term": search_term, "error": str(e)},
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while updating the contact."
+                "❌ An unexpected error occurred while updating the contact.",
+                ephemeral=True,
             )
 
     def _parse_desired_hours(self, desired_hours: str) -> str | None:
@@ -11064,7 +11157,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "error": "contact_id_missing",
                 },
             )
-            await interaction.followup.send("❌ Contact ID not found.")
+            await interaction.followup.send("❌ Contact ID not found.", ephemeral=True)
             return
 
         try:
@@ -11090,7 +11183,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     resource_type="crm_contact",
                     resource_id=str(contact_id),
                 )
-                await interaction.followup.send("❌ Failed to upload file to CRM.")
+                await interaction.followup.send(
+                    "❌ Failed to upload file to CRM.", ephemeral=True
+                )
                 return
 
             if not await self._update_contact_resume(
@@ -11112,7 +11207,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     resource_id=str(contact_id),
                 )
                 await interaction.followup.send(
-                    "⚠️ File uploaded, but failed to link in contact resume field."
+                    "⚠️ File uploaded, but failed to link in contact resume field.",
+                    ephemeral=True,
                 )
                 return
 
@@ -11169,7 +11265,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 resource_id=str(contact_id),
             )
             await interaction.followup.send(
-                f"❌ Failed to upload file to CRM: {str(e)}"
+                f"❌ Failed to upload file to CRM: {str(e)}",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -11220,7 +11317,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ You must have Steering Committee role or higher to upload a resume for another contact."
+                    "❌ You must have Steering Committee role or higher to upload a resume for another contact.",
+                    ephemeral=True,
                 )
                 return
             if (
@@ -11239,7 +11337,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ You must have Steering Committee role or higher to upload a resume for another Discord user."
+                    "❌ You must have Steering Committee role or higher to upload a resume for another Discord user.",
+                    ephemeral=True,
                 )
                 return
             if not is_steering:
@@ -11268,7 +11367,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         },
                     )
                     await interaction.followup.send(
-                        f"❌ No contact found for: `{search_term}`"
+                        f"❌ No contact found for: `{search_term}`",
+                        ephemeral=True,
                     )
                     return
                 if len(contacts) > 1:
@@ -11286,7 +11386,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         f"⚠️ Multiple contacts found for `{search_term}`. "
-                        "Please be more specific or use the contact ID."
+                        "Please be more specific or use the contact ID.",
+                        ephemeral=True,
                     )
                     return
                 target_contact = contacts[0]
@@ -11337,6 +11438,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         "Would you like to create a new contact for this Discord user "
                         "from the resume details?",
                         view=view,
+                        ephemeral=True,
                     )
                     return
             elif is_steering:
@@ -11434,7 +11536,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                         )
                         await interaction.followup.send(
                             "⚠️ Resume-based contact inference failed. "
-                            "Please provide `search_term` or `link_user`."
+                            "Please provide `search_term` or `link_user`.",
+                            ephemeral=True,
                         )
                     return
                 target_scope = "resume"
@@ -11456,7 +11559,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     )
                     await interaction.followup.send(
                         "❌ Your Discord account is not linked to a CRM contact. "
-                        "Please ask a Steering Committee member to link your account first."
+                        "Please ask a Steering Committee member to link your account first.",
+                        ephemeral=True,
                     )
                     return
 
@@ -11487,7 +11591,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while uploading the resume."
+                "❌ An unexpected error occurred while uploading the resume.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -11519,7 +11624,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    "❌ You must have Steering Committee role or higher to reprocess another profile."
+                    "❌ You must have Steering Committee role or higher to reprocess another profile.",
+                    ephemeral=True,
                 )
                 return
 
@@ -11536,7 +11642,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     },
                 )
                 await interaction.followup.send(
-                    f"❌ No contact found for: `{search_term}`"
+                    f"❌ No contact found for: `{search_term}`",
+                    ephemeral=True,
                 )
                 return
 
@@ -11575,7 +11682,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "❌ An unexpected error occurred while reprocessing the profile."
+                "❌ An unexpected error occurred while reprocessing the profile.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -11614,7 +11722,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "An unexpected error occurred while loading bulk resume results."
+                "An unexpected error occurred while loading bulk resume results.",
+                ephemeral=True,
             )
 
     @app_commands.command(
@@ -11653,7 +11762,8 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 },
             )
             await interaction.followup.send(
-                "An unexpected error occurred while loading bulk profile results."
+                "An unexpected error occurred while loading bulk profile results.",
+                ephemeral=True,
             )
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -11,6 +11,9 @@ that most often matter in local development and deployment.
 - `LOG_LEVEL`: defaults to `INFO`.
 - `API_SHARED_SECRET`: required for protected non-dashboard API routes and for
   `./scripts/dev.sh login`.
+- `WEBHOOK_SHARED_SECRET`: optional separate secret for external `/webhooks/*`
+  callers such as DocuSeal, Google Forms, and EspoCRM. When unset, webhook
+  routes fall back to `API_SHARED_SECRET` for compatibility.
 
 ## Queue And Jobs
 

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -54,6 +54,7 @@ class SharedSettings(BaseSettings):
         validation_alias=AliasChoices("WEB_PORT", "WEBHOOK_INGEST_PORT"),
     )
     api_shared_secret: str | None = None
+    webhook_shared_secret: str | None = None
     discord_logs_webhook_url: str | None = None
     discord_logs_webhook_wait: bool = True
     docuseal_base_url: str | None = None

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -eu
-
-script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd)
-if [ "$#" -eq 0 ]; then
-  exec "$script_dir/dev.sh" infra
-fi
-
-exec "$script_dir/dev.sh" "$@"

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -189,6 +189,26 @@ def test_webhook_secret_isolated_from_internal_api_secret(
     mock_enqueue.assert_called_once()
 
 
+def test_blank_webhook_secret_falls_back_to_internal_api_secret(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Whitespace WEBHOOK_SHARED_SECRET should behave like it is unset."""
+    monkeypatch.setattr(api.settings, "webhook_shared_secret", "  ")
+
+    with patch("five08.backend.api.enqueue_job") as mock_enqueue:
+        mock_enqueue.return_value = Mock(id="job-123")
+        response = client.post(
+            "/webhooks/github",
+            json={"id": "evt-1"},
+            headers=auth_headers,
+        )
+
+    assert response.status_code == 202
+    mock_enqueue.assert_called_once()
+
+
 def test_ingest_handler_rejects_non_object_payload(
     client: TestClient,
     auth_headers: dict[str, str],
@@ -276,6 +296,23 @@ def test_internal_api_secret_isolated_from_webhook_secret(
     assert webhook_secret_response.status_code == 401
     assert internal_secret_response.status_code == 202
     mock_enqueue.assert_called_once()
+
+
+def test_blank_internal_api_secret_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+) -> None:
+    """Whitespace API_SHARED_SECRET should not authorize protected endpoints."""
+    monkeypatch.setattr(api.settings, "api_shared_secret", "  ")
+
+    with patch("five08.backend.api.enqueue_job") as mock_enqueue:
+        response = client.post(
+            "/process-contact/c-123",
+            headers={"X-API-Secret": "  "},
+        )
+
+    assert response.status_code == 401
+    mock_enqueue.assert_not_called()
 
 
 def test_resume_extract_handler_enqueues_job(

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -162,6 +162,33 @@ def test_ingest_handler_enqueues_job(
     assert payload["source"] == "github"
 
 
+def test_webhook_secret_isolated_from_internal_api_secret(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """External webhooks should use WEBHOOK_SHARED_SECRET when configured."""
+    monkeypatch.setattr(api.settings, "webhook_shared_secret", "webhook-secret")
+
+    with patch("five08.backend.api.enqueue_job") as mock_enqueue:
+        mock_enqueue.return_value = Mock(id="job-123")
+
+        internal_secret_response = client.post(
+            "/webhooks/github",
+            json={"id": "evt-1"},
+            headers=auth_headers,
+        )
+        webhook_secret_response = client.post(
+            "/webhooks/github",
+            json={"id": "evt-1"},
+            headers={"X-API-Secret": "webhook-secret"},
+        )
+
+    assert internal_secret_response.status_code == 401
+    assert webhook_secret_response.status_code == 202
+    mock_enqueue.assert_called_once()
+
+
 def test_ingest_handler_rejects_non_object_payload(
     client: TestClient,
     auth_headers: dict[str, str],
@@ -225,6 +252,30 @@ def test_process_contact_handler_enqueues_single_contact(
     assert response.status_code == 202
     assert payload["contact_id"] == "c-123"
     assert payload["job_id"] == "job-123"
+
+
+def test_internal_api_secret_isolated_from_webhook_secret(
+    monkeypatch: pytest.MonkeyPatch,
+    client: TestClient,
+    auth_headers: dict[str, str],
+) -> None:
+    """Internal endpoints should not accept WEBHOOK_SHARED_SECRET."""
+    monkeypatch.setattr(api.settings, "webhook_shared_secret", "webhook-secret")
+
+    with patch("five08.backend.api.enqueue_job") as mock_enqueue:
+        mock_enqueue.return_value = Mock(id="job-123", created=True)
+        webhook_secret_response = client.post(
+            "/process-contact/c-123",
+            headers={"X-API-Secret": "webhook-secret"},
+        )
+        internal_secret_response = client.post(
+            "/process-contact/c-123",
+            headers=auth_headers,
+        )
+
+    assert webhook_secret_response.status_code == 401
+    assert internal_secret_response.status_code == 202
+    mock_enqueue.assert_called_once()
 
 
 def test_resume_extract_handler_enqueues_job(

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -14,6 +14,7 @@ from five08.discord_bot.cogs.crm import (
     CRMCog,
     DiscordLinkOverwriteConfirmationView,
     ResumeButtonView,
+    ResumeConfirmationView,
     ResumeCreateContactView,
     ResumeUpdateConfirmationView,
     ResumeReprocessConfirmationView,
@@ -5369,6 +5370,41 @@ class TestCRMCog:
         # Check PUT call - should not add duplicate
         put_call = crm_cog.espo_api.request.call_args_list[1]
         assert put_call[0][2]["resumeIds"] == ["attachment_id"]
+
+    @pytest.mark.asyncio
+    async def test_resume_duplicate_confirmation_defers_ephemerally(
+        self, crm_cog, mock_interaction
+    ):
+        """Duplicate-resume confirmation must keep the first followup private."""
+        mock_interaction.message = None
+        file = AsyncMock()
+        file.filename = "resume.pdf"
+        file.size = 2048
+        file.read = AsyncMock(return_value=b"%PDF")
+
+        crm_cog.espo_api.upload_file.return_value = {"id": "attachment_id"}
+        crm_cog._update_contact_resume = AsyncMock(return_value=True)
+
+        view = ResumeConfirmationView(
+            crm_cog=crm_cog,
+            interaction=mock_interaction,
+            file=file,
+            contact_id="contact123",
+            contact_name="Jane Candidate",
+            existing_resume_id="existing_resume_id",
+        )
+        button = next(
+            child
+            for child in view.children
+            if isinstance(child, discord.ui.Button)
+            and child.label == "Yes, Upload Anyway"
+        )
+
+        await button.callback(mock_interaction)
+
+        mock_interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+        mock_interaction.followup.send.assert_awaited_once()
+        assert mock_interaction.followup.send.await_args.kwargs["ephemeral"] is True
 
     async def test_update_contact_resume_no_existing_resumes(
         self, crm_cog, mock_interaction

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2971,7 +2971,8 @@ class TestCRMCog:
         await crm_cog.search_members.callback(crm_cog, mock_interaction, "")
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ Please provide a search term or `skills:...` to search by."
+            "❌ Please provide a search term or `skills:...` to search by.",
+            ephemeral=True,
         )
         crm_cog.espo_api.request.assert_not_called()
 
@@ -2985,7 +2986,8 @@ class TestCRMCog:
         await crm_cog.search_members.callback(crm_cog, mock_interaction, "skills:")
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ Please provide a search term or `skills:...` to search by."
+            "❌ Please provide a search term or `skills:...` to search by.",
+            ephemeral=True,
         )
         crm_cog.espo_api.request.assert_not_called()
 
@@ -3897,7 +3899,8 @@ class TestCRMCog:
         await crm_cog.search_members.callback(crm_cog, mock_interaction, "nonexistent")
 
         mock_interaction.followup.send.assert_called_once_with(
-            "🔍 No contacts found for: `nonexistent`"
+            "🔍 No contacts found for: `nonexistent`",
+            ephemeral=True,
         )
 
     @pytest.mark.asyncio
@@ -3951,7 +3954,8 @@ class TestCRMCog:
         )
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ No contact found for: `nonexistent@example.com`"
+            "❌ No contact found for: `nonexistent@example.com`",
+            ephemeral=True,
         )
 
     @pytest.mark.asyncio
@@ -3978,7 +3982,8 @@ class TestCRMCog:
         await crm_cog.get_resume.callback(crm_cog, mock_interaction, "john@508.dev")
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ No resume found for John Doe"
+            "❌ No resume found for John Doe",
+            ephemeral=True,
         )
 
     @pytest.mark.asyncio
@@ -6892,7 +6897,8 @@ class TestCRMCog:
             )
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ No contact found for: `missing-user`"
+            "❌ No contact found for: `missing-user`",
+            ephemeral=True,
         )
 
     @pytest.mark.asyncio
@@ -7026,7 +7032,8 @@ class TestCRMCog:
         )
 
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ Contact ID not found."
+            "❌ Contact ID not found.",
+            ephemeral=True,
         )
 
     @pytest.mark.asyncio
@@ -7506,7 +7513,8 @@ class TestCRMCog:
         crm_cog._create_member_agreement_submission_for_contact.assert_awaited_once()
         mock_interaction.followup.send.assert_called_once_with(
             "✅ Sent the member agreement to **Jane Doe** at `jane@example.com`."
-            " Submission ID: `4200`."
+            " Submission ID: `4200`.",
+            ephemeral=True,
         )
         audit_kwargs = crm_cog._audit_command.call_args.kwargs
         assert audit_kwargs["action"] == "crm.send_member_agreement"
@@ -7541,7 +7549,8 @@ class TestCRMCog:
         crm_cog._create_member_agreement_submission_for_contact.assert_not_awaited()
         mock_interaction.followup.send.assert_called_once_with(
             "⚠️ **Jane Doe** already signed the member agreement at "
-            "`2026-03-20 10:00:00`. No DocuSeal submission was sent."
+            "`2026-03-20 10:00:00`. No DocuSeal submission was sent.",
+            ephemeral=True,
         )
         audit_kwargs = crm_cog._audit_command.call_args.kwargs
         assert audit_kwargs["result"] == "denied"
@@ -7573,7 +7582,8 @@ class TestCRMCog:
 
         crm_cog._create_member_agreement_submission_for_contact.assert_not_awaited()
         mock_interaction.followup.send.assert_called_once_with(
-            "❌ **Jane Doe** does not have an email address in CRM."
+            "❌ **Jane Doe** does not have an email address in CRM.",
+            ephemeral=True,
         )
         audit_kwargs = crm_cog._audit_command.call_args.kwargs
         assert audit_kwargs["result"] == "denied"


### PR DESCRIPTION
## Summary
- make CRM Discord followup responses explicitly ephemeral to reduce accidental public disclosure
- split external webhook authentication onto WEBHOOK_SHARED_SECRET, with API_SHARED_SECRET fallback for compatibility
- keep internal protected routes on API_SHARED_SECRET and document the new webhook secret

## Notes
- Per request, DISCORD_LINK_REQUIRE_OIDC_IDENTITY_CHECKS=false still allows direct Discord-backed dashboard link consumption. This PR does not force those links through SSO.

## Validation
- ./scripts/test.sh: 1653 passed, 20 skipped, 10 warnings
- focused smoke: Discord dashboard login, dashboard Playwright interactivity, webhook/internal secret isolation
- commit hooks: ruff, ruff format, mypy
