### PR TITLE
[codex] Fix bot gig candidate matching

### DIFF
--- a/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/jobs.py
@@ -494,6 +494,20 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
         starter_author_id = getattr(starter_author, "id", None)
         return str(starter_author_id) if starter_author_id else None
 
+    def _is_own_bot_thread_owner(
+        self,
+        thread: discord.Thread,
+        owner: discord.Member,
+    ) -> bool:
+        """Return whether a bot-owned job thread was created by this bot."""
+        if not getattr(owner, "bot", False):
+            return False
+        bot_user = getattr(self.bot, "user", None)
+        bot_user_id = getattr(bot_user, "id", None)
+        if bot_user_id is None or thread.owner_id is None:
+            return False
+        return str(thread.owner_id) == str(bot_user_id)
+
     async def _refresh_jobs_channel_cache_if_missing(self, guild_id: int) -> bool:
         """Ensure guild cache is loaded, retrying after startup-load failures."""
         if guild_id in self._jobs_channels_by_guild:
@@ -3385,10 +3399,14 @@ class JobsCog(DiscordAuditCogMixin, commands.Cog):
             return
 
         owner = guild.get_member(thread.owner_id) if thread.owner_id else None
-        if owner is None or owner.bot:
+        if owner is None:
             return
-        if not check_user_roles_with_hierarchy(owner.roles, ["Member"]):
-            return
+        if getattr(owner, "bot", False):
+            if not self._is_own_bot_thread_owner(thread, owner):
+                return
+        else:
+            if not check_user_roles_with_hierarchy(owner.roles, ["Member"]):
+                return
 
         await self._run_auto_match_candidates_for_thread(
             thread=thread,

--- a/packages/shared/src/five08/job_match.py
+++ b/packages/shared/src/five08/job_match.py
@@ -18,6 +18,8 @@ from five08.skills import normalize_skill, normalize_skill_list
 logger = logging.getLogger(__name__)
 
 _MAX_HARD_REQUIRED_SKILLS = 2
+_JOB_REQUIREMENTS_INITIAL_MAX_TOKENS = 4096
+_JOB_REQUIREMENTS_MAX_ATTEMPTS = 3
 
 # Normalize abstract or overly compound job-post phrases into concise, searchable
 # skill terms that are more likely to line up with CRM/resume skill records.
@@ -890,43 +892,80 @@ def extract_job_requirements(
     hints = _regex_hints(posting_text)
     prompt = _build_prompt(posting_text, hints)
 
-    try:
-        response = cast(
-            "ChatCompletion",
-            client.chat.completions.create(
-                **provider_model.chat_completion_kwargs(
-                    temperature=0.1,
-                    response_format={"type": "json_object"},
-                    messages=[
-                        {
-                            "role": "system",
-                            "content": (
-                                "You are a recruiting assistant. Extract structured hiring requirements "
-                                "from job postings. Return only valid JSON."
-                            ),
-                        },
-                        {"role": "user", "content": prompt},
-                    ],
-                    max_tokens=2048,
-                )
+    response: Any | None = None
+    raw_content = ""
+    data: dict[str, Any] | None = None
+    attempt_max_tokens = _JOB_REQUIREMENTS_INITIAL_MAX_TOKENS
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a recruiting assistant. Extract structured hiring requirements "
+                "from job postings. Return only valid JSON."
             ),
-        )
-    except Exception as exc:
-        logger.error("OpenAI job extraction call failed: %s", exc)
-        raise RuntimeError(f"OpenAI extraction failed: {exc}") from exc
+        },
+        {"role": "user", "content": prompt},
+    ]
 
-    if not response.choices or not response.choices[0].message.content:
+    for attempt_index in range(_JOB_REQUIREMENTS_MAX_ATTEMPTS):
+        try:
+            response = cast(
+                "ChatCompletion",
+                client.chat.completions.create(
+                    **provider_model.chat_completion_kwargs(
+                        temperature=0.1 if attempt_index == 0 else 0.0,
+                        response_format={"type": "json_object"},
+                        messages=messages,
+                        max_tokens=attempt_max_tokens,
+                        reasoning_effort="minimal",
+                        verbosity="low",
+                    )
+                ),
+            )
+        except Exception as exc:
+            logger.error("OpenAI job extraction call failed: %s", exc)
+            raise RuntimeError(f"OpenAI extraction failed: {exc}") from exc
+
+        first_choice = response.choices[0] if response.choices else None
+        finish_reason = getattr(first_choice, "finish_reason", None)
+        message = getattr(first_choice, "message", None)
+        raw_content = str(getattr(message, "content", "") or "").strip()
+        can_retry_length = (
+            finish_reason == "length"
+            and attempt_index < _JOB_REQUIREMENTS_MAX_ATTEMPTS - 1
+        )
+        if not raw_content:
+            if can_retry_length:
+                attempt_max_tokens *= 2
+                continue
+            raise RuntimeError(
+                f"OpenAI returned empty or missing response content (finish_reason="
+                f"{finish_reason if first_choice is not None else 'no choices'})."
+            )
+
+        try:
+            data = _parse_llm_response(raw_content)
+            break
+        except (json.JSONDecodeError, ValueError) as exc:
+            if can_retry_length:
+                attempt_max_tokens *= 2
+                continue
+            logger.error(
+                "Failed to parse LLM job extraction response: %s",
+                raw_content,
+            )
+            raise RuntimeError(f"LLM returned unparseable response: {exc}") from exc
+
+    if data is None:
+        final_finish_reason = (
+            response.choices[0].finish_reason
+            if response and response.choices
+            else "no choices"
+        )
         raise RuntimeError(
             f"OpenAI returned empty or missing response content (finish_reason="
-            f"{response.choices[0].finish_reason if response.choices else 'no choices'})."
+            f"{final_finish_reason})."
         )
-    raw_content = response.choices[0].message.content.strip()
-
-    try:
-        data = _parse_llm_response(raw_content)
-    except (json.JSONDecodeError, ValueError) as exc:
-        logger.error("Failed to parse LLM job extraction response: %s", raw_content)
-        raise RuntimeError(f"LLM returned unparseable response: {exc}") from exc
 
     hard_required_skills = normalize_skill_list(
         _coerce_str_list(data.get("hard_required_skills"))

--- a/tests/unit/test_crm.py
+++ b/tests/unit/test_crm.py
@@ -2518,7 +2518,7 @@ class TestCRMCog:
         jobs_cog._run_auto_match_candidates_for_thread.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_on_thread_create_skips_bot_owner(self, jobs_cog):
+    async def test_on_thread_create_skips_other_bot_owner(self, jobs_cog, mock_bot):
         class DummyForumChannel:
             def __init__(self, channel_id: int) -> None:
                 self.id = channel_id
@@ -2526,6 +2526,8 @@ class TestCRMCog:
             def permissions_for(self, _role):
                 return Mock(view_channel=False)
 
+        mock_bot.user = Mock()
+        mock_bot.user.id = 111
         guild = Mock()
         guild.id = 123
         guild.default_role = Mock()
@@ -2550,6 +2552,48 @@ class TestCRMCog:
             await jobs_cog.on_thread_create(thread)
 
         jobs_cog._run_auto_match_candidates_for_thread.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_thread_create_auto_matches_own_bot_owner(
+        self, jobs_cog, mock_bot
+    ):
+        class DummyForumChannel:
+            def __init__(self, channel_id: int) -> None:
+                self.id = channel_id
+
+            def permissions_for(self, _role):
+                return Mock(view_channel=False)
+
+        mock_bot.user = Mock()
+        mock_bot.user.id = 999
+        guild = Mock()
+        guild.id = 123
+        guild.default_role = Mock()
+        parent = DummyForumChannel(456)
+        thread = Mock()
+        thread.guild = guild
+        thread.parent = parent
+        thread.owner_id = 999
+
+        owner = Mock()
+        owner.bot = True
+        guild.get_member.return_value = owner
+
+        jobs_cog._refresh_jobs_channel_cache_if_missing = AsyncMock(return_value=True)
+        jobs_cog._is_jobs_channel_registered = Mock(return_value=True)
+        jobs_cog._persist_thread_engagement_index = AsyncMock(return_value=True)
+        jobs_cog._run_auto_match_candidates_for_thread = AsyncMock()
+
+        with patch(
+            "five08.discord_bot.cogs.jobs.discord.ForumChannel",
+            DummyForumChannel,
+        ):
+            await jobs_cog.on_thread_create(thread)
+
+        jobs_cog._run_auto_match_candidates_for_thread.assert_awaited_once_with(
+            thread=thread,
+            trigger="thread_create",
+        )
 
     @pytest.mark.asyncio
     async def test_on_thread_create_skips_non_member(self, jobs_cog):

--- a/tests/unit/test_job_match.py
+++ b/tests/unit/test_job_match.py
@@ -122,11 +122,16 @@ def test_coerce_str_list_non_list_returns_empty() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_openai_response(payload: dict) -> MagicMock:
+def _make_openai_response(
+    payload: dict | None = None,
+    *,
+    content: str | None = None,
+    finish_reason: str = "stop",
+) -> MagicMock:
     """Build a minimal mock that looks like a chat.completions response."""
     choice = MagicMock()
-    choice.message.content = json.dumps(payload)
-    choice.finish_reason = "stop"
+    choice.message.content = content if content is not None else json.dumps(payload)
+    choice.finish_reason = finish_reason
     response = MagicMock()
     response.choices = [choice]
     return response
@@ -189,6 +194,44 @@ def test_extract_normalizes_required_skills() -> None:
     assert create_kwargs["model"] == "gpt-5-mini"
     assert create_kwargs["response_format"] == {"type": "json_object"}
     assert "temperature" not in create_kwargs
+
+
+def test_extract_retries_empty_length_response_with_larger_token_budget() -> None:
+    payload = {
+        "hard_required_skills": ["Python"],
+        "soft_required_skills": [],
+        "preferred_skills": [],
+        "required_evidence": [],
+        "required_skills": ["Python"],
+        "seniority": "senior",
+        "location_type": "remote_any",
+        "preferred_timezones": [],
+        "raw_location_text": None,
+        "title": "Backend Engineer",
+    }
+    with patch("openai.OpenAI") as mock_openai_cls:
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = [
+            _make_openai_response(content="", finish_reason="length"),
+            _make_openai_response(payload),
+        ]
+
+        result = extract_job_requirements(
+            "Need a senior Python engineer.",
+            api_key="test-key",
+        )
+
+    assert result.hard_required_skills == ["python"]
+    calls = mock_client.chat.completions.create.call_args_list
+    assert len(calls) == 2
+    first_token_budget = calls[0].kwargs.get(
+        "max_completion_tokens", calls[0].kwargs.get("max_tokens")
+    )
+    second_token_budget = calls[1].kwargs.get(
+        "max_completion_tokens", calls[1].kwargs.get("max_tokens")
+    )
+    assert second_token_budget > first_token_budget
 
 
 def test_extract_adds_regex_language_gate_to_hard_requirements() -> None:


### PR DESCRIPTION
## Summary

- Allow auto candidate matching for registered private gig forum posts created by this Discord bot, while continuing to skip other bot-owned threads.
- Add bounded retries for job requirement extraction when OpenAI returns `finish_reason=length` with empty or truncated content.
- Increase the extraction output budget and request minimal reasoning / low verbosity for GPT-5-style chat completions.

## Root Cause

Bot-posted gig threads were skipped by the `on_thread_create` owner gate because all bot owners were excluded before auto matching could run. Separately, requirement extraction used a fixed response budget and failed immediately when OpenAI stopped for `length` before returning parseable JSON.

## Validation

- `uv run pytest tests/unit/test_job_match.py tests/unit/test_jobs.py tests/unit/test_crm.py`
- `./scripts/lint.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auto-match eligibility and shared LLM job parsing used by matching flows; behavior is bounded (3 retries, explicit bot-id check) but affects recruiting automation reliability.
> 
> **Overview**
> Fixes **bot-posted private gig threads** not getting automatic candidate matching, and makes **job requirement extraction** more resilient when OpenAI stops for token limits.
> 
> **Discord auto-match:** `on_thread_create` no longer skips every bot-owned thread. It still ignores other bots, but threads owned by **this** bot (via `_is_own_bot_thread_owner`) can trigger auto-match; human posters still need the **Member** role.
> 
> **LLM extraction (`extract_job_requirements`):** Replaces a single 2048-token call with up to **3 attempts**, starting at **4096** tokens and doubling the budget on `finish_reason=length` when content is empty or JSON fails to parse. Retries use **temperature 0**; calls also pass **`reasoning_effort=minimal`** and **`verbosity=low`** for GPT-5-style completions.
> 
> Unit tests cover other-bot skip vs own-bot auto-match and length-limit retries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c598a0d8f16f2832260ae34e858eccfb6e773bd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->