### PR TITLE
fix: restore dashboard TypeScript checks

### DIFF
--- a/apps/admin_dashboard/bun.lock
+++ b/apps/admin_dashboard/bun.lock
@@ -20,12 +20,11 @@
         "@biomejs/biome": "2.5.0",
         "@testing-library/jest-dom": "6.9.1",
         "@testing-library/react": "16.3.2",
-        "@types/bun": "1.3.14",
         "@types/react": "19.2.15",
         "@types/react-dom": "19.2.3",
         "jsdom": "29.1.1",
         "shadcn": "4.11.0",
-        "typescript": "6.0.3",
+        "typescript": "5.9.3",
         "vite": "8.0.16",
         "vitest": "4.1.7",
       },
@@ -254,8 +253,6 @@
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
-
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -319,8 +316,6 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
-
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
@@ -858,7 +853,7 @@
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
-    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 

--- a/apps/admin_dashboard/package.json
+++ b/apps/admin_dashboard/package.json
@@ -29,12 +29,11 @@
     "@biomejs/biome": "2.5.0",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
-    "@types/bun": "1.3.14",
     "@types/react": "19.2.15",
     "@types/react-dom": "19.2.3",
     "jsdom": "29.1.1",
     "shadcn": "4.11.0",
-    "typescript": "6.0.3",
+    "typescript": "5.9.3",
     "vite": "8.0.16",
     "vitest": "4.1.7"
   }

--- a/apps/admin_dashboard/tsconfig.app.json
+++ b/apps/admin_dashboard/tsconfig.app.json
@@ -16,7 +16,6 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/apps/admin_dashboard/tsconfig.json
+++ b/apps/admin_dashboard/tsconfig.json
@@ -9,7 +9,6 @@
     }
   ],
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]

--- a/apps/admin_dashboard/tsconfig.node.json
+++ b/apps/admin_dashboard/tsconfig.node.json
@@ -10,8 +10,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
-    "strict": true,
-    "types": ["bun"]
+    "strict": true
   },
   "include": ["vite.config.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

- Pin the dashboard compiler to TypeScript 5.9.3, matching the supported local Bun toolchain.
- Remove TypeScript 6-only deprecation suppression.
- Remove the unused Bun ambient type dependency and compiler type entry.
- Regenerate the frozen Bun lockfile.

## Test Coverage

Configuration-only change. No application code paths changed.

## Pre-Landing Review

No issues found.

## Design Review

No frontend runtime code changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Scope Drift

Scope check: CLEAN. The PR only restores dashboard TypeScript checking compatibility.

## Verification Results

- [x] `./scripts/test.sh` — 1,919 passed, 20 skipped
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun install --frozen-lockfile --ignore-scripts`

🤖 Generated with [Codex](https://openai.com/codex/)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only changes in admin_dashboard; no runtime or application code paths affected.
> 
> **Overview**
> Restores **admin dashboard** `tsc -b` compatibility by downgrading **TypeScript** from 6.0.3 to **5.9.3** so it aligns with the supported local Bun toolchain.
> 
> Removes **TypeScript 6-only** `ignoreDeprecations: "6.0"` from the root and app tsconfigs, drops the unused **`@types/bun`** dev dependency and **`types: ["bun"]`** from `tsconfig.node.json`, and updates **`bun.lock`** accordingly. No application source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3594b8aeca022cc96a96e573d818fe4e7392313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->