### PR TITLE
[codex] Migrate type checking to Pyrefly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,7 +7,6 @@
 __pycache__
 *.pyc
 .pytest_cache
-.mypy_cache
 .ruff_cache
 tests
 dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -112,11 +112,11 @@ jobs:
 
     - name: Run ruff linter
       run: |
-        uv run ruff check apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
+        uv run ruff check apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
 
     - name: Run ruff formatter
       run: |
-        uv run ruff format --check apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
+        uv run ruff format --check apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
 
     - name: Run Pyrefly type checker
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,9 +118,9 @@ jobs:
       run: |
         uv run ruff format --check apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ tests/
 
-    - name: Run mypy type checker
+    - name: Run Pyrefly type checker
       run: |
-        uv run mypy apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ --ignore-missing-imports --explicit-package-bases
+        ./scripts/pyrefly.sh --output-format=github
 
   discord-agent-evals:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ Thumbs.db
 logs/
 
 # Testing
-.mypy_cache/
 .pytest_cache/
 .coverage
 htmlcov/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,9 +10,9 @@ repos:
 
   - repo: local
     hooks:
-      - id: mypy
-        name: mypy
-        entry: ./scripts/mypy.sh
+      - id: pyrefly
+        name: Pyrefly
+        entry: ./scripts/pyrefly.sh
         language: system
         pass_filenames: false
-        files: ^(apps/discord_bot/src/five08/|apps/worker/src/five08/|packages/shared/src/five08/)
+        files: ^(apps/api/src/five08/|apps/discord_bot/src/five08/|apps/worker/src/five08/|packages/shared/src/five08/)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@ uv sync
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
-./scripts/mypy.sh
+./scripts/pyrefly.sh
 ```
 
 Run services directly:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,8 +169,8 @@ service Dockerfiles use BuildKit cache mounts.
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
-./scripts/typecheck.sh # Python mypy + dashboard TypeScript
-./scripts/mypy.sh      # Python-only typecheck
+./scripts/typecheck.sh # Python Pyrefly + dashboard TypeScript
+./scripts/pyrefly.sh   # Python-only typecheck
 ./scripts/check-all.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ To run the Discord bot too:
 ./scripts/test.sh
 ./scripts/lint.sh
 ./scripts/format.sh
-./scripts/typecheck.sh # Python mypy + dashboard TypeScript
-./scripts/mypy.sh      # Python-only typecheck
+./scripts/typecheck.sh # Python Pyrefly + dashboard TypeScript
+./scripts/pyrefly.sh   # Python-only typecheck
 ./scripts/check-all.sh
 ```
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -20,6 +20,18 @@ dependencies = [
 five08 = { workspace = true }
 worker = { workspace = true }
 
+[tool.pyrefly]
+project-includes = ["src/five08"]
+search-path = [
+    "src",
+    "../discord_bot/src",
+    "../worker/src",
+    "../../packages/shared/src",
+]
+python-version = "3.12"
+preset = "legacy"
+ignore-missing-imports = [".*"]
+
 [project.scripts]
 backend-api = "five08.backend.api:run"
 

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal, cast
+from typing import Any, Literal, LiteralString, cast
 from urllib.parse import quote, unquote, urlencode, urlparse
 from uuid import UUID, uuid4
 
@@ -1314,20 +1314,19 @@ def _dashboard_project_viewer_emails(session: AuthSession) -> list[str]:
     if not conditions:
         return sorted(email for email in candidates if email)
 
+    query = cast(
+        LiteralString,
+        f"""
+        SELECT email, email_508
+        FROM people
+        WHERE sync_status = 'active'
+          AND ({" OR ".join(conditions)})
+        LIMIT 5
+        """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                trusted_sql(
-                    f"""
-                SELECT email, email_508
-                FROM people
-                WHERE sync_status = 'active'
-                  AND ({" OR ".join(conditions)})
-                LIMIT 5
-                """
-                ),
-                params,
-            )
+            cursor.execute(trusted_sql(query), params)
             for row in cursor.fetchall():
                 for key in ("email", "email_508"):
                     value = row.get(key)
@@ -1884,7 +1883,9 @@ def _query_dashboard_people(
 
     params.append(limit)
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
-    sql = f"""
+    sql = cast(
+        LiteralString,
+        f"""
         SELECT
             id::text,
             crm_contact_id,
@@ -1919,7 +1920,8 @@ def _query_dashboard_people(
         {where_clause}
         ORDER BY updated_at DESC
         LIMIT %s
-    """
+    """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)
@@ -2052,7 +2054,9 @@ def _list_dashboard_onboarding(
         conditions.append("COALESCE(cardinality(skills), 0) = 0")
 
     where_clause = " AND ".join(conditions)
-    sql = f"""
+    sql = cast(
+        LiteralString,
+        f"""
         SELECT
             id::text,
             crm_contact_id,
@@ -2091,7 +2095,8 @@ def _list_dashboard_onboarding(
             onboarding_updated_at DESC NULLS LAST,
             name ASC NULLS LAST
         LIMIT %s
-    """
+    """,
+    )
     params.append(limit)
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
@@ -2252,21 +2257,20 @@ def _dashboard_session_profile_row(session: AuthSession) -> dict[str, Any] | Non
     if not conditions:
         return None
 
+    query = cast(
+        LiteralString,
+        f"""
+        SELECT name, email, email_508
+        FROM people
+        WHERE sync_status = 'active'
+          AND ({" OR ".join(conditions)})
+        ORDER BY updated_at DESC NULLS LAST
+        LIMIT 1
+        """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                trusted_sql(
-                    f"""
-                SELECT name, email, email_508
-                FROM people
-                WHERE sync_status = 'active'
-                  AND ({" OR ".join(conditions)})
-                ORDER BY updated_at DESC NULLS LAST
-                LIMIT 1
-                """
-                ),
-                params,
-            )
+            cursor.execute(trusted_sql(query), params)
             return cursor.fetchone()
 
 

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -63,6 +63,7 @@ from five08.queue import (
     get_postgres_connection,
     get_redis_connection,
     is_postgres_healthy,
+    trusted_sql,
 )
 from five08.backend.auth import (
     AuthSession,
@@ -1316,13 +1317,15 @@ def _dashboard_project_viewer_emails(session: AuthSession) -> list[str]:
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(
-                f"""
+                trusted_sql(
+                    f"""
                 SELECT email, email_508
                 FROM people
                 WHERE sync_status = 'active'
                   AND ({" OR ".join(conditions)})
                 LIMIT 5
-                """,
+                """
+                ),
                 params,
             )
             for row in cursor.fetchall():
@@ -1919,7 +1922,7 @@ def _query_dashboard_people(
     """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(sql, params)
+            cursor.execute(trusted_sql(sql), params)
             rows = cursor.fetchall()
 
     return _shape_dashboard_people_rows(rows)
@@ -2092,7 +2095,7 @@ def _list_dashboard_onboarding(
     params.append(limit)
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(sql, params)
+            cursor.execute(trusted_sql(sql), params)
             rows = cursor.fetchall()
 
     return _shape_dashboard_people_rows(rows)
@@ -2252,14 +2255,16 @@ def _dashboard_session_profile_row(session: AuthSession) -> dict[str, Any] | Non
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(
-                f"""
+                trusted_sql(
+                    f"""
                 SELECT name, email, email_508
                 FROM people
                 WHERE sync_status = 'active'
                   AND ({" OR ".join(conditions)})
                 ORDER BY updated_at DESC NULLS LAST
                 LIMIT 1
-                """,
+                """
+                ),
                 params,
             )
             return cursor.fetchone()

--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -17,7 +17,7 @@ from collections.abc import Callable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any, Literal, LiteralString, cast
+from typing import Any, Literal, cast
 from urllib.parse import quote, unquote, urlencode, urlparse
 from uuid import UUID, uuid4
 
@@ -1314,16 +1314,13 @@ def _dashboard_project_viewer_emails(session: AuthSession) -> list[str]:
     if not conditions:
         return sorted(email for email in candidates if email)
 
-    query = cast(
-        LiteralString,
-        f"""
+    query = f"""
         SELECT email, email_508
         FROM people
         WHERE sync_status = 'active'
           AND ({" OR ".join(conditions)})
         LIMIT 5
-        """,
-    )
+        """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(query), params)
@@ -1883,9 +1880,7 @@ def _query_dashboard_people(
 
     params.append(limit)
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
-    sql = cast(
-        LiteralString,
-        f"""
+    sql = f"""
         SELECT
             id::text,
             crm_contact_id,
@@ -1920,8 +1915,7 @@ def _query_dashboard_people(
         {where_clause}
         ORDER BY updated_at DESC
         LIMIT %s
-    """,
-    )
+    """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)
@@ -2054,9 +2048,7 @@ def _list_dashboard_onboarding(
         conditions.append("COALESCE(cardinality(skills), 0) = 0")
 
     where_clause = " AND ".join(conditions)
-    sql = cast(
-        LiteralString,
-        f"""
+    sql = f"""
         SELECT
             id::text,
             crm_contact_id,
@@ -2095,8 +2087,7 @@ def _list_dashboard_onboarding(
             onboarding_updated_at DESC NULLS LAST,
             name ASC NULLS LAST
         LIMIT %s
-    """,
-    )
+    """
     params.append(limit)
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
@@ -2257,17 +2248,14 @@ def _dashboard_session_profile_row(session: AuthSession) -> dict[str, Any] | Non
     if not conditions:
         return None
 
-    query = cast(
-        LiteralString,
-        f"""
+    query = f"""
         SELECT name, email, email_508
         FROM people
         WHERE sync_status = 'active'
           AND ({" OR ".join(conditions)})
         ORDER BY updated_at DESC NULLS LAST
         LIMIT 1
-        """,
-    )
+        """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(query), params)

--- a/apps/discord_bot/pyproject.toml
+++ b/apps/discord_bot/pyproject.toml
@@ -18,6 +18,18 @@ dependencies = [
 [tool.uv.sources]
 five08 = { workspace = true }
 
+[tool.pyrefly]
+project-includes = ["src/five08"]
+search-path = [
+    "src",
+    "../api/src",
+    "../worker/src",
+    "../../packages/shared/src",
+]
+python-version = "3.12"
+preset = "legacy"
+ignore-missing-imports = [".*"]
+
 [project.scripts]
 discord-bot = "five08.discord_bot.main:run"
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
@@ -7,7 +7,7 @@ import difflib
 import logging
 import re
 import time
-from typing import Any, Literal
+from typing import Any, Awaitable, Callable, Literal, cast
 from uuid import uuid4
 
 import discord
@@ -705,6 +705,7 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
         create_thread = getattr(message, "create_thread", None)
         if not callable(create_thread):
             return None
+        create_thread = cast(Callable[..., Awaitable[Any]], create_thread)
         try:
             return await create_thread(
                 name=self._mention_thread_name(request),

--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -260,6 +260,10 @@ class MatchResumeSelect(discord.ui.Select):
                     ephemeral=True,
                 )
                 return
+            download_method = cast(
+                Callable[[discord.Interaction, str, str], Awaitable[bool]],
+                download_method,
+            )
 
             resume_id = self.values[0]
             contact_name = self._resume_lookup.get(resume_id, "Unknown")

--- a/apps/worker/pyproject.toml
+++ b/apps/worker/pyproject.toml
@@ -21,6 +21,18 @@ dependencies = [
 [tool.uv.sources]
 five08 = { workspace = true }
 
+[tool.pyrefly]
+project-includes = ["src/five08"]
+search-path = [
+    "src",
+    "../api/src",
+    "../discord_bot/src",
+    "../../packages/shared/src",
+]
+python-version = "3.12"
+preset = "legacy"
+ignore-missing-imports = [".*"]
+
 [project.scripts]
 worker-consumer = "five08.worker.consumer:run"
 jobsctl = "five08.jobcli:run"

--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -19,6 +19,18 @@ dependencies = [
     "langfuse==4.6.1",
 ]
 
+[tool.pyrefly]
+project-includes = ["src/five08"]
+search-path = [
+    "src",
+    "../../apps/api/src",
+    "../../apps/discord_bot/src",
+    "../../apps/worker/src",
+]
+python-version = "3.12"
+preset = "legacy"
+ignore-missing-imports = [".*"]
+
 [project.scripts]
 crmctl = "five08.crm_cli:run"
 agent-eval = "five08.agent.evals:main"

--- a/packages/shared/src/five08/engagements.py
+++ b/packages/shared/src/five08/engagements.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, cast
+from typing import Any, LiteralString, cast
 from uuid import uuid4
 
 from psycopg.rows import dict_row
@@ -624,9 +624,9 @@ def upsert_suggested_applications(
                         fit_score = EXCLUDED.fit_score,
                         evaluation = EXCLUDED.evaluation
                     """
-                cursor.execute(
-                    trusted_sql(
-                        f"""
+                insert_query = cast(
+                    LiteralString,
+                    f"""
                     INSERT INTO engagement_applications (
                         id,
                         engagement_id,
@@ -641,8 +641,10 @@ def upsert_suggested_applications(
                     ) VALUES (%s, %s, %s, %s, %s, 'suggested', %s, %s, %s, %s)
                     {conflict_clause}
                     RETURNING id
-                    """
-                    ),
+                    """,
+                )
+                cursor.execute(
+                    trusted_sql(insert_query),
                     (
                         str(uuid4()),
                         engagement_id,
@@ -1078,7 +1080,9 @@ def list_dashboard_engagements(
         )
         params.extend([like_query, tag_query, tag_query, poster_query])
     params.append(max(1, min(limit, 500)))
-    sql = f"""
+    sql = cast(
+        LiteralString,
+        f"""
         SELECT
             e.id::text,
             e.lifecycle_stage,
@@ -1165,7 +1169,8 @@ def list_dashboard_engagements(
             e.last_activity_at DESC NULLS LAST,
             e.created_at DESC
         LIMIT %s
-    """
+    """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)
@@ -1203,7 +1208,9 @@ def list_dashboard_notifications(
         conditions.append("e.posted_by_discord_user_id = %s")
         params.append(viewer_discord_user_id or "")
     params.append(max(1, min(limit, 50)))
-    sql = f"""
+    sql = cast(
+        LiteralString,
+        f"""
         SELECT
             e.id::text,
             e.title,
@@ -1233,7 +1240,8 @@ def list_dashboard_notifications(
         WHERE {" AND ".join(conditions)}
         ORDER BY age_days DESC, e.created_at ASC
         LIMIT %s
-    """
+    """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)

--- a/packages/shared/src/five08/engagements.py
+++ b/packages/shared/src/five08/engagements.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import asdict, dataclass, is_dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, LiteralString, cast
+from typing import Any, cast
 from uuid import uuid4
 
 from psycopg.rows import dict_row
@@ -624,9 +624,7 @@ def upsert_suggested_applications(
                         fit_score = EXCLUDED.fit_score,
                         evaluation = EXCLUDED.evaluation
                     """
-                insert_query = cast(
-                    LiteralString,
-                    f"""
+                insert_query = f"""
                     INSERT INTO engagement_applications (
                         id,
                         engagement_id,
@@ -641,8 +639,7 @@ def upsert_suggested_applications(
                     ) VALUES (%s, %s, %s, %s, %s, 'suggested', %s, %s, %s, %s)
                     {conflict_clause}
                     RETURNING id
-                    """,
-                )
+                    """
                 cursor.execute(
                     trusted_sql(insert_query),
                     (
@@ -1080,9 +1077,7 @@ def list_dashboard_engagements(
         )
         params.extend([like_query, tag_query, tag_query, poster_query])
     params.append(max(1, min(limit, 500)))
-    sql = cast(
-        LiteralString,
-        f"""
+    sql = f"""
         SELECT
             e.id::text,
             e.lifecycle_stage,
@@ -1169,8 +1164,7 @@ def list_dashboard_engagements(
             e.last_activity_at DESC NULLS LAST,
             e.created_at DESC
         LIMIT %s
-    """,
-    )
+    """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)
@@ -1208,9 +1202,7 @@ def list_dashboard_notifications(
         conditions.append("e.posted_by_discord_user_id = %s")
         params.append(viewer_discord_user_id or "")
     params.append(max(1, min(limit, 50)))
-    sql = cast(
-        LiteralString,
-        f"""
+    sql = f"""
         SELECT
             e.id::text,
             e.title,
@@ -1240,8 +1232,7 @@ def list_dashboard_notifications(
         WHERE {" AND ".join(conditions)}
         ORDER BY age_days DESC, e.created_at ASC
         LIMIT %s
-    """,
-    )
+    """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(trusted_sql(sql), params)

--- a/packages/shared/src/five08/engagements.py
+++ b/packages/shared/src/five08/engagements.py
@@ -13,7 +13,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 from five08.job_channels import normalize_job_posting_type
-from five08.queue import get_postgres_connection
+from five08.queue import get_postgres_connection, trusted_sql
 from five08.settings import SharedSettings
 
 _GIG_THREAD_INTEREST_BACKFILLED_EVENT_TYPE = "gig_thread_interest_backfilled"
@@ -625,7 +625,8 @@ def upsert_suggested_applications(
                         evaluation = EXCLUDED.evaluation
                     """
                 cursor.execute(
-                    f"""
+                    trusted_sql(
+                        f"""
                     INSERT INTO engagement_applications (
                         id,
                         engagement_id,
@@ -640,7 +641,8 @@ def upsert_suggested_applications(
                     ) VALUES (%s, %s, %s, %s, %s, 'suggested', %s, %s, %s, %s)
                     {conflict_clause}
                     RETURNING id
-                    """,
+                    """
+                    ),
                     (
                         str(uuid4()),
                         engagement_id,
@@ -1166,7 +1168,7 @@ def list_dashboard_engagements(
     """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(sql, params)
+            cursor.execute(trusted_sql(sql), params)
             rows = cursor.fetchall()
     return [_shape_engagement_row(row) for row in rows]
 
@@ -1234,7 +1236,7 @@ def list_dashboard_notifications(
     """
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(sql, params)
+            cursor.execute(trusted_sql(sql), params)
             rows = cursor.fetchall()
     return [_shape_stale_recruiting_notification(row, days) for row in rows]
 

--- a/packages/shared/src/five08/engineer_onboarding.py
+++ b/packages/shared/src/five08/engineer_onboarding.py
@@ -175,7 +175,7 @@ def ensure_user(
         if not _is_not_found_error(client, exc):
             raise
         # ERPNext operator convention: put the engineer's full name in User.first_name.
-        fields = {
+        fields: dict[str, Any] = {
             "email": normalized_email,
             "first_name": normalized_full_name,
             "last_name": "",

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -6,7 +6,10 @@ import json
 import logging
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from openai.types.chat import ChatCompletion
 
 from five08.discord_webhook import DiscordWebhookLogger
 from five08.llm import ProviderModel
@@ -775,22 +778,25 @@ def rerank_shortlisted_candidates(
     prompt = _build_rerank_prompt(posting_text, requirements, candidates)
 
     try:
-        response = client.chat.completions.create(
-            **provider_model.chat_completion_kwargs(
-                temperature=0.1,
-                response_format={"type": "json_object"},
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are a senior recruiting coordinator. Rerank a shortlist "
-                            "using only the provided evidence. Return only valid JSON."
-                        ),
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                max_tokens=2500,
-            )
+        response = cast(
+            "ChatCompletion",
+            client.chat.completions.create(
+                **provider_model.chat_completion_kwargs(
+                    temperature=0.1,
+                    response_format={"type": "json_object"},
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a senior recruiting coordinator. Rerank a shortlist "
+                                "using only the provided evidence. Return only valid JSON."
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    max_tokens=2500,
+                )
+            ),
         )
     except Exception as exc:
         logger.error("OpenAI candidate rerank call failed: %s", exc)
@@ -885,22 +891,25 @@ def extract_job_requirements(
     prompt = _build_prompt(posting_text, hints)
 
     try:
-        response = client.chat.completions.create(
-            **provider_model.chat_completion_kwargs(
-                temperature=0.1,
-                response_format={"type": "json_object"},
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are a recruiting assistant. Extract structured hiring requirements "
-                            "from job postings. Return only valid JSON."
-                        ),
-                    },
-                    {"role": "user", "content": prompt},
-                ],
-                max_tokens=2048,
-            )
+        response = cast(
+            "ChatCompletion",
+            client.chat.completions.create(
+                **provider_model.chat_completion_kwargs(
+                    temperature=0.1,
+                    response_format={"type": "json_object"},
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": (
+                                "You are a recruiting assistant. Extract structured hiring requirements "
+                                "from job postings. Return only valid JSON."
+                            ),
+                        },
+                        {"role": "user", "content": prompt},
+                    ],
+                    max_tokens=2048,
+                )
+            ),
         )
     except Exception as exc:
         logger.error("OpenAI job extraction call failed: %s", exc)

--- a/packages/shared/src/five08/newsletter_suppressions.py
+++ b/packages/shared/src/five08/newsletter_suppressions.py
@@ -9,7 +9,7 @@ from typing import Any, Iterable
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
-from five08.queue import get_postgres_connection
+from five08.queue import get_postgres_connection, trusted_sql
 from five08.settings import SharedSettings
 
 NEWSLETTER_SUPPRESSION_SOURCE_PROVIDERS = {"brevo", "keila", "manual"}
@@ -173,13 +173,15 @@ def list_newsletter_suppressions(
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(
-                f"""
+                trusted_sql(
+                    f"""
                 SELECT *
                 FROM newsletter_suppressions
                 {where_clause}
                 ORDER BY last_seen_at DESC, email ASC, source_provider ASC
                 LIMIT %s
-                """,
+                """
+                ),
                 params,
             )
             rows = cursor.fetchall()

--- a/packages/shared/src/five08/newsletter_suppressions.py
+++ b/packages/shared/src/five08/newsletter_suppressions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Iterable
+from typing import Any, Iterable, LiteralString, cast
 
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
@@ -169,20 +169,19 @@ def list_newsletter_suppressions(
         conditions.append("active = true")
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     params.append(limit)
+    query = cast(
+        LiteralString,
+        f"""
+        SELECT *
+        FROM newsletter_suppressions
+        {where_clause}
+        ORDER BY last_seen_at DESC, email ASC, source_provider ASC
+        LIMIT %s
+        """,
+    )
 
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                trusted_sql(
-                    f"""
-                SELECT *
-                FROM newsletter_suppressions
-                {where_clause}
-                ORDER BY last_seen_at DESC, email ASC, source_provider ASC
-                LIMIT %s
-                """
-                ),
-                params,
-            )
+            cursor.execute(trusted_sql(query), params)
             rows = cursor.fetchall()
     return [_as_record(row) for row in rows]

--- a/packages/shared/src/five08/newsletter_suppressions.py
+++ b/packages/shared/src/five08/newsletter_suppressions.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Iterable, LiteralString, cast
+from typing import Any, Iterable
 
 from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
@@ -169,16 +169,13 @@ def list_newsletter_suppressions(
         conditions.append("active = true")
     where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     params.append(limit)
-    query = cast(
-        LiteralString,
-        f"""
+    query = f"""
         SELECT *
         FROM newsletter_suppressions
         {where_clause}
         ORDER BY last_seen_at DESC, email ASC, source_provider ASC
         LIMIT %s
-        """,
-    )
+        """
 
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from difflib import SequenceMatcher
-from typing import Any, LiteralString, cast
+from typing import Any
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -402,9 +402,7 @@ def list_dashboard_projects(
         params.extend([normalized_viewer_emails, normalized_viewer_emails])
     where_sql = f"WHERE {' AND '.join(where)}" if where else ""
     params.append(max(1, min(limit, 500)))
-    query = cast(
-        LiteralString,
-        f"""
+    query = f"""
         SELECT
             p.id::text,
             p.display_name,
@@ -439,8 +437,7 @@ def list_dashboard_projects(
             p.source_modified_at DESC NULLS LAST,
             LOWER(p.display_name) ASC
         LIMIT %s
-        """,
-    )
+        """
 
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -8,7 +8,7 @@ import time
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from difflib import SequenceMatcher
-from typing import Any
+from typing import Any, LiteralString, cast
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -402,50 +402,49 @@ def list_dashboard_projects(
         params.extend([normalized_viewer_emails, normalized_viewer_emails])
     where_sql = f"WHERE {' AND '.join(where)}" if where else ""
     params.append(max(1, min(limit, 500)))
+    query = cast(
+        LiteralString,
+        f"""
+        SELECT
+            p.id::text,
+            p.display_name,
+            p.customer,
+            p.source_status,
+            p.project_type,
+            p.priority,
+            p.percent_complete,
+            p.expected_start_date,
+            p.expected_end_date,
+            p.actual_start_date,
+            p.actual_end_date,
+            p.source_modified_at,
+            p.last_synced_at,
+            pei.external_id AS erpnext_project_id,
+            COALESCE(ec.linked_engagement_count, 0) AS linked_engagement_count
+        FROM projects p
+        LEFT JOIN project_external_ids pei
+          ON pei.project_id = p.id
+         AND pei.source = 'erpnext'
+         AND pei.active IS TRUE
+        LEFT JOIN (
+            SELECT erpnext_project_id, COUNT(*)::int AS linked_engagement_count
+            FROM engagements
+            WHERE erpnext_project_id IS NOT NULL
+            GROUP BY erpnext_project_id
+        ) ec
+          ON ec.erpnext_project_id = pei.external_id
+        {where_sql}
+        ORDER BY
+            LOWER(COALESCE(p.source_status, '')) = 'open' DESC,
+            p.source_modified_at DESC NULLS LAST,
+            LOWER(p.display_name) ASC
+        LIMIT %s
+        """,
+    )
 
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
-            cursor.execute(
-                trusted_sql(
-                    f"""
-                SELECT
-                    p.id::text,
-                    p.display_name,
-                    p.customer,
-                    p.source_status,
-                    p.project_type,
-                    p.priority,
-                    p.percent_complete,
-                    p.expected_start_date,
-                    p.expected_end_date,
-                    p.actual_start_date,
-                    p.actual_end_date,
-                    p.source_modified_at,
-                    p.last_synced_at,
-                    pei.external_id AS erpnext_project_id,
-                    COALESCE(ec.linked_engagement_count, 0) AS linked_engagement_count
-                FROM projects p
-                LEFT JOIN project_external_ids pei
-                  ON pei.project_id = p.id
-                 AND pei.source = 'erpnext'
-                 AND pei.active IS TRUE
-                LEFT JOIN (
-                    SELECT erpnext_project_id, COUNT(*)::int AS linked_engagement_count
-                    FROM engagements
-                    WHERE erpnext_project_id IS NOT NULL
-                    GROUP BY erpnext_project_id
-                ) ec
-                  ON ec.erpnext_project_id = pei.external_id
-                {where_sql}
-                ORDER BY
-                    LOWER(COALESCE(p.source_status, '')) = 'open' DESC,
-                    p.source_modified_at DESC NULLS LAST,
-                    LOWER(p.display_name) ASC
-                LIMIT %s
-                """
-                ),
-                params,
-            )
+            cursor.execute(trusted_sql(query), params)
             project_rows = [dict(row) for row in cursor.fetchall()]
             project_ids = [row["id"] for row in project_rows]
             members_by_project: dict[str, list[dict[str, Any]]] = {

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -17,7 +17,7 @@ from psycopg.rows import dict_row
 from psycopg.types.json import Jsonb
 
 from five08.clients.erpnext import ERPNextAPIError, ERPNextClient
-from five08.queue import get_postgres_connection
+from five08.queue import get_postgres_connection, trusted_sql
 from five08.settings import SharedSettings
 from five08.tls import default_ca_bundle_path
 
@@ -406,7 +406,8 @@ def list_dashboard_projects(
     with get_postgres_connection(settings) as conn:
         with conn.cursor(row_factory=dict_row) as cursor:
             cursor.execute(
-                f"""
+                trusted_sql(
+                    f"""
                 SELECT
                     p.id::text,
                     p.display_name,
@@ -441,7 +442,8 @@ def list_dashboard_projects(
                     p.source_modified_at DESC NULLS LAST,
                     LOWER(p.display_name) ASC
                 LIMIT %s
-                """,
+                """
+                ),
                 params,
             )
             project_rows = [dict(row) for row in cursor.fetchall()]

--- a/packages/shared/src/five08/queue.py
+++ b/packages/shared/src/five08/queue.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, LiteralString, Protocol, cast
+from typing import Any, Protocol, cast
 from uuid import uuid4
 
 from psycopg import Connection, connect
@@ -21,9 +21,14 @@ from five08.settings import SharedSettings
 logger = logging.getLogger(__name__)
 
 
-def trusted_sql(query: LiteralString) -> SQL:
-    """Wrap SQL assembled from fixed internal fragments for psycopg typing."""
-    return SQL(query)
+def trusted_sql(query: str) -> SQL:
+    """Type SQL assembled only from internal fragments plus placeholders.
+
+    Do not pass user input through this helper. Dynamic values must stay in
+    psycopg parameter tuples; dynamic identifiers need psycopg.sql composition.
+    The runtime value remains a plain str so tests can inspect executed SQL.
+    """
+    return cast(SQL, query)
 
 
 class JobStatus(StrEnum):
@@ -231,16 +236,13 @@ def list_jobs(
                 params.append(job_type)
 
             where_clause = " AND ".join(conditions)
-            query = cast(
-                LiteralString,
-                f"""
+            query = f"""
                 SELECT *
                 FROM jobs
                 WHERE {where_clause}
                 ORDER BY created_at DESC
                 LIMIT %s
-            """,
-            )
+            """
             cursor.execute(
                 trusted_sql(query),
                 (*params, limit),
@@ -291,14 +293,11 @@ def _mark_job(
     updates.append("updated_at = NOW()")
     params.append(job_id)
 
-    query = cast(
-        LiteralString,
-        f"""
+    query = f"""
         UPDATE jobs
         SET {", ".join(updates)}
         WHERE id = %s;
-    """,
-    )
+    """
     with get_postgres_connection(settings) as conn:
         with conn.cursor() as cursor:
             cursor.execute(trusted_sql(query), params)

--- a/packages/shared/src/five08/queue.py
+++ b/packages/shared/src/five08/queue.py
@@ -7,17 +7,23 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, Protocol
+from typing import Any, LiteralString, Protocol, cast
 from uuid import uuid4
 
 from psycopg import Connection, connect
 from psycopg.rows import dict_row
+from psycopg.sql import SQL
 from psycopg.types.json import Jsonb
 from redis import Redis
 
 from five08.settings import SharedSettings
 
 logger = logging.getLogger(__name__)
+
+
+def trusted_sql(query: str) -> SQL:
+    """Wrap SQL assembled from fixed internal fragments for psycopg typing."""
+    return SQL(cast(LiteralString, query))
 
 
 class JobStatus(StrEnum):
@@ -233,7 +239,7 @@ def list_jobs(
                 LIMIT %s
             """
             cursor.execute(
-                query,
+                trusted_sql(query),
                 (*params, limit),
             )
             rows = cursor.fetchall()
@@ -289,7 +295,7 @@ def _mark_job(
     """
     with get_postgres_connection(settings) as conn:
         with conn.cursor() as cursor:
-            cursor.execute(query, params)
+            cursor.execute(trusted_sql(query), params)
 
 
 def mark_job_running(

--- a/packages/shared/src/five08/queue.py
+++ b/packages/shared/src/five08/queue.py
@@ -21,9 +21,9 @@ from five08.settings import SharedSettings
 logger = logging.getLogger(__name__)
 
 
-def trusted_sql(query: str) -> SQL:
+def trusted_sql(query: LiteralString) -> SQL:
     """Wrap SQL assembled from fixed internal fragments for psycopg typing."""
-    return SQL(cast(LiteralString, query))
+    return SQL(query)
 
 
 class JobStatus(StrEnum):
@@ -231,13 +231,16 @@ def list_jobs(
                 params.append(job_type)
 
             where_clause = " AND ".join(conditions)
-            query = f"""
+            query = cast(
+                LiteralString,
+                f"""
                 SELECT *
                 FROM jobs
                 WHERE {where_clause}
                 ORDER BY created_at DESC
                 LIMIT %s
-            """
+            """,
+            )
             cursor.execute(
                 trusted_sql(query),
                 (*params, limit),
@@ -288,11 +291,14 @@ def _mark_job(
     updates.append("updated_at = NOW()")
     params.append(job_id)
 
-    query = f"""
+    query = cast(
+        LiteralString,
+        f"""
         UPDATE jobs
         SET {", ".join(updates)}
         WHERE id = %s;
-    """
+    """,
+    )
     with get_postgres_connection(settings) as conn:
         with conn.cursor() as cursor:
             cursor.execute(trusted_sql(query), params)

--- a/packages/shared/src/five08/resume_profile_processor.py
+++ b/packages/shared/src/five08/resume_profile_processor.py
@@ -179,7 +179,7 @@ _LINKEDIN_SECTION_HEADINGS = (
     "Honors & Awards",
     "Languages",
 )
-_LINKEDIN_SECTION_HEADINGS_BY_CASEFOLD = {
+_LINKEDIN_SECTION_HEADINGS_BY_CASEFOLD: dict[str, str] = {
     heading.casefold(): heading for heading in _LINKEDIN_SECTION_HEADINGS
 }
 _LINKEDIN_LOCATION_NEGATIVE_TERMS = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,31 @@ dev = [
     "pytest-mock~=3.15",
     "coverage~=7.6",
     "ruff~=0.15.10",
-    "mypy>=1.14,<3.0",
     "watchfiles>=1.1.1",
     "types-requests>=2.33.0.20260408",
     "pre-commit>=3.7",
     "pre-commit-uv",
     "freezegun>=1.5.5",
     "playwright>=1.58.0",
+    "pyrefly>=1.1.1",
 ]
+
+[tool.pyrefly]
+project-includes = [
+    "apps/api/src/five08",
+    "apps/discord_bot/src/five08",
+    "apps/worker/src/five08",
+    "packages/shared/src/five08",
+]
+search-path = [
+    "apps/api/src",
+    "apps/discord_bot/src",
+    "apps/worker/src",
+    "packages/shared/src",
+]
+python-version = "3.12"
+preset = "legacy"
+ignore-missing-imports = [".*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -74,14 +91,4 @@ exclude_lines = [
     "raise NotImplementedError",
     "if 0:",
     "if __name__ == .__main__.:",
-]
-
-[tool.mypy]
-namespace_packages = true
-explicit_package_bases = true
-mypy_path = [
-    "apps/discord_bot/src",
-    "apps/api/src",
-    "apps/worker/src",
-    "packages/shared/src",
 ]

--- a/scripts/check-all.sh
+++ b/scripts/check-all.sh
@@ -11,7 +11,7 @@ echo "Checking Python formatting..."
 uv run ruff format --check apps/api/src/five08 apps/discord_bot/src/five08 apps/worker/src/five08 packages/shared/src/five08 tests
 echo
 
-./scripts/mypy.sh
+./scripts/pyrefly.sh
 echo
 
 ./scripts/test.sh

--- a/scripts/mypy.sh
+++ b/scripts/mypy.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-set -eu
-
-echo "Running mypy..."
-uv run mypy apps/api/src/five08/ apps/discord_bot/src/five08/ apps/worker/src/five08/ packages/shared/src/five08/ --ignore-missing-imports --explicit-package-bases

--- a/scripts/pyrefly.sh
+++ b/scripts/pyrefly.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+echo "Running Pyrefly..."
+if [ -x .venv/bin/pyrefly ]; then
+  .venv/bin/pyrefly check "$@"
+else
+  uv run pyrefly check "$@"
+fi

--- a/scripts/pyrefly.sh
+++ b/scripts/pyrefly.sh
@@ -2,8 +2,11 @@
 set -eu
 
 echo "Running Pyrefly..."
-if [ -x .venv/bin/pyrefly ]; then
-  .venv/bin/pyrefly check "$@"
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+config_path="$repo_root/pyproject.toml"
+
+if [ -x "$repo_root/.venv/bin/pyrefly" ]; then
+  "$repo_root/.venv/bin/pyrefly" check --config "$config_path" "$@"
 else
-  uv run pyrefly check "$@"
+  uv run pyrefly check --config "$config_path" "$@"
 fi

--- a/scripts/typecheck.sh
+++ b/scripts/typecheck.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 set -eu
 
-./scripts/mypy.sh
+./scripts/pyrefly.sh
 
 echo
 echo "Running admin dashboard typecheck..."

--- a/uv.lock
+++ b/uv.lock
@@ -745,10 +745,10 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "freezegun" },
-    { name = "mypy" },
     { name = "playwright" },
     { name = "pre-commit" },
     { name = "pre-commit-uv" },
+    { name = "pyrefly" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -769,10 +769,10 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = "~=7.6" },
     { name = "freezegun", specifier = ">=1.5.5" },
-    { name = "mypy", specifier = ">=1.14,<3.0" },
     { name = "playwright", specifier = ">=1.58.0" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pre-commit-uv" },
+    { name = "pyrefly", specifier = ">=1.1.1" },
     { name = "pytest", specifier = "~=9.0" },
     { name = "pytest-asyncio", specifier = "~=1.3.0" },
     { name = "pytest-mock", specifier = "~=3.15" },
@@ -1355,47 +1355,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "1.18.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/77/8f0d0001ffad290cef2f7f216f96c814866248a0b92a722365ed54648e7e/mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b", size = 3448846, upload-time = "2025-09-19T00:11:10.519Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/06/dfdd2bc60c66611dd8335f463818514733bc763e4760dee289dcc33df709/mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34", size = 12908273, upload-time = "2025-09-19T00:10:58.321Z" },
-    { url = "https://files.pythonhosted.org/packages/81/14/6a9de6d13a122d5608e1a04130724caf9170333ac5a924e10f670687d3eb/mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764", size = 11920910, upload-time = "2025-09-19T00:10:20.043Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/a9/b29de53e42f18e8cc547e38daa9dfa132ffdc64f7250e353f5c8cdd44bee/mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893", size = 12465585, upload-time = "2025-09-19T00:10:33.005Z" },
-    { url = "https://files.pythonhosted.org/packages/77/ae/6c3d2c7c61ff21f2bee938c917616c92ebf852f015fb55917fd6e2811db2/mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914", size = 13348562, upload-time = "2025-09-19T00:10:11.51Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/31/aec68ab3b4aebdf8f36d191b0685d99faa899ab990753ca0fee60fb99511/mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8", size = 13533296, upload-time = "2025-09-19T00:10:06.568Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/83/abcb3ad9478fca3ebeb6a5358bb0b22c95ea42b43b7789c7fb1297ca44f4/mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074", size = 9828828, upload-time = "2025-09-19T00:10:28.203Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/04/7f462e6fbba87a72bc8097b93f6842499c428a6ff0c81dd46948d175afe8/mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc", size = 12898728, upload-time = "2025-09-19T00:10:01.33Z" },
-    { url = "https://files.pythonhosted.org/packages/99/5b/61ed4efb64f1871b41fd0b82d29a64640f3516078f6c7905b68ab1ad8b13/mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e", size = 11910758, upload-time = "2025-09-19T00:10:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/46/d297d4b683cc89a6e4108c4250a6a6b717f5fa96e1a30a7944a6da44da35/mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986", size = 12475342, upload-time = "2025-09-19T00:11:00.371Z" },
-    { url = "https://files.pythonhosted.org/packages/83/45/4798f4d00df13eae3bfdf726c9244bcb495ab5bd588c0eed93a2f2dd67f3/mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d", size = 13338709, upload-time = "2025-09-19T00:11:03.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/09/479f7358d9625172521a87a9271ddd2441e1dab16a09708f056e97007207/mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba", size = 13529806, upload-time = "2025-09-19T00:10:26.073Z" },
-    { url = "https://files.pythonhosted.org/packages/71/cf/ac0f2c7e9d0ea3c75cd99dff7aec1c9df4a1376537cb90e4c882267ee7e9/mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544", size = 9833262, upload-time = "2025-09-19T00:10:40.035Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/0c/7d5300883da16f0063ae53996358758b2a2df2a09c72a5061fa79a1f5006/mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce", size = 12893775, upload-time = "2025-09-19T00:10:03.814Z" },
-    { url = "https://files.pythonhosted.org/packages/50/df/2cffbf25737bdb236f60c973edf62e3e7b4ee1c25b6878629e88e2cde967/mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d", size = 11936852, upload-time = "2025-09-19T00:10:51.631Z" },
-    { url = "https://files.pythonhosted.org/packages/be/50/34059de13dd269227fb4a03be1faee6e2a4b04a2051c82ac0a0b5a773c9a/mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c", size = 12480242, upload-time = "2025-09-19T00:11:07.955Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/11/040983fad5132d85914c874a2836252bbc57832065548885b5bb5b0d4359/mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb", size = 13326683, upload-time = "2025-09-19T00:09:55.572Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/ba/89b2901dd77414dd7a8c8729985832a5735053be15b744c18e4586e506ef/mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075", size = 13514749, upload-time = "2025-09-19T00:10:44.827Z" },
-    { url = "https://files.pythonhosted.org/packages/25/bc/cc98767cffd6b2928ba680f3e5bc969c4152bf7c2d83f92f5a504b92b0eb/mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf", size = 9982959, upload-time = "2025-09-19T00:10:37.344Z" },
-    { url = "https://files.pythonhosted.org/packages/87/e3/be76d87158ebafa0309946c4a73831974d4d6ab4f4ef40c3b53a385a66fd/mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e", size = 2352367, upload-time = "2025-09-19T00:10:15.489Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1512,15 +1471,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
 ]
 
 [[package]]
@@ -1899,6 +1849,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/29/690202b38b93cf77b73a29c25a63a2b6f3fcb36b1f75006e50b8dee7c108/pymupdf-1.27.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4f1837554134fb45d390a44de8844b2ca9b6c901c82ccc90b340e3b7f3b126ca", size = 25167965, upload-time = "2026-02-11T22:36:35.478Z" },
     { url = "https://files.pythonhosted.org/packages/8a/81/f937e6aa606fd263c3a45d0ff0f0bbdbf3fb779933091fc0f6179513cc93/pymupdf-1.27.1-cp310-abi3-win32.whl", hash = "sha256:fa33b512d82c6c4852edadf57f22d5f27d16243bb33dac0fbe4eb0f281c5b17e", size = 18006253, upload-time = "2026-02-12T13:48:07.129Z" },
     { url = "https://files.pythonhosted.org/packages/3e/99/fe4a7752990bf65277718fffbead4478de9afd1c7288d7a6d643f79a6fa7/pymupdf-1.27.1-cp310-abi3-win_amd64.whl", hash = "sha256:4b6268dff3a9d713034eba5c2ffce0da37c62443578941ac5df433adcde57b2f", size = 19236703, upload-time = "2026-02-11T15:04:19.607Z" },
+]
+
+[[package]]
+name = "pyrefly"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/20/976165fa4b1517a1a92f393b3f4d4badabfff1165eff09d4cd4908428183/pyrefly-1.1.1.tar.gz", hash = "sha256:6deda959f8603a7dbdf112c48983e2275b2903cf33c8c739ed65d7e71a4fd520", size = 5880491, upload-time = "2026-06-18T23:45:43.785Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/d6/02ba666018c6a1cb4ddfa2db98ada721adddd374db5c29ba47a0bf2637fa/pyrefly-1.1.1-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:f4b8595f91885bc8b5e3c282ab68d1df21201668a84e6508b1e15f2feec0bb8d", size = 13631867, upload-time = "2026-06-18T23:45:13.923Z" },
+    { url = "https://files.pythonhosted.org/packages/71/47/7a3457dbbddb513a83cf4fe527d5d5ebda5201a1010ad2a6034030e3e358/pyrefly-1.1.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d6b238e1362622d47a6eb5af704fd8b613c94e8c303386efd6350e3da59fecc8", size = 13075304, upload-time = "2026-06-18T23:45:16.865Z" },
+    { url = "https://files.pythonhosted.org/packages/84/df/70f4b3f42d58ed686a80df31e04eca54d88036cea4f9b96195c64ad0b2b5/pyrefly-1.1.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b50d4510e4f8aaea79e2c4b343a4d7a060c9451c0b2aa9bfe10d7ca1ef33d68d", size = 13446966, upload-time = "2026-06-18T23:45:19.644Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/53/12a19bd6c7af985bcbc13c6910d0f9f6684069ead2282a5c08c2bfbb5d03/pyrefly-1.1.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f330cf039ef3da3b910c84f3a7e431f0cf8d0c1d2dad26491d6cadf3c7cd4759", size = 14449222, upload-time = "2026-06-18T23:45:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/93/f0/e55c48a50076fc0f9ecf4bdedec50456db383e01162f5e2121f8468be071/pyrefly-1.1.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a6342d87c52b04f72156da04f554c4d57f3616f2b32d1763969efb22d05a1407", size = 14472947, upload-time = "2026-06-18T23:45:24.858Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e7/30e085b31fed978ecb675bdbb54df566673ab550469e5af2d350f6af0be6/pyrefly-1.1.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c08b814ad03175e9cf47111390537161828b472044c39ab3320252b3ac6b2edd", size = 13975252, upload-time = "2026-06-18T23:45:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/47/58/49c3e67641133d3fe5d8d9a660dc0826c6c37ca197d86cad05fa7dd8bfd6/pyrefly-1.1.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:d50cad97f19fc893b04deff7239626cffff5dd27ffb29b7d303a1b770247b208", size = 13471780, upload-time = "2026-06-18T23:45:29.775Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1e/65a7ba8355e2c39d8331832905fb74dcc85fc122a3f1dfd6dbf2a88907ad/pyrefly-1.1.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2150b450ee6a6bcbe69b2d45d9a4ebc934a609e1abcf65e490433f38eb873d84", size = 13989306, upload-time = "2026-06-18T23:45:32.576Z" },
+    { url = "https://files.pythonhosted.org/packages/37/de/b7ee1ab2392c36945738246fba7524439810befa3cfcc03cb6157567fc10/pyrefly-1.1.1-py3-none-win32.whl", hash = "sha256:5ffd8a8ed62fe4e6bf0afe1837d1bad149bb3b9f80e928ef248c96b836db3742", size = 12608469, upload-time = "2026-06-18T23:45:35.419Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9c/a0f5b52934bf80e9c7eff08222e7caf318287b9aef76acb8d9ac5740581b/pyrefly-1.1.1-py3-none-win_amd64.whl", hash = "sha256:4e0430f3ef69c8ac73505fd6584db70ed504665a9f0816fef7f723de510f26cb", size = 13502172, upload-time = "2026-06-18T23:45:38.375Z" },
+    { url = "https://files.pythonhosted.org/packages/42/3d/4c6bcb3d456835f51445d3662a428f56c3ea5643ec798c577030ae34298c/pyrefly-1.1.1-py3-none-win_arm64.whl", hash = "sha256:83baf0db71e172665db1fca0ced50b8f7773f5192ca57e8ac6773a772b6d2fc5", size = 12895979, upload-time = "2026-06-18T23:45:41.026Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace mypy with Pyrefly for Python type checking in project dependencies, scripts, pre-commit, and CI.
- Add explicit Pyrefly configuration for the monorepo source roots.
- Address Pyrefly-only typing issues around trusted SQL assembly, dynamic Discord methods, OpenAI chat completion responses, and narrow dict inference.
- Update developer docs and ignore files to reference Pyrefly instead of mypy.

## Impact

Python type checking now runs through `./scripts/pyrefly.sh`; `./scripts/typecheck.sh` still runs Python type checking plus the admin dashboard TypeScript check. CI and pre-commit use the same Pyrefly script.

## Validation

- `./scripts/pyrefly.sh --summary=none --progress-bar no`
- `./scripts/typecheck.sh`
- `uv run pre-commit run pyrefly --all-files`
- `./scripts/lint.sh`
- focused `ruff check` and `ruff format --check` on touched Python files

Note: full pytest suite was not run for this tooling-only migration.