### PR TITLE
[codex] Restrict agent thread continuations

### DIFF
--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -63,20 +63,22 @@ Long-running service changes should be implemented as PR-based workflows rather
 than direct production mutations. Task reads require an explicit project filter
 to avoid guild-wide task enumeration.
 
-Mention flow is opt-in per message: the bot runs the agent only when directly
-mentioned in a server channel or thread. Mention-triggered agent results and
+Mention flow is opt-in by default: the bot runs the agent when directly
+mentioned in a server channel or thread. The only unmentioned continuation path
+is a bot-owned thread named `Agent response`, which is created for public-safe
+mention clarifications. Other bot-created threads, including job forum posts,
+still require an explicit bot mention. Mention-triggered agent results and
 confirmation buttons are sent by DM to avoid leaking task or plan details into
-public channels. A follow-up in the same thread should mention the bot again so
-the bot has an explicit user trigger and fresh Discord role context for that
-request.
+public channels.
 
 Production mention handling depends on Discord gateway and channel access:
 The bot requests all intents in code, but the production Discord application
 should have the Message Content privileged intent enabled or approved in the
 Developer Portal. Direct mentions expose message content even without that
-intent, but follow-up messages in bot-created threads need it because they do
-not mention the bot. The bot also needs channel permissions to view the channel,
-send messages, create public threads, and send messages in threads.
+intent, but unmentioned follow-up messages in dedicated agent response threads
+need it because they do not mention the bot. The bot also needs channel
+permissions to view the channel, send messages, create public threads, and send
+messages in threads.
 
 Audit writes are best-effort and do not block command execution. If the audit
 store is unavailable, treat the agent surface as temporarily untraced until the

--- a/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/agent.py
@@ -32,6 +32,7 @@ _PUBLIC_SAFE_CLARIFICATION_MESSAGES = frozenset(
 _GENERIC_UNSUPPORTED_AGENT_MESSAGE = (
     "I could not turn that into a supported task action."
 )
+_AGENT_RESPONSE_THREAD_NAME = "Agent response"
 _AGENT_HELP_REQUESTS = frozenset(
     {
         "help",
@@ -475,7 +476,10 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
     def _is_agent_thread(channel: object, bot_user_id: int) -> bool:
         if not isinstance(channel, discord.Thread):
             return False
-        return getattr(channel, "owner_id", None) == bot_user_id
+        if getattr(channel, "owner_id", None) != bot_user_id:
+            return False
+        thread_name = str(getattr(channel, "name", "") or "").strip()
+        return thread_name == _AGENT_RESPONSE_THREAD_NAME
 
     @staticmethod
     def _is_agent_help_request(request: str) -> bool:
@@ -719,7 +723,7 @@ class AgentCog(DiscordAuditCogMixin, commands.Cog):
 
     @staticmethod
     def _mention_thread_name(_request: str) -> str:
-        return "Agent response"
+        return _AGENT_RESPONSE_THREAD_NAME
 
     async def _send_mention_response_dm(
         self,

--- a/tests/unit/test_agent_cog.py
+++ b/tests/unit/test_agent_cog.py
@@ -905,12 +905,17 @@ def test_mention_thread_name_does_not_include_request_content() -> None:
 def test_is_agent_thread_requires_bot_owned_thread() -> None:
     bot_owned_thread = object.__new__(discord.Thread)
     bot_owned_thread.owner_id = 999
+    bot_owned_thread.name = "Agent response"
     user_owned_prefixed_thread = object.__new__(discord.Thread)
     user_owned_prefixed_thread.owner_id = 123
-    user_owned_prefixed_thread.name = "agent: renamed by user"
+    user_owned_prefixed_thread.name = "Agent response"
+    bot_owned_job_thread = object.__new__(discord.Thread)
+    bot_owned_job_thread.owner_id = 999
+    bot_owned_job_thread.name = "[RECRUITING] Senior Engineer"
 
     assert AgentCog._is_agent_thread(bot_owned_thread, 999) is True
     assert AgentCog._is_agent_thread(user_owned_prefixed_thread, 999) is False
+    assert AgentCog._is_agent_thread(bot_owned_job_thread, 999) is False
 
 
 @pytest.mark.asyncio
@@ -1164,6 +1169,32 @@ async def test_agent_thread_reply_continues_without_mention() -> None:
     cog._post_agent_request.assert_awaited_once()
     assert cog._post_agent_request.await_args.kwargs["message"] == "show tasks"
     cog._mention_response_thread.assert_awaited_once()
+    cog._audit_message_safe.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_owned_non_agent_thread_reply_without_mention_is_ignored() -> None:
+    cog = AgentCog.__new__(AgentCog)
+    cog.bot = SimpleNamespace(user=SimpleNamespace(id=999))
+    cog._post_agent_request = AsyncMock()
+    cog._audit_message_safe = Mock()
+    channel = object.__new__(discord.Thread)
+    channel.owner_id = 999
+    channel.name = "[RECRUITING] Senior Engineer"
+    message = SimpleNamespace(
+        id=555,
+        content="@Jon Knebel ?",
+        author=SimpleNamespace(id=123, bot=False, roles=[]),
+        mentions=[SimpleNamespace(id=111)],
+        guild=SimpleNamespace(id=456),
+        channel=channel,
+        reply=AsyncMock(),
+    )
+
+    await cog.agent_mention(message)
+
+    cog._post_agent_request.assert_not_awaited()
+    message.reply.assert_not_awaited()
     cog._audit_message_safe.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
- Restrict unmentioned agent follow-ups to bot-owned `Agent response` threads only.
- Prevent bot-created job/forum threads from being treated as agent continuation threads unless the bot is explicitly mentioned.
- Add regression coverage for another-user mention inside a bot-owned recruiting thread and update bot docs.

## Root Cause
`AgentCog._is_agent_thread()` treated every bot-owned Discord thread as an agent continuation thread. Job forum posts created by the bot also matched that predicate, so ordinary replies could be routed into the agent gateway.

## Validation
- `uv run pytest tests/unit/test_agent_cog.py`
- commit hooks: `ruff`, `ruff format`, `Pyrefly`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow routing change in mention handling with targeted tests; reduces mistaken agent invocations rather than expanding capabilities.
> 
> **Overview**
> **Unmentioned agent follow-ups** are no longer treated as agent traffic in every bot-owned thread. `AgentCog._is_agent_thread()` now requires the thread name to be exactly **`Agent response`** (the thread created for public-safe mention clarifications), in addition to bot ownership.
> 
> **Bot-created recruiting/forum threads** (e.g. `[RECRUITING] …`) no longer auto-route ordinary replies into the agent gateway; those threads still need an explicit `@bot` mention. Dedicated **`Agent response`** threads keep the continuation-without-mention behavior.
> 
> Docs in `apps/discord_bot/README.md` describe the opt-in mention model and Message Content intent for unmentioned follow-ups only in those named threads. Unit tests cover job-thread ignores and tightened `_is_agent_thread` rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe65b0ebb0877ea167217560196445b974808c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->