### PR TITLE
Upgrade cloakbrowser to 0.4.7

### DIFF
--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Shared settings, queue, and job utilities for 508.dev services"
 requires-python = ">=3.12"
 dependencies = [
-    "cloakbrowser>=0.3.31",
+    "cloakbrowser>=0.4.7",
     "cryptography>=46.0.0",
     "curl-cffi>=0.10.0",
     "pydantic~=2.13",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
 [tool.uv]
 package = false
 exclude-newer = "7 days"
-exclude-newer-package = { cloakbrowser = "2026-06-01T16:00:00Z" }
 
 [tool.uv.pip]
 exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-cloakbrowser = "2026-06-01T16:00:00Z"
-
 [manifest]
 members = [
     "api",
@@ -441,15 +438,16 @@ wheels = [
 
 [[package]]
 name = "cloakbrowser"
-version = "0.3.31"
+version = "0.4.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cryptography" },
     { name = "httpx" },
     { name = "playwright" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/54/12/50296c1adf7f09988a8ae300f2472e8c33a9d79826980579f0aa7b938b74/cloakbrowser-0.3.31.tar.gz", hash = "sha256:7109961fc9ef0c9a288547eff6717d3cb2cc7ad7b14fecfef1221357b9a0d870", size = 5365798, upload-time = "2026-05-26T18:32:45.045Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/8e/42edfe6b2ef5429c7ee4c86747ccd7a66c453179b78d41fa43778ef40112/cloakbrowser-0.4.7.tar.gz", hash = "sha256:b7efdb2199f1612d9561af15739c3e90198131e30b319d73cab55c819ef0cddb", size = 5569399, upload-time = "2026-07-02T22:24:51.447Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/ba/7acb1250c0d453124f6bff0185296fa75618b0a4924cdf9ef5f27d1337ec/cloakbrowser-0.3.31-py3-none-any.whl", hash = "sha256:0496f586c9a580b03ef69dc26b931bbe3ad93b944be2750edcc423379d97d2d3", size = 76582, upload-time = "2026-05-26T18:32:43.436Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/62/13cf0715f9f1bd1784d0527f6064d2deeeb91406af9187c0adafac2c7ae9/cloakbrowser-0.4.7-py3-none-any.whl", hash = "sha256:4e9019795133e3ec425602813b27140c164da7075be5f064a71c44bfd4eb32bd", size = 98055, upload-time = "2026-07-02T22:24:49.808Z" },
 ]
 
 [[package]]
@@ -731,7 +729,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cloakbrowser", specifier = ">=0.3.31" },
+    { name = "cloakbrowser", specifier = ">=0.4.7" },
     { name = "cryptography", specifier = ">=46.0.0" },
     { name = "curl-cffi", specifier = ">=0.10.0" },
     { name = "langfuse", specifier = "==4.6.1" },


### PR DESCRIPTION
## Summary
- upgrade cloakbrowser dependency floor to 0.4.7
- refresh uv.lock to resolve cloakbrowser 0.4.7 under the 7-day cooldown policy
- remove the stale cloakbrowser-specific exclude-newer override so the global uv cooldown applies normally

## Verification
- uv lock --upgrade-package cloakbrowser
- uv lock --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Browser-based scraping fallbacks depend on cloakbrowser/playwright behavior, and a minor-version bump can change runtime behavior even without local code edits.
> 
> **Overview**
> Bumps the shared **`five08`** dependency floor for **`cloakbrowser`** from **0.3.31** to **>=0.4.7** and refreshes **`uv.lock`** to resolve **0.4.7** (which also pulls **`cryptography`** as a transitive dependency of cloakbrowser).
> 
> Removes the **cloakbrowser-specific** `exclude-newer-package` override from the root **`pyproject.toml`** and lockfile so only the workspace-wide **7-day** `exclude-newer` policy applies when upgrading packages.
> 
> No application code changes; existing **`launch_context`** browser fallbacks in the worker/discord paths keep the same import surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feb89c64c993afcd5913aa031c8b14f495c6e78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloakBrowser package requirement to a newer compatible version.
  * Removed an outdated package timestamp restriction from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->