### PR TITLE
[codex] CC onboarding email sender

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -144,7 +144,7 @@ current precedence rules.
 - `Optional`: `ONBOARDING_EMAIL_SMTP_PASSWORD` (dashboard-configurable; falls back to `SMTP_PASSWORD`)
 - `Optional`: `ONBOARDING_EMAIL_SENDER_EMAIL` (dashboard-configurable; default: `onboarding@508.dev`)
 - `Optional`: `ONBOARDING_EMAIL_SMTP_TIMEOUT_SECONDS` (dashboard-configurable; falls back to `SMTP_TIMEOUT_SECONDS`; default: `20.0`)
-- Note: `/onboarding-email` is limited to Steering Committee+ or the candidate's designated CRM onboarder. The command always creates an editable draft first; when recipient and Reply-To are resolved, the draft includes a `Send Email` button. Sent emails use the configured sender address with the command sender's name as the display name, and set `Reply-To` to the command user's CRM-linked email or the explicit `reply_to_email` option.
+- Note: `/onboarding-email` is limited to Steering Committee+ or the candidate's designated CRM onboarder. The command always creates an editable draft first; when recipient and Reply-To are resolved, the draft includes a `Send Email` button. Sent emails use the configured sender address with the command sender's name as the display name, set `Reply-To` to the command user's CRM-linked email or the explicit `reply_to_email` option, and CC the sender's 508.dev email when it can be resolved.
 
 ## Discord Bot Core
 

--- a/apps/admin_dashboard/src/main.tsx
+++ b/apps/admin_dashboard/src/main.tsx
@@ -216,6 +216,7 @@ type OnboardingEmailDraft = {
   candidate_name?: string
   recipient_email?: string | null
   reply_to_email?: string | null
+  cc_email?: string | null
   sender_display_name?: string | null
   signature_name?: string | null
   subject: string
@@ -6592,12 +6593,15 @@ function OnboardingRow({
               </div>
               {emailDraft ? (
                 <>
-                  <div className="grid gap-2 text-sm md:grid-cols-3">
+                  <div className="grid gap-2 text-sm md:grid-cols-4">
                     <span>
                       <strong>To:</strong> {emailDraft.recipient_email || "Missing"}
                     </span>
                     <span>
                       <strong>Reply-To:</strong> {emailDraft.reply_to_email || "Missing"}
+                    </span>
+                    <span>
+                      <strong>Cc:</strong> {emailDraft.cc_email || "Missing"}
                     </span>
                     <span>
                       <strong>From:</strong> {emailDraft.sender_display_name || "onboarding"}

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -2249,6 +2249,25 @@ def _dashboard_reply_to_email(session: AuthSession) -> str | None:
     return None
 
 
+def _dashboard_sender_cc_email(session: AuthSession) -> str | None:
+    if session.email and session.email.lower().endswith("@508.dev"):
+        try:
+            return validate_plain_email(session.email, "session.email")
+        except ValueError:
+            pass
+
+    profile = _dashboard_session_profile_row(session)
+    if not profile:
+        return None
+    candidate = str(profile.get("email_508") or "").strip()
+    if not candidate or not candidate.lower().endswith("@508.dev"):
+        return None
+    try:
+        return validate_plain_email(candidate, "email_508")
+    except ValueError:
+        return None
+
+
 def _dashboard_onboarding_email_actor(session: AuthSession) -> str:
     return session.email or session.subject
 
@@ -6125,6 +6144,7 @@ async def dashboard_onboarding_email_draft_handler(
         session,
     )
     reply_to_email = await asyncio.to_thread(_dashboard_reply_to_email, session)
+    cc_email = await asyncio.to_thread(_dashboard_sender_cc_email, session)
     candidate_name = _dashboard_contact_display_name(contact)
     recipient_email = _dashboard_preferred_contact_email(contact)
     draft = build_onboarding_email(
@@ -6148,6 +6168,7 @@ async def dashboard_onboarding_email_draft_handler(
             "candidate_name": candidate_name,
             "recipient_email": recipient_email,
             "reply_to_email": reply_to_email,
+            "cc_email": cc_email,
             "sender_display_name": sender_display_name,
             "signature_name": signature_name,
             "subject": draft.subject,
@@ -6208,6 +6229,7 @@ async def dashboard_onboarding_email_send_handler(
                 "reply_to_email_required",
                 status_code=409,
             )
+        cc_email = await asyncio.to_thread(_dashboard_sender_cc_email, session)
         recipient_email = _dashboard_preferred_contact_email(contact)
         if recipient_email is None:
             raise DashboardOnboardingEmailError(
@@ -6228,6 +6250,7 @@ async def dashboard_onboarding_email_send_handler(
             reply_to_email=reply_to_email,
             sender_name=sender_display_name,
             sender_email=settings.onboarding_email_sender_email,
+            cc_email=cc_email,
             subject="508.dev onboarding",
             text_body=text_body,
             html_body=html_body,
@@ -6328,6 +6351,7 @@ async def dashboard_onboarding_email_send_handler(
             "candidate_name": candidate_name,
             "recipient_email": recipient_email,
             "reply_to_email": reply_to_email,
+            "cc_email": cc_email,
             "sender_display_name": sender_display_name,
             "signature_name": signature_name,
             "onboarding_status": onboarding_status,
@@ -6342,6 +6366,7 @@ async def dashboard_onboarding_email_send_handler(
             "candidate_name": candidate_name,
             "recipient_email": recipient_email,
             "reply_to_email": reply_to_email,
+            "cc_email": cc_email,
             "sender_display_name": sender_display_name,
             "signature_name": signature_name,
             "subject": "508.dev onboarding",

--- a/apps/discord_bot/src/five08/discord_bot/cogs/onboarding_email.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/onboarding_email.py
@@ -57,6 +57,14 @@ class OnboardingEmailCommandState:
 
 
 @dataclass(frozen=True, slots=True)
+class OnboardingEmailSenderEmails:
+    """Email addresses resolved for the command sender."""
+
+    reply_to_email: str | None
+    cc_email: str | None
+
+
+@dataclass(frozen=True, slots=True)
 class OnboardingEmailSendPayload:
     """Validated send inputs carried by the draft review controls."""
 
@@ -386,39 +394,63 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
     def _validate_email(value: str, field_name: str) -> str:
         return validate_plain_email(value, field_name)
 
-    def _reply_to_email_for_user(
+    def _sender_emails_for_user(
         self,
         *,
         interaction: discord.Interaction,
         override: str | None,
-    ) -> str | None:
-        if override:
-            return self._validate_email(override, "reply_to_email")
-
-        contacts = self._contacts_for_discord_user_id(
-            interaction,
-            select="id,name,emailAddress,c508Email,cDiscordUserID",
+    ) -> OnboardingEmailSenderEmails:
+        reply_to_email = (
+            self._validate_email(override, "reply_to_email") if override else None
         )
+
+        try:
+            contacts = self._contacts_for_discord_user_id(
+                interaction,
+                select="id,name,emailAddress,c508Email,cDiscordUserID",
+            )
+        except EspoAPIError:
+            if reply_to_email is None:
+                raise
+            logger.warning(
+                "Unable to resolve onboarding email CC from CRM",
+                exc_info=True,
+            )
+            return OnboardingEmailSenderEmails(
+                reply_to_email=reply_to_email,
+                cc_email=None,
+            )
+
         if not contacts:
-            return None
+            return OnboardingEmailSenderEmails(
+                reply_to_email=reply_to_email,
+                cc_email=None,
+            )
         contact = contacts[0]
+        if override:
+            return OnboardingEmailSenderEmails(
+                reply_to_email=reply_to_email,
+                cc_email=self._cc_email_from_contact(contact),
+            )
 
         for field_name in ("c508Email", "emailAddress"):
             candidate = str(contact.get(field_name) or "").strip()
             if candidate and EMAIL_RE.fullmatch(candidate):
-                return candidate
-        return None
-
-    def _cc_email_for_user(self, interaction: discord.Interaction) -> str | None:
-        contacts = self._contacts_for_discord_user_id(
-            interaction,
-            select="id,name,c508Email,cDiscordUserID",
+                reply_to_email = candidate
+                break
+        return OnboardingEmailSenderEmails(
+            reply_to_email=reply_to_email,
+            cc_email=self._cc_email_from_contact(contact),
         )
-        if not contacts:
+
+    def _cc_email_from_contact(self, contact: dict[str, Any]) -> str | None:
+        candidate = str(contact.get("c508Email") or "").strip()
+        if not candidate or not candidate.lower().endswith("@508.dev"):
             return None
-        candidate = str(contacts[0].get("c508Email") or "").strip()
-        if candidate and candidate.lower().endswith("@508.dev"):
+        try:
             return self._validate_email(candidate, "cc_email")
+        except ValueError:
+            logger.warning("Ignoring invalid onboarding email CC address from CRM")
         return None
 
     def _contacts_for_discord_user_id(
@@ -1086,28 +1118,22 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
             )
         )
         try:
-            resolved_reply_to = await asyncio.to_thread(
-                self._reply_to_email_for_user,
+            sender_emails = await asyncio.to_thread(
+                self._sender_emails_for_user,
                 interaction=interaction,
                 override=state.reply_to_email,
             )
         except EspoAPIError:
             logger.warning(
-                "Unable to resolve onboarding email Reply-To from CRM",
+                "Unable to resolve onboarding email sender addresses from CRM",
                 exc_info=True,
             )
-            resolved_reply_to = None
-        try:
-            sender_cc_email = await asyncio.to_thread(
-                self._cc_email_for_user,
-                interaction,
+            sender_emails = OnboardingEmailSenderEmails(
+                reply_to_email=None,
+                cc_email=None,
             )
-        except EspoAPIError:
-            logger.warning(
-                "Unable to resolve onboarding email CC from CRM",
-                exc_info=True,
-            )
-            sender_cc_email = None
+        resolved_reply_to = sender_emails.reply_to_email
+        sender_cc_email = sender_emails.cc_email
 
         smtp_ready = self._smtp_ready()
         can_send = (

--- a/apps/discord_bot/src/five08/discord_bot/cogs/onboarding_email.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/onboarding_email.py
@@ -75,6 +75,7 @@ class OnboardingEmailSendPayload:
     agreement_signed: str
     authorization_source: str
     onboarding_status: str | None
+    cc_email: str | None = None
 
 
 def _truncate_component_text(value: str, *, limit: int) -> str:
@@ -406,6 +407,18 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
             candidate = str(contact.get(field_name) or "").strip()
             if candidate and EMAIL_RE.fullmatch(candidate):
                 return candidate
+        return None
+
+    def _cc_email_for_user(self, interaction: discord.Interaction) -> str | None:
+        contacts = self._contacts_for_discord_user_id(
+            interaction,
+            select="id,name,c508Email,cDiscordUserID",
+        )
+        if not contacts:
+            return None
+        candidate = str(contacts[0].get("c508Email") or "").strip()
+        if candidate and candidate.lower().endswith("@508.dev"):
+            return self._validate_email(candidate, "cc_email")
         return None
 
     def _contacts_for_discord_user_id(
@@ -777,6 +790,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
         recipient_email: str,
         reply_to_email: str,
         sender_name: str,
+        cc_email: str | None = None,
         subject: str,
         text_body: str,
         html_body: str,
@@ -786,6 +800,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
             reply_to_email=reply_to_email,
             sender_name=sender_name,
             sender_email=settings.onboarding_email_sender_email,
+            cc_email=cc_email,
             subject=subject,
             text_body=text_body,
             html_body=html_body,
@@ -864,6 +879,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
             recipient_email=recipient_email,
             reply_to_email=payload.reply_to_email,
             sender_name=payload.sender_display_name,
+            cc_email=payload.cc_email,
             subject=payload.subject,
             text_body=text_body,
             html_body=html_body,
@@ -883,6 +899,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
                 "agreement_signed": payload.agreement_signed,
                 "sender_display_name": payload.sender_display_name,
                 "reply_to_email": payload.reply_to_email,
+                "cc_email": payload.cc_email,
                 "authorization_source": authorization_source,
                 "onboarding_status": onboarding_status,
                 "edited": markdown_body != payload.original_markdown_body,
@@ -920,6 +937,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
                 "agreement_signed": payload.agreement_signed,
                 "sender_display_name": payload.sender_display_name,
                 "reply_to_email": payload.reply_to_email,
+                "cc_email": payload.cc_email,
                 "authorization_source": payload.authorization_source,
                 "onboarding_status": payload.onboarding_status,
                 "error": error_code,
@@ -1079,6 +1097,17 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
                 exc_info=True,
             )
             resolved_reply_to = None
+        try:
+            sender_cc_email = await asyncio.to_thread(
+                self._cc_email_for_user,
+                interaction,
+            )
+        except EspoAPIError:
+            logger.warning(
+                "Unable to resolve onboarding email CC from CRM",
+                exc_info=True,
+            )
+            sender_cc_email = None
 
         smtp_ready = self._smtp_ready()
         can_send = (
@@ -1108,6 +1137,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
                 "sender_display_name": state.sender_display_name,
                 "signature_name": state.signature_name,
                 "reply_to_email": resolved_reply_to,
+                "cc_email": sender_cc_email,
                 "authorization_source": authorization_source,
                 "onboarding_status": contact_status or None,
                 "send_available": can_send,
@@ -1127,6 +1157,8 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
             ),
             f"Reply-To: `{_discord_inline_code(reply_to_line)}`",
         ]
+        if sender_cc_email:
+            lines.append(f"Cc: `{_discord_inline_code(sender_cc_email)}`")
         if selected_contact is not None:
             status_line = contact_status or "unknown"
             lines.append(
@@ -1171,6 +1203,7 @@ class OnboardingEmailCog(DiscordAuditCogMixin, commands.Cog):
                 agreement_signed=state.agreement_signed,
                 authorization_source=authorization_source,
                 onboarding_status=contact_status or None,
+                cc_email=sender_cc_email,
             )
         view = OnboardingEmailDraftEditView(
             cog=self,

--- a/packages/shared/src/five08/onboarding_email.py
+++ b/packages/shared/src/five08/onboarding_email.py
@@ -112,6 +112,7 @@ def build_onboarding_email_message(
     reply_to_email: str,
     sender_name: str,
     sender_email: str,
+    cc_email: str | None = None,
     subject: str,
     text_body: str,
     html_body: str,
@@ -128,6 +129,8 @@ def build_onboarding_email_message(
     message["Reply-To"] = formataddr(
         (sender_name, validate_plain_email(reply_to_email, "reply_to_email"))
     )
+    if cc_email:
+        message["Cc"] = validate_plain_email(cc_email, "cc_email")
     message.set_content(text_body)
     message.add_alternative(html_body, subtype="html")
     return message

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -6357,6 +6357,7 @@ def test_dashboard_onboarding_email_send_sends_and_marks_local_state(
     message = mock_send.call_args.args[0]
     assert message["From"] == "Michael Wu <onboarding@508.dev>"
     assert message["Reply-To"] == "Michael Wu <steering@508.dev>"
+    assert message["Cc"] == "steering@508.dev"
     assert message["To"] == "jesse@example.com"
     assert message["Subject"] == "508.dev onboarding"
     mock_mark.assert_called_once_with(

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -6210,7 +6210,7 @@ def test_dashboard_onboarding_email_draft_uses_crm_contact_and_local_marker(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch(
             "five08.backend.api._dashboard_onboarding_email_marker",
@@ -6237,8 +6237,8 @@ def test_dashboard_onboarding_email_draft_uses_crm_contact_and_local_marker(
     assert payload["candidate_name"] == "Jesse Candidate"
     assert payload["recipient_email"] == "jesse@example.com"
     assert payload["reply_to_email"] == "steering@508.dev"
-    assert payload["sender_display_name"] == "Michael Wu"
-    assert payload["signature_name"] == "Michael"
+    assert payload["sender_display_name"] == "Avery Sender"
+    assert payload["signature_name"] == "Avery"
     assert payload["subject"] == "508.dev onboarding"
     assert payload["can_send"] is True
     assert payload["markdown_body"].startswith("Great talking Jesse,")
@@ -6270,7 +6270,7 @@ def test_dashboard_onboarding_email_draft_marks_not_sendable_without_smtp(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch(
             "five08.backend.api._dashboard_onboarding_email_marker",
@@ -6317,7 +6317,7 @@ def test_dashboard_onboarding_email_send_sends_and_marks_local_state(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch("five08.backend.api.onboarding_email_smtp_ready", return_value=True),
         patch("five08.backend.api.send_onboarding_email_message") as mock_send,
@@ -6355,8 +6355,8 @@ def test_dashboard_onboarding_email_send_sends_and_marks_local_state(
     assert payload["marker_error"] is None
     mock_send.assert_called_once()
     message = mock_send.call_args.args[0]
-    assert message["From"] == "Michael Wu <onboarding@508.dev>"
-    assert message["Reply-To"] == "Michael Wu <steering@508.dev>"
+    assert message["From"] == "Avery Sender <onboarding@508.dev>"
+    assert message["Reply-To"] == "Avery Sender <steering@508.dev>"
     assert message["Cc"] == "steering@508.dev"
     assert message["To"] == "jesse@example.com"
     assert message["Subject"] == "508.dev onboarding"
@@ -6400,7 +6400,7 @@ def test_dashboard_onboarding_email_send_returns_sent_when_marker_fails(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch("five08.backend.api.onboarding_email_smtp_ready", return_value=True),
         patch("five08.backend.api.send_onboarding_email_message") as mock_send,
@@ -6464,7 +6464,7 @@ def test_dashboard_onboarding_email_send_requires_smtp_configuration(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch("five08.backend.api.onboarding_email_smtp_ready", return_value=False),
         patch("five08.backend.api.send_onboarding_email_message") as mock_send,
@@ -6537,7 +6537,7 @@ def test_dashboard_onboarding_email_send_sanitizes_send_failures(
         patch("five08.backend.api.EspoClient", return_value=espo_client),
         patch(
             "five08.backend.api._dashboard_session_profile_row",
-            return_value={"name": "Michael Wu", "email_508": "michael@508.dev"},
+            return_value={"name": "Avery Sender", "email_508": "avery.sender@508.dev"},
         ),
         patch("five08.backend.api.onboarding_email_smtp_ready", return_value=True),
         patch(

--- a/tests/unit/test_onboarding_email_cog.py
+++ b/tests/unit/test_onboarding_email_cog.py
@@ -58,8 +58,8 @@ def mock_interaction() -> AsyncMock:
     interaction.followup.send = AsyncMock()
     interaction.user = Mock()
     interaction.user.id = 123
-    interaction.user.name = "michaelmwu"
-    interaction.user.display_name = "Michael Wu"
+    interaction.user.name = "averysender"
+    interaction.user.display_name = "Avery Sender"
     admin_role = Mock()
     admin_role.name = "Admin"
     interaction.user.roles = [admin_role]
@@ -74,11 +74,11 @@ def _contact_search_response(params: dict[str, object]) -> dict[str, object]:
             "list": [
                 {
                     "id": "contact-user",
-                    "name": "Michael Wu",
-                    "c508Email": "michael@508.dev",
-                    "emailAddress": "michael@example.com",
+                    "name": "Avery Sender",
+                    "c508Email": "avery.sender@508.dev",
+                    "emailAddress": "avery.sender@example.com",
                     "cDiscordUserID": "123",
-                    "cDiscordUsername": "michaelmwu",
+                    "cDiscordUsername": "averysender",
                 }
             ]
         }
@@ -90,7 +90,7 @@ def _contact_search_response(params: dict[str, object]) -> dict[str, object]:
                     "name": "Jane Example",
                     "emailAddress": "jane@example.com",
                     "c508Email": "",
-                    "cOnboarder": "michael",
+                    "cOnboarder": "avery.sender",
                     "cOnboardingState": "selected",
                 }
             ]
@@ -108,7 +108,7 @@ def test_candidate_lookup_keeps_name_filter_when_recipient_is_overridden(
                 "name": "Jane Example",
                 "emailAddress": "jane@example.com",
                 "c508Email": "",
-                "cOnboarder": "michael",
+                "cOnboarder": "avery.sender",
                 "cOnboardingState": "selected",
             }
         ]
@@ -134,6 +134,57 @@ def test_candidate_lookup_keeps_name_filter_when_recipient_is_overridden(
     } in filters
 
 
+def test_sender_emails_for_user_uses_one_lookup_for_reply_to_and_cc(
+    onboarding_cog: OnboardingEmailCog,
+    mock_interaction: AsyncMock,
+) -> None:
+    onboarding_cog.crm.list_contacts.return_value = {
+        "list": [
+            {
+                "id": "contact-user",
+                "name": "Avery Sender",
+                "c508Email": "avery.sender@508.dev",
+                "emailAddress": "avery.sender@example.com",
+                "cDiscordUserID": "123",
+            }
+        ]
+    }
+
+    sender_emails = onboarding_cog._sender_emails_for_user(
+        interaction=mock_interaction,
+        override=None,
+    )
+
+    assert sender_emails.reply_to_email == "avery.sender@508.dev"
+    assert sender_emails.cc_email == "avery.sender@508.dev"
+    onboarding_cog.crm.list_contacts.assert_called_once()
+
+
+def test_sender_emails_for_user_ignores_invalid_optional_cc(
+    onboarding_cog: OnboardingEmailCog,
+    mock_interaction: AsyncMock,
+) -> None:
+    onboarding_cog.crm.list_contacts.return_value = {
+        "list": [
+            {
+                "id": "contact-user",
+                "name": "Avery Sender",
+                "c508Email": "avery sender@508.dev",
+                "emailAddress": "avery.sender@example.com",
+                "cDiscordUserID": "123",
+            }
+        ]
+    }
+
+    sender_emails = onboarding_cog._sender_emails_for_user(
+        interaction=mock_interaction,
+        override=None,
+    )
+
+    assert sender_emails.reply_to_email == "avery.sender@example.com"
+    assert sender_emails.cc_email is None
+
+
 @pytest.mark.asyncio
 async def test_onboarding_email_command_generates_draft(
     onboarding_cog: OnboardingEmailCog,
@@ -141,7 +192,7 @@ async def test_onboarding_email_command_generates_draft(
 ) -> None:
     onboarding_cog._audit_command_safe = Mock()
     onboarding_cog.crm.list_contacts.side_effect = _contact_search_response
-    mock_interaction.user.display_name = "michaelmwu"
+    mock_interaction.user.display_name = "averysender"
 
     await onboarding_cog.onboarding_email.callback(
         onboarding_cog,
@@ -154,12 +205,12 @@ async def test_onboarding_email_command_generates_draft(
 
     args, kwargs = mock_interaction.followup.send.call_args
     assert "Onboarding email draft generated" in args[0]
-    assert "Reply-To: `michael@508.dev`" in args[0]
-    assert "Cc: `michael@508.dev`" in args[0]
-    assert "From: `Michael Wu <onboarding@508.dev>`" in args[0]
+    assert "Reply-To: `avery.sender@508.dev`" in args[0]
+    assert "Cc: `avery.sender@508.dev`" in args[0]
+    assert "From: `Avery Sender <onboarding@508.dev>`" in args[0]
     assert "CRM contact: `Jane Example`" in args[0]
     assert "**Copy/paste draft:**" in args[0]
-    assert "Cheers,\nMichael" in args[0]
+    assert "Cheers,\nAvery" in args[0]
     assert "[508 Discord server](https://discord.gg/9zAKxmUZJf)" in args[0]
     assert kwargs["ephemeral"] is True
     assert isinstance(kwargs["view"], OnboardingEmailDraftEditView)
@@ -169,8 +220,8 @@ async def test_onboarding_email_command_generates_draft(
     assert audit_kwargs["result"] == "success"
     assert audit_kwargs["metadata"]["email_action"] == "drafted_for_send"
     assert audit_kwargs["metadata"]["send_available"] is True
-    assert audit_kwargs["metadata"]["sender_display_name"] == "Michael Wu"
-    assert audit_kwargs["metadata"]["signature_name"] == "Michael"
+    assert audit_kwargs["metadata"]["sender_display_name"] == "Avery Sender"
+    assert audit_kwargs["metadata"]["signature_name"] == "Avery"
 
 
 @pytest.mark.asyncio
@@ -185,7 +236,7 @@ async def test_onboarding_email_command_prepares_send_button_when_possible(
         "name": "Sam Member",
         "emailAddress": "sam@example.com",
         "c508Email": "",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected",
     }
     onboarding_cog._send_message = Mock()
@@ -198,8 +249,8 @@ async def test_onboarding_email_command_prepares_send_button_when_possible(
         recipient_email="sam@example.com",
         discord_joined="yes",
         agreement_signed="no",
-        sender_name="Michael Wu",
-        reply_to_email="michael@508.dev",
+        sender_name="Avery Sender",
+        reply_to_email="avery.sender@508.dev",
     )
 
     onboarding_cog._send_message.assert_not_called()
@@ -216,9 +267,9 @@ async def test_onboarding_email_command_prepares_send_button_when_possible(
 
     onboarding_cog._send_message.assert_called_once()
     message = onboarding_cog._send_message.call_args.args[0]
-    assert message["From"] == "Michael Wu <onboarding@508.dev>"
-    assert message["Reply-To"] == "Michael Wu <michael@508.dev>"
-    assert message["Cc"] == "michael@508.dev"
+    assert message["From"] == "Avery Sender <onboarding@508.dev>"
+    assert message["Reply-To"] == "Avery Sender <avery.sender@508.dev>"
+    assert message["Cc"] == "avery.sender@508.dev"
     assert message["To"] == "sam@example.com"
     assert message["Subject"] == "508.dev onboarding"
     assert "Onboarding email sent" in mock_interaction.followup.send.call_args.args[0]
@@ -240,7 +291,7 @@ async def test_onboarding_email_command_disables_send_button_without_smtp(
         "name": "Sam Member",
         "emailAddress": "sam@example.com",
         "c508Email": "",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected",
     }
 
@@ -252,8 +303,8 @@ async def test_onboarding_email_command_disables_send_button_without_smtp(
         recipient_email="sam@example.com",
         discord_joined="yes",
         agreement_signed="no",
-        sender_name="Michael Wu",
-        reply_to_email="michael@508.dev",
+        sender_name="Avery Sender",
+        reply_to_email="avery.sender@508.dev",
     )
 
     send_args, send_kwargs = mock_interaction.followup.send.call_args
@@ -280,8 +331,8 @@ async def test_review_send_uses_edited_markdown_body(
     onboarding_cog._send_message = Mock()
     payload = OnboardingEmailSendPayload(
         recipient_email="sam@example.com",
-        reply_to_email="michael@508.dev",
-        sender_display_name="Michael Wu",
+        reply_to_email="avery.sender@508.dev",
+        sender_display_name="Avery Sender",
         subject="508.dev onboarding",
         recipient_from_crm=False,
         original_markdown_body="Original draft\n",
@@ -335,13 +386,13 @@ async def test_review_send_refreshes_crm_derived_recipient_before_smtp(
         "name": "Sam Member",
         "emailAddress": "fresh@example.com",
         "c508Email": "",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected",
     }
     payload = OnboardingEmailSendPayload(
         recipient_email="stale@example.com",
-        reply_to_email="michael@508.dev",
-        sender_display_name="Michael Wu",
+        reply_to_email="avery.sender@508.dev",
+        sender_display_name="Avery Sender",
         subject="508.dev onboarding",
         recipient_from_crm=True,
         original_markdown_body="Original draft\n",
@@ -382,8 +433,8 @@ async def test_review_send_revalidates_smtp_configuration(
     onboarding_cog._smtp_ready = Mock(return_value=False)  # type: ignore[method-assign]
     payload = OnboardingEmailSendPayload(
         recipient_email="sam@example.com",
-        reply_to_email="michael@508.dev",
-        sender_display_name="Michael Wu",
+        reply_to_email="avery.sender@508.dev",
+        sender_display_name="Avery Sender",
         subject="508.dev onboarding",
         recipient_from_crm=False,
         original_markdown_body="Original draft\n",
@@ -438,16 +489,16 @@ async def test_review_send_revalidates_designated_onboarder_assignment(
         "list": [
             {
                 "id": "contact-user",
-                "name": "Michael Wu",
-                "c508Email": "michael@508.dev",
+                "name": "Avery Sender",
+                "c508Email": "avery.sender@508.dev",
                 "cDiscordUserID": "123",
             }
         ]
     }
     payload = OnboardingEmailSendPayload(
         recipient_email="stale@example.com",
-        reply_to_email="michael@508.dev",
-        sender_display_name="Michael Wu",
+        reply_to_email="avery.sender@508.dev",
+        sender_display_name="Avery Sender",
         subject="508.dev onboarding",
         recipient_from_crm=True,
         original_markdown_body="Original draft\n",
@@ -491,13 +542,13 @@ async def test_review_send_blocks_terminal_onboarding_state(
         "name": "Sam Member",
         "emailAddress": "fresh@example.com",
         "c508Email": "",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "rejected",
     }
     payload = OnboardingEmailSendPayload(
         recipient_email="stale@example.com",
-        reply_to_email="michael@508.dev",
-        sender_display_name="Michael Wu",
+        reply_to_email="avery.sender@508.dev",
+        sender_display_name="Avery Sender",
         subject="508.dev onboarding",
         recipient_from_crm=True,
         original_markdown_body="Original draft\n",
@@ -564,15 +615,15 @@ async def test_onboarding_email_summary_escapes_inline_code_values(
         recipient_email="jane@example.com",
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael `Wu`",
-        signature_name="Michael",
-        reply_to_email="michael@508.dev",
+        sender_display_name="Avery `Sender`",
+        signature_name="Avery",
+        reply_to_email="avery.sender@508.dev",
     )
     selected_contact = {
         "id": "contact-`jane`",
         "name": "Jane `Tick`",
         "emailAddress": "jane@example.com",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected`now",
     }
 
@@ -583,7 +634,7 @@ async def test_onboarding_email_summary_escapes_inline_code_values(
     )
 
     message = mock_interaction.followup.send.call_args.args[0]
-    assert "From: `Michael 'Wu' <onboarding@508.dev>`" in message
+    assert "From: `Avery 'Sender' <onboarding@508.dev>`" in message
     assert "CRM contact: `Jane 'Tick'` (`contact-'jane'`)" in message
     assert "status: `selected'now`" in message
 
@@ -601,7 +652,7 @@ async def test_multiple_candidate_matches_show_selector(
                 "name": "Jane Example",
                 "emailAddress": "jane@example.com",
                 "c508Email": "",
-                "cOnboarder": "michael",
+                "cOnboarder": "avery.sender",
                 "cOnboardingState": "selected",
             },
             {
@@ -646,8 +697,8 @@ async def test_multiple_candidate_matches_are_filtered_for_designated_onboarder(
                 "list": [
                     {
                         "id": "contact-user",
-                        "name": "Michael Wu",
-                        "c508Email": "michael@508.dev",
+                        "name": "Avery Sender",
+                        "c508Email": "avery.sender@508.dev",
                         "cDiscordUserID": "123",
                     }
                 ]
@@ -659,14 +710,14 @@ async def test_multiple_candidate_matches_are_filtered_for_designated_onboarder(
                         "id": "contact-1",
                         "name": "Jane Assigned",
                         "emailAddress": "jane@example.com",
-                        "cOnboarder": "michael",
+                        "cOnboarder": "avery.sender",
                         "cOnboardingState": "selected",
                     },
                     {
                         "id": "contact-2",
                         "name": "Jane Also Assigned",
                         "emailAddress": "jane2@example.com",
-                        "cOnboarder": "michael@508.dev",
+                        "cOnboarder": "avery.sender@508.dev",
                         "cOnboardingState": "selected",
                     },
                     {
@@ -713,7 +764,7 @@ async def test_terminal_onboarding_state_is_reported_without_draft(
                 "name": "Jane Onboarded",
                 "emailAddress": "jane@example.com",
                 "c508Email": "jane@508.dev",
-                "cOnboarder": "michael",
+                "cOnboarder": "avery.sender",
                 "cOnboardingState": status,
             }
         ]
@@ -806,8 +857,8 @@ async def test_designated_onboarder_authorization_requires_discord_user_id_link(
     member_role.name = "Member"
     mock_interaction.user.roles = [member_role]
     mock_interaction.user.id = 999
-    mock_interaction.user.name = "michaelmwu"
-    mock_interaction.user.display_name = "Michael Wu"
+    mock_interaction.user.name = "averysender"
+    mock_interaction.user.display_name = "Avery Sender"
 
     def list_contacts(params: dict[str, object]) -> dict[str, object]:
         select = str(params.get("select") or "")
@@ -819,9 +870,9 @@ async def test_designated_onboarder_authorization_requires_discord_user_id_link(
                 "list": [
                     {
                         "id": "contact-user",
-                        "name": "Michael Wu",
-                        "c508Email": "michael@508.dev",
-                        "cDiscordUsername": "michaelmwu",
+                        "name": "Avery Sender",
+                        "c508Email": "avery.sender@508.dev",
+                        "cDiscordUsername": "averysender",
                     }
                 ]
             }
@@ -832,7 +883,7 @@ async def test_designated_onboarder_authorization_requires_discord_user_id_link(
                         "id": "contact-candidate",
                         "name": "Jane Example",
                         "emailAddress": "jane@example.com",
-                        "cOnboarder": "michael",
+                        "cOnboarder": "avery.sender",
                         "cOnboardingState": "selected",
                     }
                 ]
@@ -870,8 +921,8 @@ async def test_unauthorized_selection_authorizes_before_draft_and_reply_to_looku
         recipient_email="jane@example.com",
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael Wu",
-        signature_name="Michael",
+        sender_display_name="Avery Sender",
+        signature_name="Avery",
         reply_to_email=None,
     )
     selected_contact = {
@@ -885,8 +936,8 @@ async def test_unauthorized_selection_authorizes_before_draft_and_reply_to_looku
         "list": [
             {
                 "id": "contact-user",
-                "name": "Michael Wu",
-                "c508Email": "michael@508.dev",
+                "name": "Avery Sender",
+                "c508Email": "avery.sender@508.dev",
                 "cDiscordUserID": "123",
             }
         ]
@@ -896,7 +947,7 @@ async def test_unauthorized_selection_authorizes_before_draft_and_reply_to_looku
         patch(
             "five08.discord_bot.cogs.onboarding_email.build_onboarding_email"
         ) as build_mock,
-        patch.object(onboarding_cog, "_reply_to_email_for_user") as reply_to_mock,
+        patch.object(onboarding_cog, "_sender_emails_for_user") as sender_emails_mock,
     ):
         await onboarding_cog._run_onboarding_email_flow(
             mock_interaction,
@@ -905,7 +956,7 @@ async def test_unauthorized_selection_authorizes_before_draft_and_reply_to_looku
         )
 
     build_mock.assert_not_called()
-    reply_to_mock.assert_not_called()
+    sender_emails_mock.assert_not_called()
     audit_kwargs = onboarding_cog._audit_command_safe.call_args.kwargs
     assert audit_kwargs["result"] == "denied"
     assert audit_kwargs["metadata"]["error"] == "permission_denied"
@@ -928,7 +979,7 @@ async def test_onboarding_email_without_reply_to_generates_copy_only_draft(
                         "name": "Sam Member",
                         "emailAddress": "sam@example.com",
                         "c508Email": "",
-                        "cOnboarder": "michael",
+                        "cOnboarder": "avery.sender",
                         "cOnboardingState": "selected",
                     }
                 ]
@@ -975,9 +1026,9 @@ async def test_sender_identity_falls_back_to_crm_discord_username(
                 "list": [
                     {
                         "id": "contact-user",
-                        "name": "Michael Wu",
-                        "c508Email": "michael@508.dev",
-                        "cDiscordUsername": "michaelmwu",
+                        "name": "Avery Sender",
+                        "c508Email": "avery.sender@508.dev",
+                        "cDiscordUsername": "averysender",
                     }
                 ]
             }
@@ -988,7 +1039,7 @@ async def test_sender_identity_falls_back_to_crm_discord_username(
                         "id": "contact-candidate",
                         "name": "Jane Example",
                         "emailAddress": "jane@example.com",
-                        "cOnboarder": "michael",
+                        "cOnboarder": "avery.sender",
                         "cOnboardingState": "selected",
                     }
                 ]
@@ -1005,8 +1056,8 @@ async def test_sender_identity_falls_back_to_crm_discord_username(
     )
 
     message = mock_interaction.followup.send.call_args.args[0]
-    assert "From: `Michael Wu <onboarding@508.dev>`" in message
-    assert "Cheers,\nMichael" in message
+    assert "From: `Avery Sender <onboarding@508.dev>`" in message
+    assert "Cheers,\nAvery" in message
 
 
 @pytest.mark.asyncio
@@ -1021,8 +1072,8 @@ async def test_onboarding_email_flow_sanitizes_crm_errors(
         recipient_email="jane@example.com",
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael Wu",
-        signature_name="Michael",
+        sender_display_name="Avery Sender",
+        signature_name="Avery",
         reply_to_email=None,
     )
     onboarding_cog._complete_onboarding_email = AsyncMock(
@@ -1055,8 +1106,8 @@ async def test_onboarding_email_flow_handles_unexpected_errors(
         recipient_email="jane@example.com",
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael Wu",
-        signature_name="Michael",
+        sender_display_name="Avery Sender",
+        signature_name="Avery",
         reply_to_email=None,
     )
     onboarding_cog._complete_onboarding_email = AsyncMock(
@@ -1090,15 +1141,15 @@ async def test_selected_contact_flow_refetches_contact_snapshot(
         recipient_email=None,
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael Wu",
-        signature_name="Michael",
+        sender_display_name="Avery Sender",
+        signature_name="Avery",
         reply_to_email=None,
     )
     stale_contact = {
         "id": "contact-candidate",
         "name": "Jane Example",
         "emailAddress": "old@example.com",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected",
     }
     fresh_contact = {
@@ -1137,15 +1188,15 @@ async def test_selected_contact_flow_handles_refetch_errors(
         recipient_email=None,
         discord_joined="unknown",
         agreement_signed="unknown",
-        sender_display_name="Michael Wu",
-        signature_name="Michael",
+        sender_display_name="Avery Sender",
+        signature_name="Avery",
         reply_to_email=None,
     )
     stale_contact = {
         "id": "contact-candidate",
         "name": "Jane Example",
         "emailAddress": "old@example.com",
-        "cOnboarder": "michael",
+        "cOnboarder": "avery.sender",
         "cOnboardingState": "selected",
     }
     onboarding_cog.crm.get_contact.side_effect = EspoAPIError("CRM detail")

--- a/tests/unit/test_onboarding_email_cog.py
+++ b/tests/unit/test_onboarding_email_cog.py
@@ -155,6 +155,7 @@ async def test_onboarding_email_command_generates_draft(
     args, kwargs = mock_interaction.followup.send.call_args
     assert "Onboarding email draft generated" in args[0]
     assert "Reply-To: `michael@508.dev`" in args[0]
+    assert "Cc: `michael@508.dev`" in args[0]
     assert "From: `Michael Wu <onboarding@508.dev>`" in args[0]
     assert "CRM contact: `Jane Example`" in args[0]
     assert "**Copy/paste draft:**" in args[0]
@@ -217,6 +218,7 @@ async def test_onboarding_email_command_prepares_send_button_when_possible(
     message = onboarding_cog._send_message.call_args.args[0]
     assert message["From"] == "Michael Wu <onboarding@508.dev>"
     assert message["Reply-To"] == "Michael Wu <michael@508.dev>"
+    assert message["Cc"] == "michael@508.dev"
     assert message["To"] == "sam@example.com"
     assert message["Subject"] == "508.dev onboarding"
     assert "Onboarding email sent" in mock_interaction.followup.send.call_args.args[0]


### PR DESCRIPTION
## Summary

- Add optional CC support to the shared onboarding email message builder.
- Resolve and pass the sender's `508.dev` address through the Discord and dashboard onboarding email flows.
- Show the CC address in the Discord/dashboard draft review surfaces and assert the delivered `Cc` header in unit tests.

## Why

Onboarding emails already use the shared configured sender address and set Reply-To to the sender. The sender should also receive a copy at their `508.dev` email for visibility and record keeping.

## Validation

- `uv run pytest tests/unit/test_onboarding_email_cog.py tests/unit/test_backend_api.py -q`
- `uv run ruff check packages/shared/src/five08/onboarding_email.py apps/discord_bot/src/five08/discord_bot/cogs/onboarding_email.py apps/api/src/five08/backend/api.py tests/unit/test_onboarding_email_cog.py tests/unit/test_backend_api.py`
- `bun install --frozen-lockfile` in `apps/admin_dashboard`
- `bun run typecheck` in `apps/admin_dashboard`
- `bun run test` in `apps/admin_dashboard`
- commit hooks: `ruff`, `ruff format`, `mypy`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Onboarding emails can now include an additional CC recipient when one is available.
  * The onboarding email draft and review screens now display a CC line alongside To and Reply-To.
  * Sent onboarding emails now preserve the CC recipient in the outgoing message and audit details.

* **Bug Fixes**
  * Improved handling of missing recipient information by showing “Missing” where a CC value is not available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->