### PR TITLE
Fix onboarding orphan prospect query

### DIFF
--- a/apps/api/src/five08/backend/api.py
+++ b/apps/api/src/five08/backend/api.py
@@ -2404,7 +2404,7 @@ def _list_dashboard_orphan_intake_submissions(
             WHERE lower(people.email) = onboarding_intake_submissions.email
                 AND people.sync_status = 'active'
                 AND people.is_member = false
-                AND people.contact_type ILIKE '%prospect%'
+                AND people.contact_type ILIKE %s
                 AND (
                     people.onboarding_state IS NULL
                     OR replace(
@@ -2420,7 +2420,7 @@ def _list_dashboard_orphan_intake_submissions(
         )
         """,
     ]
-    params: list[Any] = []
+    params: list[Any] = ["%prospect%"]
 
     if normalized_query:
         conditions.append(f"{_ORPHAN_INTAKE_SEARCH_SQL} ILIKE %s")

--- a/tests/unit/test_backend_api.py
+++ b/tests/unit/test_backend_api.py
@@ -3463,7 +3463,9 @@ def test_list_dashboard_onboarding_includes_orphan_intake_without_raw_payload() 
     orphan_sql = cursor.execute.call_args_list[1].args[0]
     assert "raw_payload" not in people_sql
     assert "people.sync_status = 'active'" in orphan_sql
-    assert "people.contact_type ILIKE '%prospect%'" in orphan_sql
+    orphan_params = cursor.execute.call_args_list[1].args[1]
+    assert "people.contact_type ILIKE %s" in orphan_sql
+    assert orphan_params[0] == "%prospect%"
 
 
 def test_list_dashboard_onboarding_merges_orphans_before_applying_limit() -> None:


### PR DESCRIPTION
## Summary
- Fix the onboarding orphan-intake lookup so the prospect contact-type pattern is passed as a psycopg parameter instead of an inline `%prospect%` SQL literal.
- Update the regression test to assert the placeholder and bound parameter.

## Root Cause
The onboarding queue always runs the orphan-intake query. That query included `people.contact_type ILIKE '%prospect%'` inside a psycopg parameterized statement, so psycopg parsed `%p` as an invalid placeholder and raised `ProgrammingError: only '%s', '%b', '%t' are allowed as placeholders, got '%p'`.\n\n## Validation\n- `uv run --package api pytest tests/unit/test_backend_api.py -q`\n- pre-commit hooks on commit: ruff, ruff format, Pyrefly\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how dashboard intake submissions are filtered so matching is handled consistently with query parameters.
  * Updated related validation to confirm the filter value is passed safely and correctly during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->