### PR TITLE
[codex] Add sourced job lead review workflow

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -3416,6 +3416,10 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
     def _truncate_job_lead_text(value: str, limit: int) -> str:
         """Trim lead text for Discord command responses."""
         normalized = value.replace("\r", " ").strip()
+        if limit <= 0:
+            return ""
+        if limit <= 3:
+            return normalized[:limit]
         if len(normalized) <= limit:
             return normalized
         return f"{normalized[: limit - 3]}..."
@@ -3443,8 +3447,23 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             lines.append(f"Apply/contact: {lead.apply_url}")
         if lead.tags:
             lines.append(f"Lead tags: {', '.join(lead.tags)}")
-        body = cls._truncate_job_lead_text(lead.body_normalized, 3200)
-        return "\n".join(lines) + f"\n\n{body}"
+        metadata = "\n".join(lines)
+        separator = "\n\n"
+        body_limit = (
+            settings.discord_sendmsg_character_limit - len(metadata) - len(separator)
+        )
+        if body_limit <= 0:
+            return cls._truncate_job_lead_text(
+                metadata,
+                settings.discord_sendmsg_character_limit,
+            )
+        body = cls._truncate_job_lead_text(lead.body_normalized, body_limit)
+        return f"{metadata}{separator}{body}"
+
+    @staticmethod
+    def _job_lead_allowed_mentions() -> discord.AllowedMentions:
+        """Disable mention parsing for untrusted external lead content."""
+        return discord.AllowedMentions.none()
 
     @staticmethod
     def _resolve_job_lead_forum_tags(
@@ -3611,6 +3630,7 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
                 name=self._truncate_job_lead_text(lead.title, 100),
                 content=content,
                 applied_tags=applied_tags,
+                allowed_mentions=self._job_lead_allowed_mentions(),
                 reason=f"Approved sourced job lead by {interaction.user}",
             )
         except discord.Forbidden:

--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -64,6 +64,13 @@ from five08.job_channels import (
     register_job_post_channel,
     unregister_job_post_channel,
 )
+from five08.job_leads import (
+    JobLead,
+    JobLeadStatus,
+    list_job_leads,
+    mark_job_lead_posted,
+    review_job_lead,
+)
 from five08.job_match import (
     DISCORD_ROLES_EXCLUDE_FROM_SYNC,
     JobRequirements,
@@ -3404,6 +3411,251 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         recorded_interest = await self._persist_thread_direct_interest(message)
         if not recorded_interest:
             await self._persist_thread_reply_activity(message)
+
+    @staticmethod
+    def _truncate_job_lead_text(value: str, limit: int) -> str:
+        """Trim lead text for Discord command responses."""
+        normalized = value.replace("\r", " ").strip()
+        if len(normalized) <= limit:
+            return normalized
+        return f"{normalized[: limit - 3]}..."
+
+    @classmethod
+    def _format_job_lead_review_line(cls, index: int, lead: JobLead) -> str:
+        tags = ", ".join(lead.tags[:5]) if lead.tags else "untagged"
+        title = cls._truncate_job_lead_text(lead.title, 120)
+        return (
+            f"{index}. `{lead.id[:8]}` **{title}** "
+            f"({lead.confidence:.0%}; {tags})\n{lead.source_url}"
+        )
+
+    @classmethod
+    def _format_job_lead_thread_content(cls, lead: JobLead) -> str:
+        lines = [
+            f"Source: {lead.source_url}",
+            f"Status: {lead.status.value}",
+        ]
+        if lead.organization:
+            lines.append(f"Organization: {lead.organization}")
+        if lead.location:
+            lines.append(f"Location: {lead.location}")
+        if lead.apply_url:
+            lines.append(f"Apply/contact: {lead.apply_url}")
+        if lead.tags:
+            lines.append(f"Lead tags: {', '.join(lead.tags)}")
+        body = cls._truncate_job_lead_text(lead.body_normalized, 3200)
+        return "\n".join(lines) + f"\n\n{body}"
+
+    @staticmethod
+    def _resolve_job_lead_forum_tags(
+        channel: discord.ForumChannel,
+        lead: JobLead,
+        extra_tag_names: str | None,
+    ) -> list[discord.ForumTag]:
+        requested = {tag.casefold() for tag in lead.tags}
+        if lead.remote:
+            requested.add("remote")
+        for raw_name in (extra_tag_names or "").split(","):
+            normalized = raw_name.strip().casefold()
+            if normalized:
+                requested.add(normalized)
+        if not requested:
+            return []
+        selected: list[discord.ForumTag] = []
+        for tag in channel.available_tags:
+            normalized_name = tag.name.strip().casefold()
+            if normalized_name in requested:
+                selected.append(tag)
+        return selected[:5]
+
+    @app_commands.command(
+        name="list-job-leads",
+        description="List pending externally sourced job leads awaiting review.",
+    )
+    @app_commands.describe(limit="Number of pending leads to show, up to 10.")
+    @require_role("Steering Committee")
+    async def list_sourced_job_leads(
+        self,
+        interaction: discord.Interaction,
+        limit: int = 5,
+    ) -> None:
+        """Show pending scraped leads without publishing anything to Discord."""
+        await interaction.response.defer(ephemeral=True)
+        safe_limit = max(1, min(limit, 10))
+        try:
+            leads = await asyncio.to_thread(
+                list_job_leads,
+                settings,
+                status=JobLeadStatus.PENDING,
+                limit=safe_limit,
+            )
+        except Exception as exc:
+            logger.warning("Failed listing job leads: %s", exc)
+            await interaction.followup.send(
+                "❌ Failed to load pending job leads.",
+                ephemeral=True,
+            )
+            return
+
+        if not leads:
+            await interaction.followup.send(
+                "No pending job leads found.",
+                ephemeral=True,
+            )
+            return
+
+        lines = [
+            self._format_job_lead_review_line(index, lead)
+            for index, lead in enumerate(leads, start=1)
+        ]
+        await interaction.followup.send(
+            "Pending job leads:\n\n" + "\n\n".join(lines),
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="reject-job-lead",
+        description="Reject a sourced job lead so it will not be posted.",
+    )
+    @app_commands.describe(lead_id="Lead UUID or unambiguous UUID prefix.")
+    @require_role("Steering Committee")
+    async def reject_sourced_job_lead(
+        self,
+        interaction: discord.Interaction,
+        lead_id: str,
+    ) -> None:
+        """Reject a scraped lead without publishing it."""
+        await interaction.response.defer(ephemeral=True)
+        try:
+            lead = await asyncio.to_thread(
+                review_job_lead,
+                settings,
+                lead_id=lead_id,
+                status=JobLeadStatus.REJECTED,
+                reviewer_discord_user_id=str(interaction.user.id),
+            )
+        except Exception as exc:
+            logger.warning("Failed rejecting job lead %s: %s", lead_id, exc)
+            await interaction.followup.send(
+                "❌ Failed to reject this job lead.",
+                ephemeral=True,
+            )
+            return
+
+        if lead is None:
+            await interaction.followup.send(
+                "⚠️ Could not find a pending/approved lead with that ID.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            f"✅ Rejected job lead `{lead.id[:8]}`.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="approve-job-lead",
+        description="Approve a sourced job lead and create a Discord forum thread.",
+    )
+    @app_commands.describe(
+        lead_id="Lead UUID or unambiguous UUID prefix.",
+        channel="Forum channel where the approved lead should be posted.",
+        tags="Optional comma-separated Discord forum tag names to apply.",
+    )
+    @require_role("Steering Committee")
+    async def approve_sourced_job_lead(
+        self,
+        interaction: discord.Interaction,
+        lead_id: str,
+        channel: discord.ForumChannel,
+        tags: str | None = None,
+    ) -> None:
+        """Approve a scraped lead and publish it to Discord."""
+        guild = interaction.guild
+        if guild is None:
+            await interaction.response.send_message(
+                "⚠️ This command must be used inside a server.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        try:
+            lead = await asyncio.to_thread(
+                review_job_lead,
+                settings,
+                lead_id=lead_id,
+                status=JobLeadStatus.APPROVED,
+                reviewer_discord_user_id=str(interaction.user.id),
+            )
+        except Exception as exc:
+            logger.warning("Failed approving job lead %s: %s", lead_id, exc)
+            await interaction.followup.send(
+                "❌ Failed to approve this job lead.",
+                ephemeral=True,
+            )
+            return
+
+        if lead is None:
+            await interaction.followup.send(
+                "⚠️ Could not find a pending/approved lead with that ID.",
+                ephemeral=True,
+            )
+            return
+
+        applied_tags = self._resolve_job_lead_forum_tags(channel, lead, tags)
+        content = self._format_job_lead_thread_content(lead)
+        try:
+            created = await channel.create_thread(
+                name=self._truncate_job_lead_text(lead.title, 100),
+                content=content,
+                applied_tags=applied_tags,
+                reason=f"Approved sourced job lead by {interaction.user}",
+            )
+        except discord.Forbidden:
+            await interaction.followup.send(
+                "❌ Lead approved, but I do not have permission to create a thread in that forum.",
+                ephemeral=True,
+            )
+            return
+        except discord.HTTPException as exc:
+            logger.warning("Failed posting approved job lead %s: %s", lead.id, exc)
+            await interaction.followup.send(
+                "❌ Lead approved, but Discord rejected the thread creation.",
+                ephemeral=True,
+            )
+            return
+
+        thread = getattr(created, "thread", created)
+        thread_id = str(getattr(thread, "id", ""))
+        if not thread_id:
+            await interaction.followup.send(
+                "⚠️ Lead approved and Discord returned success, but I could not record the thread ID.",
+                ephemeral=True,
+            )
+            return
+
+        posted = await asyncio.to_thread(
+            mark_job_lead_posted,
+            settings,
+            lead_id=lead.id,
+            reviewer_discord_user_id=str(interaction.user.id),
+            guild_id=str(guild.id),
+            channel_id=str(channel.id),
+            thread_id=thread_id,
+        )
+        if posted is None:
+            await interaction.followup.send(
+                f"⚠️ Created <#{thread_id}>, but could not mark lead `{lead.id[:8]}` as posted.",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.followup.send(
+            f"✅ Posted approved lead `{lead.id[:8]}` to <#{thread_id}>.",
+            ephemeral=True,
+        )
 
     @app_commands.command(
         name="register-jobs-channel",

--- a/apps/worker/src/five08/worker/jobs.py
+++ b/apps/worker/src/five08/worker/jobs.py
@@ -22,6 +22,7 @@ from five08.worker.erpnext_project_sync import ERPNextProjectSyncProcessor
 from five08.worker.mailbox_resume_ingest import ResumeMailboxProcessor
 from five08.worker.masking import mask_email
 from five08.newsletter_sync import NewsletterSyncProcessor
+from five08.job_lead_sources import scrape_job_leads
 
 logger = logging.getLogger(__name__)
 
@@ -216,6 +217,19 @@ def sync_508_members_newsletters_job() -> dict[str, Any]:
     return _mask_newsletter_sync_result(processor.sync_508_members())
 
 
+def scrape_job_leads_job(
+    source: str = "hackernews_who_is_hiring",
+    story_id: int | None = None,
+) -> dict[str, Any]:
+    """Scrape external job lead sources into the review queue.
+
+    This job intentionally does not publish to Discord. Publishing requires a
+    separate approval action in the bot/dashboard layer.
+    """
+    logger.info("Scraping job leads source=%s story_id=%s", source, story_id)
+    return scrape_job_leads(settings, source=source, story_id=story_id)
+
+
 JOB_FUNCTIONS: dict[str, Callable[..., dict[str, Any]]] = {
     process_webhook_event.__name__: process_webhook_event,
     process_contact_skills_job.__name__: process_contact_skills_job,
@@ -228,4 +242,5 @@ JOB_FUNCTIONS: dict[str, Callable[..., dict[str, Any]]] = {
     sync_projects_from_erpnext_job.__name__: sync_projects_from_erpnext_job,
     sync_508_members_newsletters_job.__name__: sync_508_members_newsletters_job,
     process_docuseal_agreement_job.__name__: process_docuseal_agreement_job,
+    scrape_job_leads_job.__name__: scrape_job_leads_job,
 }

--- a/apps/worker/src/five08/worker/migrations/versions/20260706_0100_create_job_leads.py
+++ b/apps/worker/src/five08/worker/migrations/versions/20260706_0100_create_job_leads.py
@@ -1,0 +1,131 @@
+"""Create sourced job leads review table."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision = "20260706_0100"
+down_revision = "20260614_0200"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create external job leads table with explicit review states."""
+    op.create_table(
+        "job_leads",
+        sa.Column(
+            "id", postgresql.UUID(as_uuid=True), nullable=False, primary_key=True
+        ),
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        sa.Column("source_key", sa.Text(), nullable=False),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column("external_id", sa.Text(), nullable=False),
+        sa.Column("external_parent_id", sa.Text(), nullable=True),
+        sa.Column("source_url", sa.Text(), nullable=False),
+        sa.Column("source_posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("title", sa.Text(), nullable=False),
+        sa.Column("organization", sa.Text(), nullable=True),
+        sa.Column("body_raw", sa.Text(), nullable=False),
+        sa.Column("body_normalized", sa.Text(), nullable=False),
+        sa.Column(
+            "posting_type",
+            sa.Text(),
+            nullable=False,
+            server_default=sa.text("'part_time'"),
+        ),
+        sa.Column("location", sa.Text(), nullable=True),
+        sa.Column("remote", sa.Boolean(), nullable=True),
+        sa.Column("apply_url", sa.Text(), nullable=True),
+        sa.Column(
+            "tags",
+            postgresql.ARRAY(sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::text[]"),
+        ),
+        sa.Column(
+            "confidence",
+            sa.Float(),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "metadata",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column("reviewed_by_discord_user_id", sa.Text(), nullable=True),
+        sa.Column("reviewed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("discord_guild_id", sa.Text(), nullable=True),
+        sa.Column("discord_channel_id", sa.Text(), nullable=True),
+        sa.Column("discord_thread_id", sa.Text(), nullable=True),
+        sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected', 'posted')",
+            name="ck_job_leads_status",
+        ),
+        sa.CheckConstraint(
+            "posting_type IN ('part_time', 'full_time', 'part_time_or_full_time', 'unknown')",
+            name="ck_job_leads_posting_type",
+        ),
+        sa.UniqueConstraint(
+            "source_key",
+            "external_id",
+            name="uq_job_leads_source_external_id",
+        ),
+    )
+    op.create_index("idx_job_leads_status", "job_leads", ["status"])
+    op.create_index(
+        "idx_job_leads_source_parent",
+        "job_leads",
+        ["source_key", "external_parent_id"],
+    )
+    op.create_index(
+        "idx_job_leads_source_posted_at",
+        "job_leads",
+        ["source_posted_at"],
+    )
+    op.create_index(
+        "idx_job_leads_tags",
+        "job_leads",
+        ["tags"],
+        postgresql_using="gin",
+    )
+
+    op.execute(
+        """
+        CREATE TRIGGER job_leads_set_updated_at
+        BEFORE UPDATE ON job_leads
+        FOR EACH ROW EXECUTE FUNCTION engagements_set_updated_at_fn();
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop external job leads table."""
+    op.execute("DROP TRIGGER IF EXISTS job_leads_set_updated_at ON job_leads")
+    op.drop_index("idx_job_leads_tags", table_name="job_leads")
+    op.drop_index("idx_job_leads_source_posted_at", table_name="job_leads")
+    op.drop_index("idx_job_leads_source_parent", table_name="job_leads")
+    op.drop_index("idx_job_leads_status", table_name="job_leads")
+    op.drop_table("job_leads")

--- a/packages/shared/src/five08/job_lead_sources.py
+++ b/packages/shared/src/five08/job_lead_sources.py
@@ -1,0 +1,331 @@
+"""External job lead source adapters."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from html.parser import HTMLParser
+from typing import Any, Protocol
+from urllib.parse import quote, urlencode
+from urllib.request import Request, urlopen
+
+from five08.job_channels import JobPostingType
+from five08.job_leads import JobLeadInput, upsert_job_lead
+from five08.settings import SharedSettings
+
+HN_FIREBASE_BASE_URL = "https://hacker-news.firebaseio.com/v0"
+HN_ALGOLIA_BASE_URL = "https://hn.algolia.com/api/v1"
+HN_WHO_IS_HIRING_SOURCE_KEY = "hackernews_who_is_hiring"
+HN_WHO_IS_HIRING_SOURCE_TYPE = "hackernews"
+
+_WHO_IS_HIRING_TITLE_RE = re.compile(
+    r"^Ask HN: Who is hiring\? \((?P<month>[A-Za-z]+) (?P<year>20\d\d)\)$"
+)
+_URL_RE = re.compile(r"https?://[^\s<>()\[\]\"']+")
+_SEEKING_WORK_RE = re.compile(r"^\s*SEEKING\s+WORK\b", re.IGNORECASE)
+_REMOTE_RE = re.compile(r"\bremote\b", re.IGNORECASE)
+_CONTRACT_TERMS: tuple[tuple[str, re.Pattern[str], float], ...] = (
+    ("contract-to-hire", re.compile(r"\bcontract\s*-?\s*to\s*-?\s*hire\b", re.I), 0.35),
+    ("contract", re.compile(r"\bcontracts?\b|\bcontractors?\b", re.I), 0.30),
+    ("1099", re.compile(r"\b1099\b", re.I), 0.30),
+    ("freelance", re.compile(r"\bfreelanc(?:e|er|ers|ing)\b", re.I), 0.30),
+    ("consulting", re.compile(r"\bconsult(?:ant|ants|ing)\b", re.I), 0.10),
+    ("part-time", re.compile(r"\bpart\s*-?\s*time\b", re.I), 0.20),
+    ("fractional", re.compile(r"\bfractional\b", re.I), 0.20),
+    ("b2b", re.compile(r"\bB2B\b", re.I), 0.15),
+    ("deel", re.compile(r"\bDeel\b", re.I), 0.10),
+)
+
+
+class JobLeadSource(Protocol):
+    """Contract for source adapters that produce job lead candidates."""
+
+    source_key: str
+
+    def collect(self) -> list[JobLeadInput]:
+        """Return current leads from the source."""
+
+
+class _TextExtractor(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in {"p", "br", "li"}:
+            self._parts.append("\n")
+        if tag == "a":
+            href = dict(attrs).get("href")
+            if href:
+                self._parts.append(f" {href} ")
+
+    def handle_data(self, data: str) -> None:
+        self._parts.append(data)
+
+    def text(self) -> str:
+        text = html.unescape("".join(self._parts))
+        text = re.sub(r"[ \t\r\f\v]+", " ", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        return text.strip()
+
+
+@dataclass(frozen=True)
+class HackerNewsThread:
+    """HN monthly Who is hiring thread metadata."""
+
+    story_id: int
+    title: str
+    created_at: datetime | None
+    descendants: int | None = None
+
+
+class HackerNewsClient:
+    """Small HN API client using Algolia for search/tree and Firebase for freshness."""
+
+    def __init__(self, *, timeout_seconds: float = 15.0) -> None:
+        self.timeout_seconds = timeout_seconds
+
+    def _get_json(self, url: str) -> dict[str, Any]:
+        request = Request(url, headers={"User-Agent": "508-workflows-job-leads/1.0"})
+        with urlopen(request, timeout=self.timeout_seconds) as response:
+            return json.loads(response.read().decode("utf-8"))
+
+    def get_item(self, item_id: int) -> dict[str, Any]:
+        return self._get_json(f"{HN_FIREBASE_BASE_URL}/item/{item_id}.json")
+
+    def get_algolia_item_tree(self, item_id: int) -> dict[str, Any]:
+        return self._get_json(f"{HN_ALGOLIA_BASE_URL}/items/{item_id}")
+
+    def search_who_is_hiring_threads(
+        self, *, hits_per_page: int = 12
+    ) -> list[HackerNewsThread]:
+        params = urlencode(
+            {
+                "tags": "story,author_whoishiring",
+                "query": '"Who is hiring?"',
+                "hitsPerPage": str(hits_per_page),
+            }
+        )
+        payload = self._get_json(f"{HN_ALGOLIA_BASE_URL}/search_by_date?{params}")
+        threads: list[HackerNewsThread] = []
+        for hit in payload.get("hits", []):
+            title = str(hit.get("title") or "")
+            if not _WHO_IS_HIRING_TITLE_RE.match(title):
+                continue
+            story_id = int(hit["objectID"])
+            created_at = _parse_datetime(hit.get("created_at"))
+            threads.append(
+                HackerNewsThread(
+                    story_id=story_id,
+                    title=title,
+                    created_at=created_at,
+                    descendants=hit.get("num_comments"),
+                )
+            )
+        return threads
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if isinstance(value, int | float):
+        return datetime.fromtimestamp(value, tz=timezone.utc)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip().replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def html_to_text(raw_html: str | None) -> str:
+    """Convert HN/Algolia comment HTML into normalized text."""
+    parser = _TextExtractor()
+    parser.feed(raw_html or "")
+    return parser.text()
+
+
+def _first_url(text: str) -> str | None:
+    match = _URL_RE.search(text)
+    if not match:
+        return None
+    return match.group(0).rstrip(".,);]")
+
+
+def _split_header(text: str) -> list[str]:
+    first_line = text.splitlines()[0] if text.splitlines() else text
+    return [part.strip() for part in first_line.split("|") if part.strip()]
+
+
+def _contract_tags_and_confidence(text: str) -> tuple[list[str], float]:
+    tags: list[str] = []
+    confidence = 0.0
+    for tag, pattern, weight in _CONTRACT_TERMS:
+        if pattern.search(text):
+            tags.append(tag)
+            confidence += weight
+    if len(tags) >= 2:
+        confidence += 0.15
+    return sorted(set(tags)), min(confidence, 1.0)
+
+
+def classify_contractor_lead(comment_text: str) -> tuple[bool, list[str], float]:
+    """Return whether a HN job post looks contractor-friendly."""
+    if _SEEKING_WORK_RE.search(comment_text):
+        return False, [], 0.0
+    tags, confidence = _contract_tags_and_confidence(comment_text)
+    return bool(tags) and confidence >= 0.20, tags, confidence
+
+
+def _lead_from_hn_comment(
+    *,
+    story_id: int,
+    story_title: str,
+    comment: dict[str, Any],
+) -> JobLeadInput | None:
+    text = html_to_text(comment.get("text"))
+    if not text:
+        return None
+    is_lead, tags, confidence = classify_contractor_lead(text)
+    if not is_lead:
+        return None
+
+    header_parts = _split_header(text)
+    organization = header_parts[0] if header_parts else None
+    title = " | ".join(header_parts[:4]) if header_parts else text[:120]
+    if len(title) > 240:
+        title = f"{title[:237]}..."
+    location = None
+    for part in header_parts[1:]:
+        if any(
+            token in part.casefold()
+            for token in ("remote", "onsite", "hybrid", "us", "eu", "nyc", "sf")
+        ):
+            location = part
+            break
+    comment_id = str(comment["id"])
+    comment_url = f"https://news.ycombinator.com/item?id={comment_id}"
+    metadata = {
+        "hn_story_id": story_id,
+        "hn_story_title": story_title,
+        "hn_author": comment.get("author"),
+        "hn_parent_id": comment.get("parent_id"),
+    }
+    return JobLeadInput(
+        source_key=HN_WHO_IS_HIRING_SOURCE_KEY,
+        source_type=HN_WHO_IS_HIRING_SOURCE_TYPE,
+        external_id=comment_id,
+        external_parent_id=str(story_id),
+        source_url=comment_url,
+        source_posted_at=_parse_datetime(comment.get("created_at")),
+        title=title,
+        organization=organization,
+        body_raw=str(comment.get("text") or ""),
+        body_normalized=text,
+        posting_type=JobPostingType.PART_TIME,
+        location=location,
+        remote=bool(_REMOTE_RE.search(text)) if text else None,
+        apply_url=_first_url(text),
+        tags=tags,
+        confidence=confidence,
+        metadata=metadata,
+    )
+
+
+class HackerNewsWhoIsHiringLeadSource:
+    """Scrape contractor-friendly posts from monthly HN Who is hiring threads."""
+
+    source_key = HN_WHO_IS_HIRING_SOURCE_KEY
+
+    def __init__(
+        self,
+        *,
+        client: HackerNewsClient | None = None,
+        story_id: int | None = None,
+        include_latest: bool = True,
+    ) -> None:
+        self.client = client or HackerNewsClient()
+        self.story_id = story_id
+        self.include_latest = include_latest
+
+    def discover_threads(self) -> list[HackerNewsThread]:
+        if self.story_id is not None:
+            item = self.client.get_item(self.story_id)
+            return [
+                HackerNewsThread(
+                    story_id=self.story_id,
+                    title=str(item.get("title") or f"HN item {self.story_id}"),
+                    created_at=_parse_datetime(item.get("time")),
+                    descendants=item.get("descendants"),
+                )
+            ]
+        threads = self.client.search_who_is_hiring_threads(hits_per_page=6)
+        return threads[:1] if self.include_latest else threads
+
+    def collect(self) -> list[JobLeadInput]:
+        leads: list[JobLeadInput] = []
+        for thread in self.discover_threads():
+            tree = self.client.get_algolia_item_tree(thread.story_id)
+            children = tree.get("children") or []
+            for child in children:
+                if not isinstance(child, dict):
+                    continue
+                if child.get("parent_id") != thread.story_id:
+                    continue
+                lead = _lead_from_hn_comment(
+                    story_id=thread.story_id,
+                    story_title=thread.title,
+                    comment=child,
+                )
+                if lead is not None:
+                    leads.append(lead)
+        return leads
+
+
+def build_job_lead_source(
+    source: str,
+    *,
+    story_id: int | None = None,
+) -> JobLeadSource:
+    """Construct a source adapter by stable source id."""
+    normalized = source.strip().casefold()
+    if normalized in {"hn", "hackernews", HN_WHO_IS_HIRING_SOURCE_KEY}:
+        return HackerNewsWhoIsHiringLeadSource(story_id=story_id)
+    raise ValueError(f"Unsupported job lead source: {source}")
+
+
+def scrape_job_leads(
+    settings: SharedSettings,
+    *,
+    source: str = HN_WHO_IS_HIRING_SOURCE_KEY,
+    story_id: int | None = None,
+) -> dict[str, Any]:
+    """Collect leads from a source and upsert them for review."""
+    adapter = build_job_lead_source(source, story_id=story_id)
+    created = 0
+    updated = 0
+    lead_ids: list[str] = []
+    for lead in adapter.collect():
+        lead_id, was_created = upsert_job_lead(settings, lead)
+        lead_ids.append(lead_id)
+        if was_created:
+            created += 1
+        else:
+            updated += 1
+    return {
+        "source": adapter.source_key,
+        "created": created,
+        "updated": updated,
+        "total": len(lead_ids),
+        "lead_ids": lead_ids,
+    }
+
+
+def hn_story_url(story_id: int) -> str:
+    """Return canonical HN story URL."""
+    return f"https://news.ycombinator.com/item?id={quote(str(story_id))}"

--- a/packages/shared/src/five08/job_leads.py
+++ b/packages/shared/src/five08/job_leads.py
@@ -1,0 +1,330 @@
+"""Persistence helpers for sourced job leads awaiting review."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Any
+from uuid import uuid4
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Jsonb
+
+from five08.job_channels import JobPostingType, normalize_job_posting_type
+from five08.queue import get_postgres_connection, trusted_sql
+from five08.settings import SharedSettings
+
+
+class JobLeadStatus(StrEnum):
+    """Review states for externally sourced job leads."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    POSTED = "posted"
+
+
+@dataclass(frozen=True)
+class JobLeadInput:
+    """One external job lead candidate produced by a source scraper."""
+
+    source_key: str
+    source_type: str
+    external_id: str
+    source_url: str
+    title: str
+    body_raw: str
+    body_normalized: str
+    organization: str | None = None
+    external_parent_id: str | None = None
+    source_posted_at: datetime | None = None
+    posting_type: str | JobPostingType | None = JobPostingType.PART_TIME
+    location: str | None = None
+    remote: bool | None = None
+    apply_url: str | None = None
+    tags: list[str] | None = None
+    confidence: float = 0.0
+    metadata: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class JobLead:
+    """Persisted lead row used by review and publishing flows."""
+
+    id: str
+    status: JobLeadStatus
+    source_key: str
+    source_type: str
+    external_id: str
+    source_url: str
+    title: str
+    body_raw: str
+    body_normalized: str
+    organization: str | None
+    external_parent_id: str | None
+    source_posted_at: datetime | None
+    posting_type: JobPostingType
+    location: str | None
+    remote: bool | None
+    apply_url: str | None
+    tags: list[str]
+    confidence: float
+    metadata: dict[str, Any]
+    reviewed_by_discord_user_id: str | None
+    reviewed_at: datetime | None
+    discord_guild_id: str | None
+    discord_channel_id: str | None
+    discord_thread_id: str | None
+    posted_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def _normalize_status(value: str | JobLeadStatus | None) -> JobLeadStatus:
+    if isinstance(value, JobLeadStatus):
+        return value
+    try:
+        return JobLeadStatus(str(value or "").strip().casefold())
+    except ValueError:
+        return JobLeadStatus.PENDING
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _as_lead(row: dict[str, Any]) -> JobLead:
+    tags = row.get("tags") or []
+    metadata = row.get("metadata") or {}
+    return JobLead(
+        id=str(row["id"]),
+        status=_normalize_status(row.get("status")),
+        source_key=str(row["source_key"]),
+        source_type=str(row["source_type"]),
+        external_id=str(row["external_id"]),
+        source_url=str(row["source_url"]),
+        title=str(row["title"]),
+        body_raw=str(row.get("body_raw") or ""),
+        body_normalized=str(row.get("body_normalized") or ""),
+        organization=row.get("organization"),
+        external_parent_id=row.get("external_parent_id"),
+        source_posted_at=row.get("source_posted_at"),
+        posting_type=normalize_job_posting_type(row.get("posting_type")),
+        location=row.get("location"),
+        remote=row.get("remote"),
+        apply_url=row.get("apply_url"),
+        tags=list(tags) if isinstance(tags, list) else [],
+        confidence=float(row.get("confidence") or 0.0),
+        metadata=metadata if isinstance(metadata, dict) else {},
+        reviewed_by_discord_user_id=row.get("reviewed_by_discord_user_id"),
+        reviewed_at=row.get("reviewed_at"),
+        discord_guild_id=row.get("discord_guild_id"),
+        discord_channel_id=row.get("discord_channel_id"),
+        discord_thread_id=row.get("discord_thread_id"),
+        posted_at=row.get("posted_at"),
+        created_at=row["created_at"],
+        updated_at=row["updated_at"],
+    )
+
+
+def upsert_job_lead(settings: SharedSettings, lead: JobLeadInput) -> tuple[str, bool]:
+    """Create or update a sourced lead without changing human review state."""
+    lead_id = str(uuid4())
+    posting_type = normalize_job_posting_type(lead.posting_type)
+    source_posted_at = _as_utc(lead.source_posted_at)
+    tags = sorted({tag.strip().casefold() for tag in lead.tags or [] if tag.strip()})
+    query = """
+        INSERT INTO job_leads (
+            id,
+            status,
+            source_key,
+            source_type,
+            external_id,
+            external_parent_id,
+            source_url,
+            source_posted_at,
+            title,
+            organization,
+            body_raw,
+            body_normalized,
+            posting_type,
+            location,
+            remote,
+            apply_url,
+            tags,
+            confidence,
+            metadata
+        ) VALUES (
+            %s, 'pending', %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s, %s, %s, %s, %s
+        )
+        ON CONFLICT (source_key, external_id) DO UPDATE SET
+            source_url = EXCLUDED.source_url,
+            source_posted_at = COALESCE(EXCLUDED.source_posted_at, job_leads.source_posted_at),
+            title = EXCLUDED.title,
+            organization = COALESCE(EXCLUDED.organization, job_leads.organization),
+            body_raw = EXCLUDED.body_raw,
+            body_normalized = EXCLUDED.body_normalized,
+            posting_type = EXCLUDED.posting_type,
+            location = COALESCE(EXCLUDED.location, job_leads.location),
+            remote = COALESCE(EXCLUDED.remote, job_leads.remote),
+            apply_url = COALESCE(EXCLUDED.apply_url, job_leads.apply_url),
+            tags = EXCLUDED.tags,
+            confidence = GREATEST(job_leads.confidence, EXCLUDED.confidence),
+            metadata = job_leads.metadata || EXCLUDED.metadata,
+            updated_at = NOW()
+        RETURNING id::text, (xmax = 0) AS inserted
+    """
+    with get_postgres_connection(settings) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(
+                query,
+                (
+                    lead_id,
+                    lead.source_key,
+                    lead.source_type,
+                    lead.external_id,
+                    lead.external_parent_id,
+                    lead.source_url,
+                    source_posted_at,
+                    lead.title.strip() or "Untitled job lead",
+                    lead.organization,
+                    lead.body_raw,
+                    lead.body_normalized,
+                    posting_type.value,
+                    lead.location,
+                    lead.remote,
+                    lead.apply_url,
+                    tags,
+                    float(max(0.0, min(1.0, lead.confidence))),
+                    Jsonb(lead.metadata or {}),
+                ),
+            )
+            row = cursor.fetchone()
+    if row is None:
+        raise RuntimeError("Unable to upsert job lead.")
+    return str(row["id"]), bool(row["inserted"])
+
+
+def list_job_leads(
+    settings: SharedSettings,
+    *,
+    status: JobLeadStatus | str | None = JobLeadStatus.PENDING,
+    limit: int = 10,
+) -> list[JobLead]:
+    """List recent job leads for review."""
+    conditions: list[str] = []
+    params: list[Any] = []
+    if status is not None:
+        conditions.append("status = %s")
+        params.append(_normalize_status(status).value)
+    where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    query = f"""
+        SELECT *
+        FROM job_leads
+        {where_clause}
+        ORDER BY confidence DESC, source_posted_at DESC NULLS LAST, created_at DESC
+        LIMIT %s
+    """
+    params.append(max(1, min(limit, 50)))
+    with get_postgres_connection(settings) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(trusted_sql(query), tuple(params))
+            rows = cursor.fetchall()
+    return [_as_lead(row) for row in rows]
+
+
+def get_job_lead(settings: SharedSettings, lead_id: str) -> JobLead | None:
+    """Load one lead by UUID or unambiguous UUID prefix."""
+    raw = lead_id.strip()
+    if not raw:
+        return None
+    query = """
+        SELECT *
+        FROM job_leads
+        WHERE id::text = %s OR id::text LIKE %s
+        ORDER BY created_at DESC
+        LIMIT 2
+    """
+    with get_postgres_connection(settings) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(query, (raw, f"{raw}%"))
+            rows = cursor.fetchall()
+    if len(rows) != 1:
+        return None
+    return _as_lead(rows[0])
+
+
+def review_job_lead(
+    settings: SharedSettings,
+    *,
+    lead_id: str,
+    status: JobLeadStatus | str,
+    reviewer_discord_user_id: str,
+) -> JobLead | None:
+    """Approve or reject a pending lead without publishing it."""
+    normalized_status = _normalize_status(status)
+    if normalized_status not in {JobLeadStatus.APPROVED, JobLeadStatus.REJECTED}:
+        raise ValueError("Job lead review status must be approved or rejected.")
+    existing = get_job_lead(settings, lead_id)
+    if existing is None:
+        return None
+    query = """
+        UPDATE job_leads
+        SET
+            status = %s,
+            reviewed_by_discord_user_id = %s,
+            reviewed_at = NOW(),
+            updated_at = NOW()
+        WHERE id = %s
+          AND status IN ('pending', 'approved')
+        RETURNING *
+    """
+    with get_postgres_connection(settings) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(
+                query,
+                (normalized_status.value, reviewer_discord_user_id, existing.id),
+            )
+            row = cursor.fetchone()
+    return _as_lead(row) if row is not None else None
+
+
+def mark_job_lead_posted(
+    settings: SharedSettings,
+    *,
+    lead_id: str,
+    reviewer_discord_user_id: str,
+    guild_id: str,
+    channel_id: str,
+    thread_id: str,
+) -> JobLead | None:
+    """Mark an approved lead as published to Discord."""
+    query = """
+        UPDATE job_leads
+        SET
+            status = 'posted',
+            reviewed_by_discord_user_id = COALESCE(reviewed_by_discord_user_id, %s),
+            reviewed_at = COALESCE(reviewed_at, NOW()),
+            discord_guild_id = %s,
+            discord_channel_id = %s,
+            discord_thread_id = %s,
+            posted_at = NOW(),
+            updated_at = NOW()
+        WHERE id = %s
+          AND status = 'approved'
+        RETURNING *
+    """
+    with get_postgres_connection(settings) as conn:
+        with conn.cursor(row_factory=dict_row) as cursor:
+            cursor.execute(
+                query,
+                (reviewer_discord_user_id, guild_id, channel_id, thread_id, lead_id),
+            )
+            row = cursor.fetchone()
+    return _as_lead(row) if row is not None else None

--- a/tests/unit/test_job_lead_sources.py
+++ b/tests/unit/test_job_lead_sources.py
@@ -60,9 +60,7 @@ class _FakeHackerNewsClient:
 def test_html_to_text_preserves_links_and_paragraph_breaks() -> None:
     text = html_to_text('Hello<p><a href="https://example.com">Apply</a>')
 
-    assert "Hello" in text
-    assert "https://example.com" in text
-    assert "Apply" in text
+    assert text == "Hello\n https://example.com Apply"
 
 
 def test_classify_contractor_lead_rejects_seeking_work() -> None:

--- a/tests/unit/test_job_lead_sources.py
+++ b/tests/unit/test_job_lead_sources.py
@@ -1,0 +1,92 @@
+"""Tests for external job lead source adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from five08.job_lead_sources import (
+    HackerNewsThread,
+    HackerNewsWhoIsHiringLeadSource,
+    classify_contractor_lead,
+    html_to_text,
+)
+
+
+class _FakeHackerNewsClient:
+    def search_who_is_hiring_threads(self, *, hits_per_page: int = 12):  # noqa: ANN201
+        return [
+            HackerNewsThread(
+                story_id=48357725,
+                title="Ask HN: Who is hiring? (June 2026)",
+                created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                descendants=3,
+            )
+        ]
+
+    def get_algolia_item_tree(self, item_id: int) -> dict:
+        assert item_id == 48357725
+        return {
+            "id": item_id,
+            "children": [
+                {
+                    "id": 1,
+                    "parent_id": item_id,
+                    "author": "company",
+                    "created_at": "2026-06-01T15:02:00Z",
+                    "text": (
+                        "Acme | Contract Backend Engineer | Remote US"
+                        "<p>We need a 1099 contractor for Python APIs."
+                        '<p>Apply: <a href="https://acme.example/jobs">link</a>'
+                    ),
+                },
+                {
+                    "id": 2,
+                    "parent_id": item_id,
+                    "author": "person",
+                    "created_at": "2026-06-01T15:03:00Z",
+                    "text": "SEEKING WORK | Remote | Freelance engineer",
+                },
+                {
+                    "id": 3,
+                    "parent_id": 1,
+                    "author": "reply",
+                    "created_at": "2026-06-01T15:04:00Z",
+                    "text": "Is this contract remote?",
+                },
+            ],
+        }
+
+
+def test_html_to_text_preserves_links_and_paragraph_breaks() -> None:
+    text = html_to_text('Hello<p><a href="https://example.com">Apply</a>')
+
+    assert "Hello" in text
+    assert "https://example.com" in text
+    assert "Apply" in text
+
+
+def test_classify_contractor_lead_rejects_seeking_work() -> None:
+    is_lead, tags, confidence = classify_contractor_lead(
+        "SEEKING WORK | Remote | Freelance developer"
+    )
+
+    assert is_lead is False
+    assert tags == []
+    assert confidence == 0.0
+
+
+def test_hacker_news_source_extracts_top_level_contractor_posts() -> None:
+    source = HackerNewsWhoIsHiringLeadSource(client=_FakeHackerNewsClient())
+
+    leads = source.collect()
+
+    assert len(leads) == 1
+    lead = leads[0]
+    assert lead.external_id == "1"
+    assert lead.external_parent_id == "48357725"
+    assert lead.organization == "Acme"
+    assert lead.title == "Acme | Contract Backend Engineer | Remote US"
+    assert lead.remote is True
+    assert lead.apply_url == "https://acme.example/jobs"
+    assert {"contract", "1099"}.issubset(set(lead.tags or []))
+    assert lead.confidence >= 0.5

--- a/tests/unit/test_job_leads.py
+++ b/tests/unit/test_job_leads.py
@@ -1,0 +1,165 @@
+"""Tests for sourced job lead persistence helpers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import five08.job_leads as job_leads
+from five08.job_leads import JobLeadInput, JobLeadStatus
+
+
+class _CursorStub:
+    def __init__(self, rows: list[dict] | None = None):
+        self.rows = rows or []
+        self.executed: list[tuple[str, tuple]] = []
+
+    def __enter__(self) -> "_CursorStub":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+    def execute(self, query: str, params: tuple) -> None:
+        self.executed.append((query, params))
+
+    def fetchone(self) -> dict | None:
+        if not self.rows:
+            return None
+        row = self.rows.pop(0)
+        return row if isinstance(row, dict) else None
+
+    def fetchall(self) -> list[dict]:
+        if not self.rows:
+            return []
+        rows = self.rows.pop(0)
+        return list(rows) if isinstance(rows, list) else [rows]
+
+
+class _ConnectionStub:
+    def __init__(self, cursor: _CursorStub):
+        self._cursor = cursor
+
+    def cursor(self, row_factory=None) -> _CursorStub:  # noqa: ARG002
+        return self._cursor
+
+    def __enter__(self) -> "_ConnectionStub":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # noqa: ANN001
+        return None
+
+
+def _install_connection_stub(monkeypatch, cursor: _CursorStub) -> None:
+    @contextmanager
+    def _conn():
+        yield _ConnectionStub(cursor)
+
+    monkeypatch.setattr(job_leads, "get_postgres_connection", lambda _: _conn())
+
+
+def _lead_row(**overrides: object) -> dict:
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    row = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": "pending",
+        "source_key": "hackernews_who_is_hiring",
+        "source_type": "hackernews",
+        "external_id": "48392586",
+        "external_parent_id": "48357725",
+        "source_url": "https://news.ycombinator.com/item?id=48392586",
+        "source_posted_at": now,
+        "title": "CO-Ver | Fullstack | 1099 Contract-to-Hire",
+        "organization": "CO-Ver",
+        "body_raw": "raw",
+        "body_normalized": "normalized",
+        "posting_type": "part_time",
+        "location": "Remote US",
+        "remote": True,
+        "apply_url": "https://example.com",
+        "tags": ["1099", "contract-to-hire"],
+        "confidence": 0.65,
+        "metadata": {"hn_story_id": 48357725},
+        "reviewed_by_discord_user_id": None,
+        "reviewed_at": None,
+        "discord_guild_id": None,
+        "discord_channel_id": None,
+        "discord_thread_id": None,
+        "posted_at": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_upsert_job_lead_preserves_review_state_on_conflict(monkeypatch) -> None:
+    cursor = _CursorStub(rows=[{"id": "lead-1", "inserted": False}])
+    _install_connection_stub(monkeypatch, cursor)
+
+    lead_id, created = job_leads.upsert_job_lead(
+        job_leads.SharedSettings(),
+        JobLeadInput(
+            source_key="hackernews_who_is_hiring",
+            source_type="hackernews",
+            external_id="48392586",
+            source_url="https://news.ycombinator.com/item?id=48392586",
+            title="CO-Ver | Fullstack | 1099 Contract-to-Hire",
+            body_raw="raw",
+            body_normalized="normalized",
+            tags=["Contract-to-Hire", "1099"],
+            confidence=0.65,
+        ),
+    )
+
+    assert lead_id == "lead-1"
+    assert created is False
+    query, params = cursor.executed[0]
+    assert "ON CONFLICT (source_key, external_id) DO UPDATE" in query
+    assert "status =" not in query.split("DO UPDATE SET", 1)[1]
+    assert params[15] == ["1099", "contract-to-hire"]
+
+
+def test_list_job_leads_filters_pending(monkeypatch) -> None:
+    cursor = _CursorStub(rows=[_lead_row()])
+    _install_connection_stub(monkeypatch, cursor)
+
+    result = job_leads.list_job_leads(
+        job_leads.SharedSettings(),
+        status=JobLeadStatus.PENDING,
+        limit=5,
+    )
+
+    assert len(result) == 1
+    assert result[0].status is JobLeadStatus.PENDING
+    assert cursor.executed[0][1] == ("pending", 5)
+
+
+def test_review_job_lead_uses_exact_id_after_prefix_lookup(monkeypatch) -> None:
+    cursor = _CursorStub(
+        rows=[
+            [_lead_row()],
+            _lead_row(status="approved", reviewed_by_discord_user_id="42"),
+        ]
+    )
+
+    @contextmanager
+    def _conn():
+        yield _ConnectionStub(cursor)
+
+    monkeypatch.setattr(job_leads, "get_postgres_connection", lambda _: _conn())
+
+    reviewed = job_leads.review_job_lead(
+        job_leads.SharedSettings(),
+        lead_id="11111111",
+        status=JobLeadStatus.APPROVED,
+        reviewer_discord_user_id="42",
+    )
+
+    assert reviewed is not None
+    assert reviewed.status is JobLeadStatus.APPROVED
+    assert cursor.executed[1][1] == (
+        "approved",
+        "42",
+        "11111111-1111-1111-1111-111111111111",
+    )

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import five08.discord_bot.cogs.jobs as jobs_module
 from five08.discord_bot.cogs.jobs import JobsCog
 from five08.engagements import EngagementStatus
+from five08.job_leads import JobLead, JobLeadStatus
 from five08.job_match import CandidateRerankResult, JobRequirements
 
 
@@ -49,6 +50,41 @@ def _make_candidate(**overrides: object) -> SimpleNamespace:
     return SimpleNamespace(**base)
 
 
+def _make_job_lead(**overrides: object) -> JobLead:
+    now = datetime(2026, 7, 6, tzinfo=timezone.utc)
+    base = {
+        "id": "11111111-1111-1111-1111-111111111111",
+        "status": JobLeadStatus.APPROVED,
+        "source_key": "hackernews_who_is_hiring",
+        "source_type": "hackernews",
+        "external_id": "48392586",
+        "source_url": "https://news.ycombinator.com/item?id=48392586",
+        "title": "CO-Ver | Fullstack SWE | Remote US | 1099 Contract-to-Hire",
+        "body_raw": "raw",
+        "body_normalized": "CO-Ver needs a 1099 contractor.",
+        "organization": "CO-Ver",
+        "external_parent_id": "48357725",
+        "source_posted_at": now,
+        "posting_type": jobs_module.JobPostingType.PART_TIME,
+        "location": "Remote US",
+        "remote": True,
+        "apply_url": "https://example.com",
+        "tags": ["1099", "contract-to-hire"],
+        "confidence": 0.65,
+        "metadata": {},
+        "reviewed_by_discord_user_id": "42",
+        "reviewed_at": now,
+        "discord_guild_id": None,
+        "discord_channel_id": None,
+        "discord_thread_id": None,
+        "posted_at": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    base.update(overrides)
+    return JobLead(**base)
+
+
 def test_build_match_candidate_lines_uses_crm_name_and_discord_username() -> None:
     candidate = _make_candidate(
         is_member=True,
@@ -70,6 +106,33 @@ def test_build_match_candidate_lines_uses_crm_name_and_discord_username() -> Non
         "1. **[Member]** [Caleb](<https://crm.example/#Contact/view/abc>)" in lines[0]
     )
     assert "`@caleb`" in lines[0]
+
+
+def test_job_lead_forum_tags_match_detected_and_extra_tags() -> None:
+    channel = SimpleNamespace(
+        available_tags=[
+            SimpleNamespace(name="Remote"),
+            SimpleNamespace(name="Contract-to-Hire"),
+            SimpleNamespace(name="Python"),
+            SimpleNamespace(name="Full-time"),
+        ]
+    )
+    lead = _make_job_lead()
+
+    tags = JobsCog._resolve_job_lead_forum_tags(channel, lead, "Python")
+
+    assert [tag.name for tag in tags] == ["Remote", "Contract-to-Hire", "Python"]
+
+
+def test_format_job_lead_thread_content_includes_review_context() -> None:
+    lead = _make_job_lead()
+
+    content = JobsCog._format_job_lead_thread_content(lead)
+
+    assert "Source: https://news.ycombinator.com/item?id=48392586" in content
+    assert "Apply/contact: https://example.com" in content
+    assert "Lead tags: 1099, contract-to-hire" in content
+    assert "CO-Ver needs a 1099 contractor." in content
 
 
 def test_update_gig_status_allows_original_thread_poster() -> None:

--- a/tests/unit/test_jobs.py
+++ b/tests/unit/test_jobs.py
@@ -135,6 +135,22 @@ def test_format_job_lead_thread_content_includes_review_context() -> None:
     assert "CO-Ver needs a 1099 contractor." in content
 
 
+def test_format_job_lead_thread_content_respects_discord_limit() -> None:
+    lead = _make_job_lead(body_normalized="x" * 5000)
+
+    content = JobsCog._format_job_lead_thread_content(lead)
+
+    assert len(content) <= jobs_module.settings.discord_sendmsg_character_limit
+    assert content.endswith("...")
+
+
+def test_job_lead_allowed_mentions_disables_all_mentions() -> None:
+    allowed_mentions = JobsCog._job_lead_allowed_mentions()
+
+    payload = allowed_mentions.to_dict()
+    assert payload["parse"] == []
+
+
 def test_update_gig_status_allows_original_thread_poster() -> None:
     interaction = SimpleNamespace(user=SimpleNamespace(id=123, roles=[]))
 

--- a/tests/unit/test_worker_job_leads.py
+++ b/tests/unit/test_worker_job_leads.py
@@ -1,0 +1,29 @@
+"""Tests for job lead worker jobs."""
+
+from __future__ import annotations
+
+from five08.worker import jobs
+
+
+def test_scrape_job_leads_job_is_registered() -> None:
+    assert jobs.JOB_FUNCTIONS["scrape_job_leads_job"] is jobs.scrape_job_leads_job
+
+
+def test_scrape_job_leads_job_delegates_to_shared_scraper(monkeypatch) -> None:
+    calls: list[tuple[object, str, int | None]] = []
+
+    def _scrape(settings: object, *, source: str, story_id: int | None):
+        calls.append((settings, source, story_id))
+        return {"source": source, "created": 1, "updated": 0, "total": 1}
+
+    monkeypatch.setattr(jobs, "scrape_job_leads", _scrape)
+
+    result = jobs.scrape_job_leads_job(source="hackernews_who_is_hiring", story_id=1)
+
+    assert result == {
+        "source": "hackernews_who_is_hiring",
+        "created": 1,
+        "updated": 0,
+        "total": 1,
+    }
+    assert calls == [(jobs.settings, "hackernews_who_is_hiring", 1)]


### PR DESCRIPTION
## Summary

Adds a sourced job lead workflow for contractor-friendly external posts, starting with Hacker News Who is Hiring threads.

- Add reusable job lead persistence with explicit `pending`, `approved`, `rejected`, and `posted` states.
- Add an HN Who is Hiring scraper that discovers monthly threads, reads top-level comments, filters contractor-looking posts, excludes `SEEKING WORK`, and upserts leads without posting to Discord.
- Add a worker job entrypoint for lead ingestion.
- Add Discord review commands to list, reject, and approve leads; Discord forum threads are created only after explicit approval and can apply matching forum tags.
- Add a migration for the `job_leads` table and focused unit coverage.

## Validation

- `uv run pytest tests/unit/test_job_lead_sources.py tests/unit/test_job_leads.py tests/unit/test_worker_job_leads.py tests/unit/test_jobs.py`
- `./scripts/lint.sh`
- `./scripts/pyrefly.sh`
- `./scripts/test.sh` Python suite: `1840 passed, 20 skipped`
- Live HN collector smoke test against story `48357725`: returned 27 contractor-friendly top-level leads without writing to DB

Note: `./scripts/test.sh` then failed in the admin dashboard step because `vitest` was not installed in that package environment (`vitest: command not found`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New DB migration and Discord publishing of third-party content; approval is gated to Steering Committee and mentions are disabled, but mis-approved posts or partial failures (approved but thread/posted state out of sync) need operational awareness.
> 
> **Overview**
> Introduces an **externally sourced job lead** pipeline with human review before anything hits Discord.
> 
> A new **`job_leads`** table and shared persistence layer store leads in **`pending` → `approved` / `rejected` → `posted`** states, with upserts keyed by source and external id so rescrapes refresh content without resetting review.
> 
> A **Hacker News “Who is hiring?”** adapter discovers monthly threads, parses top-level comments, filters contractor-friendly posts (excluding **SEEKING WORK**), and scores tags/confidence. A **worker job** (`scrape_job_leads_job`) ingests into the queue only—no auto-posting.
> 
> **Steering Committee** slash commands in `JobsCog` list pending leads, reject them, or approve and create a forum thread (with optional tag mapping and **mentions disabled** on untrusted body text), then record the Discord thread on the lead row.
> 
> Unit tests cover the HN parser, DB helpers, worker registration, and Discord formatting helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3343db92e84cbd537c1eb60276e4d984a39bd7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->