### PR TITLE
[codex] Add bot internal URL to web service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -119,6 +119,7 @@ services:
       # Use '-' intentionally: an explicitly blank value means "scanner not configured",
       # allowing startup while /health reports degraded in non-local runtimes.
       INTAKE_RESUME_VIRUS_SCAN_COMMAND: ${INTAKE_RESUME_VIRUS_SCAN_COMMAND-clamdscan --stream --no-summary --config-file=/etc/clamav/clamdscan.conf}
+      DISCORD_BOT_INTERNAL_BASE_URL: http://discord_bot:3000
       # Keep the container's internal listen port fixed; vary only the published
       # host port for tunnels/local multi-worktree runs.
       WEB_HOST: 0.0.0.0


### PR DESCRIPTION
## Summary

- Add `DISCORD_BOT_INTERNAL_BASE_URL=http://discord_bot:3000` to the Docker Compose `web` service environment.
- Keep the dashboard job-lead posting path aligned with the existing worker/bot service routing.

## Root Cause

The dashboard/backend API owns the call to the bot internal endpoint for posting approved job leads to Discord, but the internal bot URL was only configured on the `worker` service. In containerized runtimes the web process therefore fell back to the host-runtime default and could not reach the bot listener.

## Impact

Dashboard job-lead posting can now route from `web` to the `discord_bot` service over the Compose network.

## Validation

- `docker compose -f compose.yaml config` shows `DISCORD_BOT_INTERNAL_BASE_URL` on both `web` and `worker`.
- `uv run pytest tests/unit/test_backend_api.py -k "job_lead or discord"` passed: 43 tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Compose env addition with no application logic changes; aligns web with an existing worker setting.
> 
> **Overview**
> Adds **`DISCORD_BOT_INTERNAL_BASE_URL=http://discord_bot:3000`** to the Docker Compose **`web`** service so the backend API can reach the Discord bot over the internal network.
> 
> The **`worker`** service already had this variable; without it on **`web`**, dashboard flows that call the bot (e.g. approved job-lead posting and related internal job endpoints) could fall back to a host-local default and fail inside Compose.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7716e0367b52d5be62fcd4f8e3bcf4459da7173. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s service configuration to improve connectivity with the Discord bot, helping bot-related features run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->