### PR TITLE
Add Discord Outline wiki search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,20 +85,20 @@ AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
 # Outline integrations
-# Privileged key used for invitations (also requires Migadu + Authentik for
-# /create-user-accounts) and project wiki integrations. Do not reuse it for
-# Discord member commands. OUTLINE_API_KEY is accepted as a legacy fallback.
+# Privileged key used only for invitations (also requires Migadu + Authentik
+# for /create-user-accounts). Do not reuse it for member-safe content reads.
+# OUTLINE_API_KEY is accepted as a legacy fallback.
 # Required for /create-user-accounts and /invite-outline-user.
 # For Outline Cloud, keep the default https://app.getoutline.com.
 # For self-hosted Outline, use https://your-outline-host.
 OUTLINE_BASE_URL=https://app.getoutline.com
 OUTLINE_API_TIMEOUT_SECONDS=20.0
 OUTLINE_ADMIN_API_KEY=
-# Optional for /wiki. Create this key for a dedicated regular Outline Member
-# with access only to member-safe collections; scope it to documents.search and
-# stars.list. OUTLINE_WIKI_API_KEY is accepted as a legacy fallback. That
-# account's starred documents are /wiki quick links.
-OUTLINE_DISCORD_MEMBER_API_KEY=
+# Used by /wiki and project wiki matching. Create this key for a dedicated
+# regular Outline Member with access only to member-safe collections; scope it
+# to documents.search, documents.info, and stars.list. That account's starred
+# documents are /wiki quick links.
+OUTLINE_CONTENTS_API_KEY=
 # ERPNext project tracking (required for project dashboard sync and /projects)
 ERPNEXT_BASE_URL=https://erp.example.com/
 ERPNEXT_API_TIMEOUT_SECONDS=20.0

--- a/.env.example
+++ b/.env.example
@@ -123,7 +123,7 @@ DASHBOARD_DEFAULT_PATH=/dashboard
 # Optional external base URL for generated deep links and dashboard CSRF origin checks
 DASHBOARD_PUBLIC_BASE_URL=
 
-# Discord admin link checks (DB-first, Discord API fallback)
+# Configured Discord co-op server (required for /wiki and admin link checks)
 DISCORD_SERVER_ID=
 DISCORD_ADMIN_ROLES=Admin,Owner
 DISCORD_API_TIMEOUT_SECONDS=8.0

--- a/.env.example
+++ b/.env.example
@@ -84,13 +84,19 @@ AUTHENTIK_API_TOKEN=
 AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
-# Outline wiki invitations (also requires Migadu + Authentik for /create-user-accounts)
+# Outline integrations
+# OUTLINE_API_KEY is used for invitations (also requires Migadu + Authentik for
+# /create-user-accounts). Do not reuse it for Discord wiki search.
 # Required for /create-user-accounts and /invite-outline-user.
 # For Outline Cloud, keep the default https://app.getoutline.com.
 # For self-hosted Outline, use https://your-outline-host.
 OUTLINE_BASE_URL=https://app.getoutline.com
 OUTLINE_API_TIMEOUT_SECONDS=20.0
 OUTLINE_API_KEY=
+# Optional for /wiki. Create this key for a dedicated regular Outline account
+# with access only to member-safe collections; scope it to documents.search and
+# stars.list. That account's starred documents are /wiki quick links.
+OUTLINE_WIKI_API_KEY=
 # ERPNext project tracking (required for project dashboard sync and /projects)
 ERPNEXT_BASE_URL=https://erp.example.com/
 ERPNEXT_API_TIMEOUT_SECONDS=20.0

--- a/.env.example
+++ b/.env.example
@@ -85,18 +85,20 @@ AUTHENTIK_RECOVERY_EMAIL_STAGE_ID=
 # Optional Authentik Email Stage name used when the UUID override is unset.
 AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME=default-recovery-email
 # Outline integrations
-# OUTLINE_API_KEY is used for invitations (also requires Migadu + Authentik for
-# /create-user-accounts). Do not reuse it for Discord wiki search.
+# Privileged key used for invitations (also requires Migadu + Authentik for
+# /create-user-accounts) and project wiki integrations. Do not reuse it for
+# Discord member commands. OUTLINE_API_KEY is accepted as a legacy fallback.
 # Required for /create-user-accounts and /invite-outline-user.
 # For Outline Cloud, keep the default https://app.getoutline.com.
 # For self-hosted Outline, use https://your-outline-host.
 OUTLINE_BASE_URL=https://app.getoutline.com
 OUTLINE_API_TIMEOUT_SECONDS=20.0
-OUTLINE_API_KEY=
-# Optional for /wiki. Create this key for a dedicated regular Outline account
+OUTLINE_ADMIN_API_KEY=
+# Optional for /wiki. Create this key for a dedicated regular Outline Member
 # with access only to member-safe collections; scope it to documents.search and
-# stars.list. That account's starred documents are /wiki quick links.
-OUTLINE_WIKI_API_KEY=
+# stars.list. OUTLINE_WIKI_API_KEY is accepted as a legacy fallback. That
+# account's starred documents are /wiki quick links.
+OUTLINE_DISCORD_MEMBER_API_KEY=
 # ERPNext project tracking (required for project dashboard sync and /projects)
 ERPNEXT_BASE_URL=https://erp.example.com/
 ERPNEXT_API_TIMEOUT_SECONDS=20.0

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -205,22 +205,35 @@ Pydantic import errors.
 - `Optional`: `AUTHENTIK_RECOVERY_EMAIL_STAGE_ID` (when unset, the bot resolves by name)
 - `Optional`: `AUTHENTIK_RECOVERY_EMAIL_STAGE_NAME` (default: `default-recovery-email`)
 
-## Outline Invitations
+## Privileged Outline Integration
 
-- `Required for /create-user-accounts and /invite-outline-user`: `OUTLINE_API_KEY`
+- `Required for /create-user-accounts and /invite-outline-user`:
+  `OUTLINE_ADMIN_API_KEY`
 - Note: `/create-user-accounts` also requires the Migadu and Authentik settings above.
 - `Optional`: `OUTLINE_BASE_URL` (default: `https://app.getoutline.com`; root and `/api` URLs are both accepted)
 - `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
+- `OUTLINE_API_KEY` remains a compatibility fallback. A non-empty
+  `OUTLINE_ADMIN_API_KEY` wins; a blank new value continues to fall back to the
+  old value during migration. Add the new variable in the deployment dashboard,
+  redeploy, and then remove the old variable.
+- The in-app Configuration dashboard stores encrypted database overrides; it
+  does not edit deployment environment variables. It displays
+  `OUTLINE_ADMIN_API_KEY`, reads an existing `OUTLINE_API_KEY` dashboard value
+  as a fallback, and removes that old stored value when the new setting is saved.
+  Any non-empty environment value under either name locks the dashboard setting.
 
 ## Discord Wiki Search
 
-- `Optional for /wiki`: `OUTLINE_WIKI_API_KEY`
+- `Optional for /wiki`: `OUTLINE_DISCORD_MEMBER_API_KEY`
 - `Required for /wiki`: `DISCORD_SERVER_ID`. The command refuses DMs and other
   guilds so the dedicated Outline credential is never used outside the co-op
   server.
-- Do not reuse `OUTLINE_API_KEY`: it can invite users and may access private
+- Do not reuse `OUTLINE_ADMIN_API_KEY`: it can invite users and may access private
   collections. Create the wiki key for a dedicated regular Outline account with
   access only to collections that every Discord `Member` may search.
+- `OUTLINE_WIKI_API_KEY` remains a compatibility fallback. A non-empty new
+  member key wins; a blank new value continues to fall back to the old value
+  during migration.
 - Scope the key to `documents.search` and `stars.list`. `/wiki query:...`
   searches published documents only; `/wiki` without a query shows the
   dedicated account's starred documents as quick links.

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -222,21 +222,25 @@ Pydantic import errors.
   as a fallback, and removes that old stored value when the new setting is saved.
   Any non-empty environment value under either name locks the dashboard setting.
 
-## Discord Wiki Search
+## Member-safe Outline Content
 
-- `Optional for /wiki`: `OUTLINE_DISCORD_MEMBER_API_KEY`
+- `Required when using /wiki or project wiki matching`:
+  `OUTLINE_CONTENTS_API_KEY`
 - `Required for /wiki`: `DISCORD_SERVER_ID`. The command refuses DMs and other
   guilds so the dedicated Outline credential is never used outside the co-op
   server.
 - Do not reuse `OUTLINE_ADMIN_API_KEY`: it can invite users and may access private
-  collections. Create the wiki key for a dedicated regular Outline account with
-  access only to collections that every Discord `Member` may search.
-- `OUTLINE_WIKI_API_KEY` remains a compatibility fallback. A non-empty new
-  member key wins; a blank new value continues to fall back to the old value
-  during migration.
-- Scope the key to `documents.search` and `stars.list`. `/wiki query:...`
-  searches published documents only; `/wiki` without a query shows the
-  dedicated account's starred documents as quick links.
+  collections. Create the contents key for a dedicated regular Outline account
+  with access only to collections that every Discord `Member` may search.
+- Scope the key to `documents.search`, `documents.info`, and `stars.list`.
+  `/wiki query:...` searches published documents only; `/wiki` without a query
+  shows the dedicated account's starred documents as quick links. The same key
+  reads the member-visible project-matching document for the dashboard.
+- Add only the exact document-write scopes needed when a write feature is
+  introduced; do not grant `documents.*` preemptively.
+- The in-app Configuration dashboard stores this encrypted key under
+  `OUTLINE_CONTENTS_API_KEY`; a non-empty deployment environment value locks
+  the dashboard setting.
 - The command always replies ephemerally. It does not log search queries or
   document snippets.
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -215,6 +215,9 @@ Pydantic import errors.
 ## Discord Wiki Search
 
 - `Optional for /wiki`: `OUTLINE_WIKI_API_KEY`
+- `Required for /wiki`: `DISCORD_SERVER_ID`. The command refuses DMs and other
+  guilds so the dedicated Outline credential is never used outside the co-op
+  server.
 - Do not reuse `OUTLINE_API_KEY`: it can invite users and may access private
   collections. Create the wiki key for a dedicated regular Outline account with
   access only to collections that every Discord `Member` may search.

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -212,6 +212,18 @@ Pydantic import errors.
 - `Optional`: `OUTLINE_BASE_URL` (default: `https://app.getoutline.com`; root and `/api` URLs are both accepted)
 - `Optional`: `OUTLINE_API_TIMEOUT_SECONDS` (default: `20.0`)
 
+## Discord Wiki Search
+
+- `Optional for /wiki`: `OUTLINE_WIKI_API_KEY`
+- Do not reuse `OUTLINE_API_KEY`: it can invite users and may access private
+  collections. Create the wiki key for a dedicated regular Outline account with
+  access only to collections that every Discord `Member` may search.
+- Scope the key to `documents.search` and `stars.list`. `/wiki query:...`
+  searches published documents only; `/wiki` without a query shows the
+  dedicated account's starred documents as quick links.
+- The command always replies ephemerally. It does not log search queries or
+  document snippets.
+
 ## Discord CRM Audit Logging (Best Effort)
 
 - `Optional`: `AUDIT_API_BASE_URL` (defaults to `BACKEND_API_BASE_URL`; Compose clears stale `.env` values so the fallback uses the injected backend URL)

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -113,6 +113,18 @@ Relevant configuration:
 - **Steering Committee**: includes member permissions and adds additional moderation/admin-assist commands.
 - **Admin**: can run sensitive writes such as ID verification updates.
 
+## Wiki Search
+
+`/wiki` is a private, read-only Outline search surface for members. With no
+query it shows the starred quick links from the dedicated Outline integration
+account; with `query:` it searches that account's published, member-safe
+documents and returns short excerpts plus Outline links.
+
+Configure `OUTLINE_WIKI_API_KEY` separately from `OUTLINE_API_KEY`. The wiki
+key must belong to a regular account that has access only to collections safe
+for every Discord `Member`, and should be scoped to `documents.search` and
+`stars.list`. Search queries and result snippets are not audit logged.
+
 ## Slash Commands
 
 - `/agent`
@@ -143,6 +155,15 @@ Relevant configuration:
     - Sends the invoking member's Discord role names so local/dev/test backends can authorize links when the local people cache is empty.
     - Returns an ephemeral one-time URL with expiry.
     - Opening the URL loads a short browser page that automatically continues with a POST. The link is not consumed by the initial GET, so normal Discord link previews and security scanners do not burn the token.
+
+- `/wiki`
+  - Description: Search member-safe Outline documents or show quick links.
+  - Required role: Member.
+  - Args: `query` (optional). Omit it to show quick links curated by the
+    integration account's Outline stars.
+  - Behavior: Returns up to five published search results, each with a short
+    excerpt, last-updated date, and an Outline link. Responses are ephemeral.
+  - Search syntax: supports quoted phrases, `OR`, and `-exclude`.
 
 - `/payment-info`
   - Description: View masked ERPNext Supplier Details payment info and open a modal to update your own payment details.

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -123,7 +123,8 @@ documents and returns short excerpts plus Outline links.
 Configure `OUTLINE_WIKI_API_KEY` separately from `OUTLINE_API_KEY`. The wiki
 key must belong to a regular account that has access only to collections safe
 for every Discord `Member`, and should be scoped to `documents.search` and
-`stars.list`. Search queries and result snippets are not audit logged.
+`stars.list`. `DISCORD_SERVER_ID` is required: `/wiki` refuses DMs and other
+guilds. Search queries and result snippets are not audit logged.
 
 ## Slash Commands
 

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -120,11 +120,12 @@ query it shows the starred quick links from the dedicated Outline integration
 account; with `query:` it searches that account's published, member-safe
 documents and returns short excerpts plus Outline links.
 
-Configure `OUTLINE_WIKI_API_KEY` separately from `OUTLINE_API_KEY`. The wiki
-key must belong to a regular account that has access only to collections safe
-for every Discord `Member`, and should be scoped to `documents.search` and
-`stars.list`. `DISCORD_SERVER_ID` is required: `/wiki` refuses DMs and other
-guilds. Search queries and result snippets are not audit logged.
+Configure `OUTLINE_DISCORD_MEMBER_API_KEY` separately from
+`OUTLINE_ADMIN_API_KEY`. The member key must belong to a regular account that
+has access only to collections safe for every Discord `Member`, and should be
+scoped to `documents.search` and `stars.list`. `DISCORD_SERVER_ID` is required:
+`/wiki` refuses DMs and other guilds. `OUTLINE_WIKI_API_KEY` remains a
+compatibility fallback. Search queries and result snippets are not audit logged.
 
 ## Slash Commands
 

--- a/apps/discord_bot/README.md
+++ b/apps/discord_bot/README.md
@@ -120,12 +120,13 @@ query it shows the starred quick links from the dedicated Outline integration
 account; with `query:` it searches that account's published, member-safe
 documents and returns short excerpts plus Outline links.
 
-Configure `OUTLINE_DISCORD_MEMBER_API_KEY` separately from
-`OUTLINE_ADMIN_API_KEY`. The member key must belong to a regular account that
+Configure `OUTLINE_CONTENTS_API_KEY` separately from
+`OUTLINE_ADMIN_API_KEY`. The contents key must belong to a regular account that
 has access only to collections safe for every Discord `Member`, and should be
-scoped to `documents.search` and `stars.list`. `DISCORD_SERVER_ID` is required:
-`/wiki` refuses DMs and other guilds. `OUTLINE_WIKI_API_KEY` remains a
-compatibility fallback. Search queries and result snippets are not audit logged.
+scoped to `documents.search`, `documents.info`, and `stars.list`.
+`DISCORD_SERVER_ID` is required: `/wiki` refuses DMs and other guilds. The same
+member-safe key supports project wiki matching in the dashboard. Search queries
+and result snippets are not audit logged.
 
 ## Slash Commands
 

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm/core.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm/core.py
@@ -3644,9 +3644,9 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
 
     def _outline_client(self) -> OutlineClient:
         """Build an Outline API client from shared settings."""
-        api_key = self._contact_text_value(settings.outline_api_key)
+        api_key = self._contact_text_value(settings.outline_admin_api_key)
         if not api_key:
-            raise ValueError("OUTLINE_API_KEY is not configured.")
+            raise ValueError("OUTLINE_ADMIN_API_KEY is not configured.")
 
         base_url = (
             self._contact_text_value(settings.outline_base_url)

--- a/apps/discord_bot/src/five08/discord_bot/cogs/crm/core.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/crm/core.py
@@ -8294,12 +8294,17 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 ephemeral=True,
             )
         except OutlineAPIError as exc:
+            logger.exception("Outline invite failed for CRM contact")
             message = self._sanitize_error_message_for_discord(exc)
             self._audit_command_safe(
                 interaction=interaction,
                 action="crm.invite_outline_user",
                 result="error",
-                metadata={"search_term": search_term, "error": message},
+                metadata={
+                    "search_term": search_term,
+                    "stage": "outline",
+                    "error": message,
+                },
             )
             await interaction.followup.send(
                 f"❌ Outline invite failed: {message}",
@@ -8345,6 +8350,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 ephemeral=True,
             )
         except OutlineAPIError as exc:
+            logger.exception("Outline invite failed for direct email")
             message = self._sanitize_error_message_for_discord(exc)
             self._audit_command_safe(
                 interaction=interaction,
@@ -8354,6 +8360,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                     "search_term": search_term,
                     "email": email,
                     "direct_email": True,
+                    "stage": "outline",
                     "error": message,
                 },
             )
@@ -8553,6 +8560,7 @@ class CRMCog(DiscordAuditCogMixin, commands.Cog):
                 ephemeral=True,
             )
         except OutlineAPIError as exc:
+            logger.exception("Outline invite failed during user account provisioning")
             message = self._sanitize_error_message_for_discord(exc)
             self._audit_command_safe(
                 interaction=interaction,

--- a/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
@@ -1,0 +1,208 @@
+"""Read-only Outline wiki search commands for Discord members."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+import html
+import logging
+import re
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from five08.clients.outline import (
+    OutlineAPIError,
+    OutlineClient,
+    OutlineDocumentSummary,
+    OutlineSearchResult,
+)
+from five08.discord_bot.config import settings
+from five08.discord_bot.utils.role_decorators import require_role
+
+
+logger = logging.getLogger(__name__)
+NO_MENTIONS = discord.AllowedMentions.none()
+WIKI_SEARCH_RESULT_LIMIT = 5
+WIKI_QUICK_LINK_LIMIT = 6
+WIKI_QUERY_MAX_LENGTH = 200
+WIKI_TITLE_MAX_LENGTH = 220
+WIKI_CONTEXT_MAX_LENGTH = 300
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _safe_display_text(value: str, *, max_length: int) -> str:
+    """Collapse and escape untrusted wiki text for a Discord embed."""
+    normalized = html.unescape(value)
+    normalized = _HTML_TAG_RE.sub("", normalized)
+    normalized = " ".join(normalized.split())
+    normalized = discord.utils.escape_mentions(
+        discord.utils.escape_markdown(normalized)
+    )
+    if len(normalized) <= max_length:
+        return normalized
+    return f"{normalized[: max_length - 1].rstrip()}…"
+
+
+def _updated_date(updated_at: str | None) -> str | None:
+    """Format a trusted Outline timestamp as a compact date."""
+    if not updated_at:
+        return None
+    try:
+        return (
+            datetime.fromisoformat(updated_at.replace("Z", "+00:00")).date().isoformat()
+        )
+    except ValueError:
+        return None
+
+
+def _document_link(document: OutlineDocumentSummary) -> str:
+    """Return one safe Markdown link to a validated Outline document URL."""
+    title = _safe_display_text(document.title, max_length=WIKI_TITLE_MAX_LENGTH)
+    return f"[{title}]({document.url})"
+
+
+class WikiCog(commands.Cog, name="Wiki"):
+    """Search member-safe Outline content and show curated quick links."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    def _outline_client(self) -> OutlineClient:
+        api_key = (settings.outline_wiki_api_key or "").strip()
+        if not api_key:
+            raise ValueError("Outline wiki search is not configured.")
+        return OutlineClient(
+            api_key=api_key,
+            base_url=settings.outline_base_url,
+            timeout_seconds=max(1.0, float(settings.outline_api_timeout_seconds)),
+        )
+
+    def _search(self, query: str) -> list[OutlineSearchResult]:
+        return self._outline_client().search_documents(
+            query=query,
+            limit=WIKI_SEARCH_RESULT_LIMIT,
+        )
+
+    def _quick_links(self) -> list[OutlineDocumentSummary]:
+        return self._outline_client().list_starred_documents(
+            limit=WIKI_QUICK_LINK_LIMIT,
+        )
+
+    @app_commands.command(
+        name="wiki",
+        description="Search member-safe wiki pages or show quick links.",
+    )
+    @app_commands.describe(query="Optional search terms.")
+    @require_role("Member")
+    async def wiki(
+        self,
+        interaction: discord.Interaction,
+        query: str | None = None,
+    ) -> None:
+        """Search the wiki, or show the integration account's starred pages."""
+        await interaction.response.defer(ephemeral=True)
+        normalized_query = " ".join((query or "").split())
+        if len(normalized_query) > WIKI_QUERY_MAX_LENGTH:
+            await interaction.followup.send(
+                f"Search terms must be {WIKI_QUERY_MAX_LENGTH} characters or fewer.",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+            return
+
+        try:
+            if normalized_query:
+                results = await asyncio.to_thread(self._search, normalized_query)
+                await interaction.followup.send(
+                    embed=self._search_embed(normalized_query, results),
+                    allowed_mentions=NO_MENTIONS,
+                    ephemeral=True,
+                )
+                return
+
+            quick_links = await asyncio.to_thread(self._quick_links)
+            await interaction.followup.send(
+                embed=self._quick_links_embed(quick_links),
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+        except ValueError:
+            await interaction.followup.send(
+                "The co-op wiki is not configured yet. Ask an administrator for help.",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+        except OutlineAPIError:
+            logger.warning("Outline wiki lookup failed", exc_info=True)
+            await interaction.followup.send(
+                "The co-op wiki is temporarily unavailable. Please try again later.",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+
+    @staticmethod
+    def _quick_links_embed(
+        quick_links: list[OutlineDocumentSummary],
+    ) -> discord.Embed:
+        """Build the no-query quick-links response."""
+        if not quick_links:
+            description = (
+                "No quick links are configured yet. "
+                "Try `/wiki query:your search terms` instead."
+            )
+        else:
+            description = "\n".join(
+                f"• {_document_link(document)}" for document in quick_links
+            )
+
+        embed = discord.Embed(
+            title="Co-op Wiki",
+            description=description,
+            color=discord.Color.teal(),
+        )
+        embed.set_footer(text="Search with /wiki query:…")
+        return embed
+
+    @staticmethod
+    def _search_embed(
+        query: str,
+        results: list[OutlineSearchResult],
+    ) -> discord.Embed:
+        """Build a compact, private search-results response."""
+        safe_query = _safe_display_text(query, max_length=WIKI_QUERY_MAX_LENGTH)
+        if not results:
+            return discord.Embed(
+                title="No wiki matches",
+                description=(
+                    f"Nothing matched **{safe_query}**. Try fewer words, quoted "
+                    "phrases, `OR`, or `-word`."
+                ),
+                color=discord.Color.orange(),
+            )
+
+        embed = discord.Embed(
+            title=f"Wiki results for {safe_query}",
+            description=f"Showing {len(results)} result(s)",
+            color=discord.Color.teal(),
+        )
+        for index, result in enumerate(results, start=1):
+            document = result.document
+            context = result.context or "No matching excerpt available."
+            parts = [_safe_display_text(context, max_length=WIKI_CONTEXT_MAX_LENGTH)]
+            if updated_date := _updated_date(document.updated_at):
+                parts.append(f"Updated: {updated_date}")
+            parts.append(f"[Open in Outline]({document.url})")
+            embed.add_field(
+                name=f"{index}. {_safe_display_text(document.title, max_length=WIKI_TITLE_MAX_LENGTH)}",
+                value="\n".join(parts),
+                inline=False,
+            )
+        embed.set_footer(text="Search supports quoted phrases, OR, and -exclude.")
+        return embed
+
+
+async def setup(bot: commands.Bot) -> None:
+    """Load the wiki cog."""
+    await bot.add_cog(WikiCog(bot))

--- a/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
@@ -74,7 +74,7 @@ class WikiCog(commands.Cog, name="Wiki"):
         self.bot = bot
 
     def _outline_client(self) -> OutlineClient:
-        api_key = (settings.outline_discord_member_api_key or "").strip()
+        api_key = (settings.outline_contents_api_key or "").strip()
         if not api_key:
             raise OutlineWikiConfigurationError(
                 "Outline wiki search is not configured."

--- a/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
@@ -74,7 +74,7 @@ class WikiCog(commands.Cog, name="Wiki"):
         self.bot = bot
 
     def _outline_client(self) -> OutlineClient:
-        api_key = (settings.outline_wiki_api_key or "").strip()
+        api_key = (settings.outline_discord_member_api_key or "").strip()
         if not api_key:
             raise OutlineWikiConfigurationError(
                 "Outline wiki search is not configured."

--- a/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
+++ b/apps/discord_bot/src/five08/discord_bot/cogs/wiki.py
@@ -32,6 +32,10 @@ WIKI_CONTEXT_MAX_LENGTH = 300
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 
+class OutlineWikiConfigurationError(RuntimeError):
+    """Raised when the dedicated Outline wiki integration is not configured."""
+
+
 def _safe_display_text(value: str, *, max_length: int) -> str:
     """Collapse and escape untrusted wiki text for a Discord embed."""
     normalized = html.unescape(value)
@@ -72,11 +76,21 @@ class WikiCog(commands.Cog, name="Wiki"):
     def _outline_client(self) -> OutlineClient:
         api_key = (settings.outline_wiki_api_key or "").strip()
         if not api_key:
-            raise ValueError("Outline wiki search is not configured.")
+            raise OutlineWikiConfigurationError(
+                "Outline wiki search is not configured."
+            )
         return OutlineClient(
             api_key=api_key,
             base_url=settings.outline_base_url,
             timeout_seconds=max(1.0, float(settings.outline_api_timeout_seconds)),
+        )
+
+    @staticmethod
+    def _is_configured_guild(interaction: discord.Interaction) -> bool:
+        """Only allow the wiki credential to be used in the configured co-op guild."""
+        configured_guild_id = str(settings.discord_server_id or "").strip()
+        return bool(configured_guild_id) and (
+            str(interaction.guild_id or "") == configured_guild_id
         )
 
     def _search(self, query: str) -> list[OutlineSearchResult]:
@@ -102,6 +116,14 @@ class WikiCog(commands.Cog, name="Wiki"):
         query: str | None = None,
     ) -> None:
         """Search the wiki, or show the integration account's starred pages."""
+        if not self._is_configured_guild(interaction):
+            await interaction.response.send_message(
+                "This command is only available in the configured co-op server.",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+            return
+
         await interaction.response.defer(ephemeral=True)
         normalized_query = " ".join((query or "").split())
         if len(normalized_query) > WIKI_QUERY_MAX_LENGTH:
@@ -128,7 +150,7 @@ class WikiCog(commands.Cog, name="Wiki"):
                 allowed_mentions=NO_MENTIONS,
                 ephemeral=True,
             )
-        except ValueError:
+        except OutlineWikiConfigurationError:
             await interaction.followup.send(
                 "The co-op wiki is not configured yet. Ask an administrator for help.",
                 allowed_mentions=NO_MENTIONS,
@@ -136,6 +158,13 @@ class WikiCog(commands.Cog, name="Wiki"):
             )
         except OutlineAPIError:
             logger.warning("Outline wiki lookup failed", exc_info=True)
+            await interaction.followup.send(
+                "The co-op wiki is temporarily unavailable. Please try again later.",
+                allowed_mentions=NO_MENTIONS,
+                ephemeral=True,
+            )
+        except ValueError:
+            logger.warning("Outline wiki lookup rejected invalid client input")
             await interaction.followup.send(
                 "The co-op wiki is temporarily unavailable. Please try again later.",
                 allowed_mentions=NO_MENTIONS,

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -7,7 +7,7 @@ and configuration with type validation and default values.
 
 from urllib.parse import urlparse
 
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, model_validator
 
 from five08.openai_fallback import (
     OpenAICompatibleProvider,
@@ -29,9 +29,21 @@ class Settings(SharedSettings):
 
     discord_admin_roles: str = "Admin,Owner"
     discord_default_job_forum_channels: str = "gigs:part_time,fulltime-roles:full_time"
-    # Dedicated, read-only Outline token for the /wiki Discord command. This must
-    # not reuse OUTLINE_API_KEY, which is used for user invitations.
-    outline_wiki_api_key: str | None = None
+    # Dedicated member-safe Outline token for Discord commands. This must not
+    # reuse OUTLINE_ADMIN_API_KEY, which is used for privileged integrations.
+    outline_discord_member_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OUTLINE_DISCORD_MEMBER_API_KEY",
+            "outline_discord_member_api_key",
+        ),
+    )
+    legacy_outline_discord_member_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OUTLINE_WIKI_API_KEY", "outline_wiki_api_key"),
+        exclude=True,
+        repr=False,
+    )
     # Healthcheck Configuration
     healthcheck_port: int = 3000
 
@@ -75,6 +87,33 @@ class Settings(SharedSettings):
         """Lower-cased configured Discord admin role names."""
         values = [item.strip() for item in self.discord_admin_roles.split(",")]
         return {value.casefold() for value in values if value}
+
+    @model_validator(mode="after")
+    def _resolve_outline_discord_member_api_key_alias(self) -> "Settings":
+        """Prefer a non-empty member key, then its legacy wiki-key alias."""
+        canonical_value = object.__getattribute__(
+            self,
+            "outline_discord_member_api_key",
+        )
+        legacy_value = object.__getattribute__(
+            self,
+            "legacy_outline_discord_member_api_key",
+        )
+        canonical_key = (canonical_value or "").strip()
+        legacy_key = (legacy_value or "").strip()
+        object.__setattr__(
+            self,
+            "outline_discord_member_api_key",
+            canonical_value
+            if canonical_key
+            else (legacy_value if legacy_key else None),
+        )
+        return self
+
+    @property
+    def outline_wiki_api_key(self) -> str | None:
+        """Return the deprecated compatibility alias for the Discord member key."""
+        return self.outline_discord_member_api_key
 
     @property
     def resolved_resume_ai_api_key(self) -> str | None:

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -7,7 +7,7 @@ and configuration with type validation and default values.
 
 from urllib.parse import urlparse
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field
 
 from five08.openai_fallback import (
     OpenAICompatibleProvider,
@@ -29,21 +29,6 @@ class Settings(SharedSettings):
 
     discord_admin_roles: str = "Admin,Owner"
     discord_default_job_forum_channels: str = "gigs:part_time,fulltime-roles:full_time"
-    # Dedicated member-safe Outline token for Discord commands. This must not
-    # reuse OUTLINE_ADMIN_API_KEY, which is used for privileged integrations.
-    outline_discord_member_api_key: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices(
-            "OUTLINE_DISCORD_MEMBER_API_KEY",
-            "outline_discord_member_api_key",
-        ),
-    )
-    legacy_outline_discord_member_api_key: str | None = Field(
-        default=None,
-        validation_alias=AliasChoices("OUTLINE_WIKI_API_KEY", "outline_wiki_api_key"),
-        exclude=True,
-        repr=False,
-    )
     # Healthcheck Configuration
     healthcheck_port: int = 3000
 
@@ -87,33 +72,6 @@ class Settings(SharedSettings):
         """Lower-cased configured Discord admin role names."""
         values = [item.strip() for item in self.discord_admin_roles.split(",")]
         return {value.casefold() for value in values if value}
-
-    @model_validator(mode="after")
-    def _resolve_outline_discord_member_api_key_alias(self) -> "Settings":
-        """Prefer a non-empty member key, then its legacy wiki-key alias."""
-        canonical_value = object.__getattribute__(
-            self,
-            "outline_discord_member_api_key",
-        )
-        legacy_value = object.__getattribute__(
-            self,
-            "legacy_outline_discord_member_api_key",
-        )
-        canonical_key = (canonical_value or "").strip()
-        legacy_key = (legacy_value or "").strip()
-        object.__setattr__(
-            self,
-            "outline_discord_member_api_key",
-            canonical_value
-            if canonical_key
-            else (legacy_value if legacy_key else None),
-        )
-        return self
-
-    @property
-    def outline_wiki_api_key(self) -> str | None:
-        """Return the deprecated compatibility alias for the Discord member key."""
-        return self.outline_discord_member_api_key
 
     @property
     def resolved_resume_ai_api_key(self) -> str | None:

--- a/apps/discord_bot/src/five08/discord_bot/config.py
+++ b/apps/discord_bot/src/five08/discord_bot/config.py
@@ -29,6 +29,9 @@ class Settings(SharedSettings):
 
     discord_admin_roles: str = "Admin,Owner"
     discord_default_job_forum_channels: str = "gigs:part_time,fulltime-roles:full_time"
+    # Dedicated, read-only Outline token for the /wiki Discord command. This must
+    # not reuse OUTLINE_API_KEY, which is used for user invitations.
+    outline_wiki_api_key: str | None = None
     # Healthcheck Configuration
     healthcheck_port: int = 3000
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -85,6 +85,7 @@ services:
     environment:
       REDIS_URL: redis://redis:6379/0
       REDIS_QUEUE_NAME: ${REDIS_QUEUE_NAME:-jobs.default}
+      POSTGRES_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-workflows}
       BACKEND_API_BASE_URL: http://web:8090
       AUDIT_API_BASE_URL: ""
     restart: unless-stopped
@@ -93,6 +94,8 @@ services:
       - infra
     depends_on:
       redis:
+        condition: service_healthy
+      postgres:
         condition: service_healthy
 
   web:

--- a/packages/shared/src/five08/agent/tools.py
+++ b/packages/shared/src/five08/agent/tools.py
@@ -114,7 +114,7 @@ class ToolRuntimeConfig:
     authentik_recovery_email_stage_id: str | None = None
     authentik_recovery_email_stage_name: str = "default-recovery-email"
     outline_base_url: str = "https://app.getoutline.com"
-    outline_api_key: str | None = None
+    outline_admin_api_key: str | None = None
     outline_api_timeout_seconds: float = 20.0
     brevo_api_key: str | None = None
     brevo_api_base_url: str = "https://api.brevo.com/v3"
@@ -171,7 +171,10 @@ class ToolRuntimeConfig:
                 "outline_base_url",
                 "https://app.getoutline.com",
             ),
-            outline_api_key=getattr(settings, "outline_api_key", None),
+            outline_admin_api_key=(
+                getattr(settings, "outline_admin_api_key", None)
+                or getattr(settings, "outline_api_key", None)
+            ),
             outline_api_timeout_seconds=getattr(
                 settings,
                 "outline_api_timeout_seconds",
@@ -901,8 +904,8 @@ class ToolRegistry:
     def _outline_client(self) -> OutlineClient:
         return OutlineClient(
             api_key=_required_config(
-                self.runtime_config.outline_api_key,
-                "OUTLINE_API_KEY",
+                self.runtime_config.outline_admin_api_key,
+                "OUTLINE_ADMIN_API_KEY",
             ),
             base_url=self.runtime_config.outline_base_url
             or "https://app.getoutline.com",

--- a/packages/shared/src/five08/clients/outline.py
+++ b/packages/shared/src/five08/clients/outline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
@@ -9,6 +10,26 @@ import requests
 
 
 OUTLINE_BASE_URL = "https://app.getoutline.com"
+OUTLINE_SEARCH_RESULT_LIMIT = 10
+
+
+@dataclass(frozen=True, slots=True)
+class OutlineDocumentSummary:
+    """The safe document fields needed for Discord wiki rendering."""
+
+    id: str
+    title: str
+    url: str
+    updated_at: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OutlineSearchResult:
+    """One keyword-search result with a short context excerpt."""
+
+    document: OutlineDocumentSummary
+    context: str | None
+    ranking: float | None
 
 
 class OutlineAPIError(RuntimeError):
@@ -34,8 +55,20 @@ def normalize_outline_api_base_url(base_url: str) -> str:
     return urlunsplit((parsed.scheme, parsed.netloc, api_path, "", ""))
 
 
+def normalize_outline_web_base_url(base_url: str) -> str:
+    """Normalize an Outline root or API URL to the browser-facing base URL."""
+    api_url = normalize_outline_api_base_url(base_url)
+    parsed = urlsplit(api_url)
+    api_path = parsed.path.rstrip("/")
+    if not api_path.endswith("/api"):  # pragma: no cover - defensive invariant
+        raise OutlineAPIError("Outline API URL must end in /api.")
+
+    web_path = api_path[: -len("/api")].rstrip("/")
+    return urlunsplit((parsed.scheme, parsed.netloc, web_path, "", ""))
+
+
 class OutlineClient:
-    """Small Outline RPC API wrapper for user invitations."""
+    """Small Outline RPC API wrapper for invitations and read-only wiki access."""
 
     def __init__(
         self,
@@ -46,6 +79,7 @@ class OutlineClient:
     ) -> None:
         self.api_key = api_key
         self.base_url = normalize_outline_api_base_url(base_url)
+        self.web_base_url = normalize_outline_web_base_url(base_url)
         self.timeout_seconds = timeout_seconds
 
     def _headers(self) -> dict[str, str]:
@@ -69,8 +103,7 @@ class OutlineClient:
 
         if not 200 <= response.status_code < 300:
             raise OutlineAPIError(
-                "Outline API request failed: "
-                f"status={response.status_code}, body={response.text}"
+                f"Outline API request failed: status={response.status_code}"
             )
 
         try:
@@ -84,8 +117,7 @@ class OutlineClient:
             raise OutlineAPIError("Outline response payload must be a JSON object.")
 
         if data.get("ok") is False:
-            error = str(data.get("error") or "unknown error")
-            raise OutlineAPIError(f"Outline API returned an error: {error}")
+            raise OutlineAPIError("Outline API returned an error.")
 
         return data
 
@@ -111,3 +143,150 @@ class OutlineClient:
                 "suppressEmail": suppress_email,
             },
         )
+
+    def search_documents(
+        self,
+        *,
+        query: str,
+        limit: int = 5,
+    ) -> list[OutlineSearchResult]:
+        """Search published documents visible to this API key's owner."""
+        normalized_query = " ".join(query.split())
+        if not normalized_query:
+            raise ValueError("Outline search query must not be empty.")
+
+        normalized_limit = min(max(int(limit), 1), OUTLINE_SEARCH_RESULT_LIMIT)
+        response = self.request(
+            "documents.search",
+            {
+                "query": normalized_query,
+                "limit": normalized_limit,
+                "offset": 0,
+                "statusFilter": ["published"],
+                "snippetMinWords": 12,
+                "snippetMaxWords": 30,
+            },
+        )
+        raw_results = response.get("data")
+        if not isinstance(raw_results, list):
+            raise OutlineAPIError("Outline search payload must include a result list.")
+
+        results: list[OutlineSearchResult] = []
+        for raw_result in raw_results:
+            if not isinstance(raw_result, dict):
+                continue
+            raw_document = raw_result.get("document")
+            if not isinstance(raw_document, dict):
+                continue
+            document = self._document_summary(raw_document)
+            if document is None:
+                continue
+
+            raw_context = raw_result.get("context")
+            context = raw_context.strip() if isinstance(raw_context, str) else None
+            raw_ranking = raw_result.get("ranking")
+            ranking = (
+                float(raw_ranking)
+                if isinstance(raw_ranking, (int, float))
+                and not isinstance(raw_ranking, bool)
+                else None
+            )
+            results.append(
+                OutlineSearchResult(
+                    document=document,
+                    context=context or None,
+                    ranking=ranking,
+                )
+            )
+
+        return results[:normalized_limit]
+
+    def list_starred_documents(
+        self,
+        *,
+        limit: int = 6,
+    ) -> list[OutlineDocumentSummary]:
+        """Return the authenticated integration account's starred documents."""
+        normalized_limit = min(max(int(limit), 1), OUTLINE_SEARCH_RESULT_LIMIT)
+        response = self.request(
+            "stars.list",
+            {"limit": normalized_limit, "offset": 0},
+        )
+        raw_data = response.get("data")
+        if not isinstance(raw_data, dict):
+            raise OutlineAPIError("Outline stars payload must include an object.")
+
+        raw_documents = raw_data.get("documents")
+        if not isinstance(raw_documents, list):
+            raise OutlineAPIError("Outline stars payload must include documents.")
+
+        documents_by_id: dict[str, OutlineDocumentSummary] = {}
+        for raw_document in raw_documents:
+            if not isinstance(raw_document, dict):
+                continue
+            document = self._document_summary(raw_document)
+            if document is not None:
+                documents_by_id[document.id] = document
+
+        raw_stars = raw_data.get("stars")
+        if not isinstance(raw_stars, list):
+            return list(documents_by_id.values())[:normalized_limit]
+
+        documents: list[OutlineDocumentSummary] = []
+        seen_ids: set[str] = set()
+        for raw_star in raw_stars:
+            if not isinstance(raw_star, dict):
+                continue
+            document_id = str(raw_star.get("documentId") or "").strip()
+            document = documents_by_id.get(document_id)
+            if document is None or document.id in seen_ids:
+                continue
+            documents.append(document)
+            seen_ids.add(document.id)
+
+        return documents[:normalized_limit]
+
+    def _document_summary(
+        self,
+        raw_document: dict[str, Any],
+    ) -> OutlineDocumentSummary | None:
+        document_id = str(raw_document.get("id") or "").strip()
+        raw_url = raw_document.get("url")
+        if not document_id or not isinstance(raw_url, str):
+            return None
+
+        url = self._document_url(raw_url)
+        if url is None:
+            return None
+
+        title = str(raw_document.get("title") or "").strip() or "Untitled document"
+        raw_updated_at = raw_document.get("updatedAt")
+        updated_at = raw_updated_at.strip() if isinstance(raw_updated_at, str) else None
+        return OutlineDocumentSummary(
+            id=document_id,
+            title=title,
+            url=url,
+            updated_at=updated_at or None,
+        )
+
+    def _document_url(self, raw_url: str) -> str | None:
+        """Build an absolute same-instance URL from Outline's document path."""
+        parsed_url = urlsplit(raw_url.strip())
+        web_base = urlsplit(self.web_base_url)
+        if parsed_url.scheme or parsed_url.netloc:
+            if (
+                parsed_url.scheme != web_base.scheme
+                or parsed_url.netloc != web_base.netloc
+            ):
+                return None
+
+        path = parsed_url.path.strip()
+        if not path:
+            return None
+
+        base_path = web_base.path.rstrip("/")
+        document_path = path.lstrip("/")
+        joined_path = (
+            f"{base_path}/{document_path}" if base_path else f"/{document_path}"
+        )
+        return urlunsplit((web_base.scheme, web_base.netloc, joined_path, "", ""))

--- a/packages/shared/src/five08/clients/outline.py
+++ b/packages/shared/src/five08/clients/outline.py
@@ -273,7 +273,8 @@ class OutlineClient:
         """Build an absolute same-instance URL from Outline's document path."""
         parsed_url = urlsplit(raw_url.strip())
         web_base = urlsplit(self.web_base_url)
-        if parsed_url.scheme or parsed_url.netloc:
+        is_absolute = bool(parsed_url.scheme or parsed_url.netloc)
+        if is_absolute:
             if (
                 parsed_url.scheme != web_base.scheme
                 or parsed_url.netloc != web_base.netloc
@@ -284,9 +285,12 @@ class OutlineClient:
         if not path:
             return None
 
-        base_path = web_base.path.rstrip("/")
-        document_path = path.lstrip("/")
-        joined_path = (
-            f"{base_path}/{document_path}" if base_path else f"/{document_path}"
-        )
+        if is_absolute:
+            joined_path = path
+        else:
+            base_path = web_base.path.rstrip("/")
+            document_path = path.lstrip("/")
+            joined_path = (
+                f"{base_path}/{document_path}" if base_path else f"/{document_path}"
+            )
         return urlunsplit((web_base.scheme, web_base.netloc, joined_path, "", ""))

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -897,10 +897,10 @@ def fetch_outline_document(
     *,
     document_id: str,
 ) -> dict[str, Any]:
-    """Fetch one Outline document via the configured API key."""
-    api_key = (settings.outline_admin_api_key or "").strip()
+    """Fetch one member-safe Outline document via the contents API key."""
+    api_key = (settings.outline_contents_api_key or "").strip()
     if not api_key:
-        raise ValueError("OUTLINE_ADMIN_API_KEY is not configured")
+        raise ValueError("OUTLINE_CONTENTS_API_KEY is not configured")
     base_url = settings.outline_base_url.rstrip("/")
     try:
         response = requests.post(

--- a/packages/shared/src/five08/projects.py
+++ b/packages/shared/src/five08/projects.py
@@ -898,9 +898,9 @@ def fetch_outline_document(
     document_id: str,
 ) -> dict[str, Any]:
     """Fetch one Outline document via the configured API key."""
-    api_key = (settings.outline_api_key or "").strip()
+    api_key = (settings.outline_admin_api_key or "").strip()
     if not api_key:
-        raise ValueError("OUTLINE_API_KEY is not configured")
+        raise ValueError("OUTLINE_ADMIN_API_KEY is not configured")
     base_url = settings.outline_base_url.rstrip("/")
     try:
         response = requests.post(

--- a/packages/shared/src/five08/runtime_config.py
+++ b/packages/shared/src/five08/runtime_config.py
@@ -1118,6 +1118,23 @@ def list_runtime_config(settings: Any) -> list[dict[str, object]]:
     return items
 
 
+def _delete_runtime_config_key_variants(
+    cursor: Any,
+    keys: tuple[str, ...],
+) -> None:
+    """Delete DB entries whose normalized keys match one of ``keys``."""
+    normalized_keys = [key.strip().upper() for key in keys if key.strip()]
+    if not normalized_keys:
+        return
+    cursor.execute(
+        """
+        DELETE FROM runtime_config_values
+        WHERE UPPER(BTRIM(key)) = ANY(%s)
+        """,
+        (normalized_keys,),
+    )
+
+
 def set_runtime_config_value(
     settings: Any,
     definition: RuntimeConfigDefinition,
@@ -1157,11 +1174,7 @@ def set_runtime_config_value(
                     updated_by_subject,
                 ),
             )
-            for legacy_key in definition.legacy_keys:
-                cursor.execute(
-                    "DELETE FROM runtime_config_values WHERE key = %s",
-                    (legacy_key,),
-                )
+            _delete_runtime_config_key_variants(cursor, definition.legacy_keys)
     invalidate_runtime_config_cache(settings)
 
 
@@ -1174,9 +1187,5 @@ def delete_runtime_config_value(
         raise ValueError(f"{definition.key} is configured by environment")
     with psycopg.connect(_cache_key(settings)) as conn:
         with conn.cursor() as cursor:
-            for key in definition.all_keys:
-                cursor.execute(
-                    "DELETE FROM runtime_config_values WHERE key = %s",
-                    (key,),
-                )
+            _delete_runtime_config_key_variants(cursor, definition.all_keys)
     invalidate_runtime_config_cache(settings)

--- a/packages/shared/src/five08/runtime_config.py
+++ b/packages/shared/src/five08/runtime_config.py
@@ -36,6 +36,7 @@ class RuntimeConfigDefinition:
     value_type: RuntimeConfigValueType = "string"
     is_secret: bool = False
     env_names: tuple[str, ...] = ()
+    legacy_keys: tuple[str, ...] = ()
     restart_required: bool = False
     min_value: float | None = None
     max_value: float | None = None
@@ -43,6 +44,11 @@ class RuntimeConfigDefinition:
     @property
     def primary_env_name(self) -> str:
         return self.env_names[0] if self.env_names else self.key
+
+    @property
+    def all_keys(self) -> tuple[str, ...]:
+        """Return the canonical dashboard key followed by compatible legacy keys."""
+        return (self.key, *self.legacy_keys)
 
 
 @dataclass(frozen=True)
@@ -82,13 +88,14 @@ _DEFINITIONS: tuple[RuntimeConfigDefinition, ...] = (
         env_names=("OUTLINE_BASE_URL",),
     ),
     RuntimeConfigDefinition(
-        key="OUTLINE_API_KEY",
-        attr="outline_api_key",
-        label="Outline API key",
+        key="OUTLINE_ADMIN_API_KEY",
+        attr="outline_admin_api_key",
+        label="Outline admin API key",
         category="Onboarding",
-        description="API key used to add users and read project wiki pages.",
+        description="Privileged Outline key used for invitations and project wiki pages.",
         is_secret=True,
-        env_names=("OUTLINE_API_KEY",),
+        env_names=("OUTLINE_ADMIN_API_KEY", "OUTLINE_API_KEY"),
+        legacy_keys=("OUTLINE_API_KEY",),
     ),
     RuntimeConfigDefinition(
         key="MIGADU_API_USER",
@@ -704,7 +711,9 @@ _DEFINITIONS: tuple[RuntimeConfigDefinition, ...] = (
     ),
 )
 
-_DEFINITIONS_BY_KEY = {definition.key: definition for definition in _DEFINITIONS}
+_DEFINITIONS_BY_KEY = {
+    key: definition for definition in _DEFINITIONS for key in definition.all_keys
+}
 _DEFINITIONS_BY_ATTR = {definition.attr: definition for definition in _DEFINITIONS}
 _CACHE_TTL_SECONDS = 5.0
 _CACHE: dict[str, tuple[float, RuntimeConfigDBSnapshot]] = {}
@@ -885,23 +894,30 @@ def _load_db_snapshot(settings: Any) -> RuntimeConfigDBSnapshot:
 
     values: dict[str, str] = {}
     present_keys: set[str] = set()
+    candidates: dict[str, tuple[RuntimeConfigDefinition, str]] = {}
     try:
         with psycopg.connect(key) as conn:
             with conn.cursor(row_factory=dict_row) as cursor:
                 cursor.execute("SELECT key, value FROM runtime_config_values")
                 for row in cursor.fetchall():
-                    row_key = str(row["key"])
+                    row_key = str(row["key"]).strip().upper()
                     definition = _DEFINITIONS_BY_KEY.get(row_key)
                     if definition is None:
                         continue
-                    present_keys.add(row_key)
-                    row_value = str(row["value"])
-                    if definition.is_secret:
-                        decrypted_value = _decrypt_secret_value(row_value)
-                        if decrypted_value is None:
-                            continue
-                        row_value = decrypted_value
-                    values[row_key] = row_value
+
+                    canonical_key = definition.key
+                    if row_key != canonical_key and canonical_key in candidates:
+                        continue
+                    candidates[canonical_key] = (definition, str(row["value"]))
+
+        for canonical_key, (definition, row_value) in candidates.items():
+            present_keys.add(canonical_key)
+            if definition.is_secret:
+                decrypted_value = _decrypt_secret_value(row_value)
+                if decrypted_value is None:
+                    continue
+                row_value = decrypted_value
+            values[canonical_key] = row_value
     except Exception:
         logger.debug("Runtime configuration DB overlay is unavailable", exc_info=True)
         with _CACHE_LOCK:
@@ -1129,6 +1145,11 @@ def set_runtime_config_value(
                     updated_by_subject,
                 ),
             )
+            for legacy_key in definition.legacy_keys:
+                cursor.execute(
+                    "DELETE FROM runtime_config_values WHERE key = %s",
+                    (legacy_key,),
+                )
     invalidate_runtime_config_cache(settings)
 
 
@@ -1141,8 +1162,9 @@ def delete_runtime_config_value(
         raise ValueError(f"{definition.key} is configured by environment")
     with psycopg.connect(_cache_key(settings)) as conn:
         with conn.cursor() as cursor:
-            cursor.execute(
-                "DELETE FROM runtime_config_values WHERE key = %s",
-                (definition.key,),
-            )
+            for key in definition.all_keys:
+                cursor.execute(
+                    "DELETE FROM runtime_config_values WHERE key = %s",
+                    (key,),
+                )
     invalidate_runtime_config_cache(settings)

--- a/packages/shared/src/five08/runtime_config.py
+++ b/packages/shared/src/five08/runtime_config.py
@@ -92,10 +92,22 @@ _DEFINITIONS: tuple[RuntimeConfigDefinition, ...] = (
         attr="outline_admin_api_key",
         label="Outline admin API key",
         category="Onboarding",
-        description="Privileged Outline key used for invitations and project wiki pages.",
+        description="Privileged Outline key used only for member invitations.",
         is_secret=True,
         env_names=("OUTLINE_ADMIN_API_KEY", "OUTLINE_API_KEY"),
         legacy_keys=("OUTLINE_API_KEY",),
+    ),
+    RuntimeConfigDefinition(
+        key="OUTLINE_CONTENTS_API_KEY",
+        attr="outline_contents_api_key",
+        label="Outline contents API key",
+        category="Onboarding",
+        description=(
+            "Member-safe Outline content key for Discord wiki search and "
+            "project wiki matching."
+        ),
+        is_secret=True,
+        env_names=("OUTLINE_CONTENTS_API_KEY",),
     ),
     RuntimeConfigDefinition(
         key="MIGADU_API_USER",

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -3,7 +3,7 @@
 import os
 import sys
 
-from pydantic import AliasChoices, Field, field_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -93,7 +93,19 @@ class SharedSettings(BaseSettings):
     authentik_recovery_email_stage_id: str | None = None
     authentik_recovery_email_stage_name: str = "default-recovery-email"
     outline_base_url: str = "https://app.getoutline.com"
-    outline_api_key: str | None = None
+    outline_admin_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices(
+            "OUTLINE_ADMIN_API_KEY",
+            "outline_admin_api_key",
+        ),
+    )
+    legacy_outline_admin_api_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("OUTLINE_API_KEY", "outline_api_key"),
+        exclude=True,
+        repr=False,
+    )
     outline_api_timeout_seconds: float = 20.0
     brevo_api_key: str | None = None
     brevo_api_base_url: str = "https://api.brevo.com/v3"
@@ -239,6 +251,25 @@ class SharedSettings(BaseSettings):
                 ) from exc
         raise TypeError("BREVO_508_MEMBERS_NEWSLETTER_LIST_ID must be an integer")
 
+    @model_validator(mode="after")
+    def _resolve_outline_admin_api_key_alias(self) -> "SharedSettings":
+        """Prefer a non-empty canonical Outline key, then its legacy alias."""
+        canonical_value = object.__getattribute__(self, "outline_admin_api_key")
+        legacy_value = object.__getattribute__(
+            self,
+            "legacy_outline_admin_api_key",
+        )
+        canonical_key = (canonical_value or "").strip()
+        legacy_key = (legacy_value or "").strip()
+        object.__setattr__(
+            self,
+            "outline_admin_api_key",
+            canonical_value
+            if canonical_key
+            else (legacy_value if legacy_key else None),
+        )
+        return self
+
     @classmethod
     def _skip_dotenv(cls) -> bool:
         if os.getenv("ENVIRONMENT", "").strip().lower() == "test":
@@ -262,6 +293,11 @@ class SharedSettings(BaseSettings):
     def sentry_environment_name(self) -> str:
         """Sentry environment always follows the app runtime environment."""
         return self.environment
+
+    @property
+    def outline_api_key(self) -> str | None:
+        """Return the deprecated compatibility alias for the admin Outline key."""
+        return self.outline_admin_api_key
 
     @property
     def sentry_release(self) -> str | None:

--- a/packages/shared/src/five08/settings.py
+++ b/packages/shared/src/five08/settings.py
@@ -106,6 +106,9 @@ class SharedSettings(BaseSettings):
         exclude=True,
         repr=False,
     )
+    # Shared member-safe content credential used by Discord wiki search and
+    # project wiki matching. Keep it separate from the invitation-only key.
+    outline_contents_api_key: str | None = None
     outline_api_timeout_seconds: float = 20.0
     brevo_api_key: str | None = None
     brevo_api_base_url: str = "https://api.brevo.com/v3"

--- a/tests/unit/test_agent_gateway.py
+++ b/tests/unit/test_agent_gateway.py
@@ -2017,7 +2017,7 @@ def test_user_accounts_create_is_admin_only() -> None:
 
 def _account_runtime_config(
     *,
-    outline_api_key: str | None = "outline-key",
+    outline_admin_api_key: str | None = "outline-key",
     brevo_api_key: str | None = None,
     keila_api_key: str | None = None,
 ) -> ToolRuntimeConfig:
@@ -2029,7 +2029,7 @@ def _account_runtime_config(
         authentik_api_base_url="https://sso.example",
         authentik_api_token="authentik-token",
         authentik_recovery_email_stage_id="stage-1",
-        outline_api_key=outline_api_key,
+        outline_admin_api_key=outline_admin_api_key,
         brevo_api_key=brevo_api_key,
         brevo_508_members_newsletter_list_id=4,
         keila_api_key=keila_api_key,
@@ -2841,10 +2841,10 @@ def test_user_accounts_tool_preflights_before_mailbox_creation(
 ) -> None:
     fakes = _install_account_tool_fakes(monkeypatch)
     registry = ToolRegistry(
-        runtime_config=_account_runtime_config(outline_api_key=None)
+        runtime_config=_account_runtime_config(outline_admin_api_key=None)
     )
 
-    with pytest.raises(RuntimeError, match="OUTLINE_API_KEY"):
+    with pytest.raises(RuntimeError, match="OUTLINE_ADMIN_API_KEY"):
         registry.execute(
             "account_write.create_user_accounts",
             {"contact_id": "contact-1", "mailbox_username": "jane@508.dev"},

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -207,28 +207,20 @@ class TestBot508:
 
         assert config.outline_admin_api_key == "preferred-admin-key"
 
-    def test_outline_discord_member_api_key_prefers_new_name_and_supports_legacy_alias(
+    def test_outline_contents_api_key_is_shared_with_the_bot(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "legacy-member-key")
+        monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", "unused-key")
+        monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "unused-key")
 
-        legacy_config = Settings()
+        assert Settings().outline_contents_api_key is None
 
-        assert legacy_config.outline_discord_member_api_key == "legacy-member-key"
-        assert legacy_config.outline_wiki_api_key == "legacy-member-key"
-
-        monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", " ")
-
-        blank_new_config = Settings()
-
-        assert blank_new_config.outline_discord_member_api_key == "legacy-member-key"
-
-        monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", "preferred-member-key")
+        monkeypatch.setenv("OUTLINE_CONTENTS_API_KEY", "contents-key")
 
         config = Settings()
 
-        assert config.outline_discord_member_api_key == "preferred-member-key"
+        assert config.outline_contents_api_key == "contents-key"
 
     def test_onboarding_email_smtp_settings_fall_back_to_generic_smtp_env(
         self,

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -188,6 +188,7 @@ class TestBot508:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ):
+        monkeypatch.delenv("OUTLINE_ADMIN_API_KEY", raising=False)
         monkeypatch.setenv("OUTLINE_API_KEY", "legacy-admin-key")
 
         legacy_config = Settings()
@@ -211,6 +212,7 @@ class TestBot508:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ):
+        monkeypatch.delenv("OUTLINE_CONTENTS_API_KEY", raising=False)
         monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", "unused-key")
         monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "unused-key")
 

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -184,6 +184,16 @@ class TestBot508:
 
         assert config.backend_api_base_url == "http://127.0.0.1:8090"
 
+    def test_outline_wiki_api_key_uses_its_own_bot_setting(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "wiki-read-only-key")
+
+        config = Settings()
+
+        assert config.outline_wiki_api_key == "wiki-read-only-key"
+
     def test_onboarding_email_smtp_settings_fall_back_to_generic_smtp_env(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_bot.py
+++ b/tests/unit/test_bot.py
@@ -184,15 +184,51 @@ class TestBot508:
 
         assert config.backend_api_base_url == "http://127.0.0.1:8090"
 
-    def test_outline_wiki_api_key_uses_its_own_bot_setting(
+    def test_outline_admin_api_key_prefers_new_name_and_supports_legacy_alias(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "wiki-read-only-key")
+        monkeypatch.setenv("OUTLINE_API_KEY", "legacy-admin-key")
+
+        legacy_config = Settings()
+
+        assert legacy_config.outline_admin_api_key == "legacy-admin-key"
+        assert legacy_config.outline_api_key == "legacy-admin-key"
+
+        monkeypatch.setenv("OUTLINE_ADMIN_API_KEY", " ")
+
+        blank_new_config = Settings()
+
+        assert blank_new_config.outline_admin_api_key == "legacy-admin-key"
+
+        monkeypatch.setenv("OUTLINE_ADMIN_API_KEY", "preferred-admin-key")
 
         config = Settings()
 
-        assert config.outline_wiki_api_key == "wiki-read-only-key"
+        assert config.outline_admin_api_key == "preferred-admin-key"
+
+    def test_outline_discord_member_api_key_prefers_new_name_and_supports_legacy_alias(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setenv("OUTLINE_WIKI_API_KEY", "legacy-member-key")
+
+        legacy_config = Settings()
+
+        assert legacy_config.outline_discord_member_api_key == "legacy-member-key"
+        assert legacy_config.outline_wiki_api_key == "legacy-member-key"
+
+        monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", " ")
+
+        blank_new_config = Settings()
+
+        assert blank_new_config.outline_discord_member_api_key == "legacy-member-key"
+
+        monkeypatch.setenv("OUTLINE_DISCORD_MEMBER_API_KEY", "preferred-member-key")
+
+        config = Settings()
+
+        assert config.outline_discord_member_api_key == "preferred-member-key"
 
     def test_onboarding_email_smtp_settings_fall_back_to_generic_smtp_env(
         self,

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -842,7 +842,7 @@ async def test_create_user_accounts_validates_outline_before_mailbox_creation(
         patch.object(
             cog,
             "_outline_client",
-            side_effect=ValueError("OUTLINE_API_KEY is not configured."),
+            side_effect=ValueError("OUTLINE_ADMIN_API_KEY is not configured."),
         ),
         patch.object(cog, "_migadu_client") as migadu_client,
         patch.object(cog, "_audit_command_safe"),
@@ -856,7 +856,7 @@ async def test_create_user_accounts_validates_outline_before_mailbox_creation(
 
     migadu_client.assert_not_called()
     message = mock_interaction.followup.send.call_args.args[0]
-    assert "OUTLINE_API_KEY is not configured" in message
+    assert "OUTLINE_ADMIN_API_KEY is not configured" in message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_crm_create_sso_user.py
+++ b/tests/unit/test_crm_create_sso_user.py
@@ -1218,6 +1218,7 @@ async def test_invite_outline_user_reports_outline_api_error(
     assert "outline unavailable" in message
     audit_metadata = mock_audit.call_args.kwargs["metadata"]
     assert audit_metadata["search_term"] == "jane"
+    assert audit_metadata["stage"] == "outline"
     assert audit_metadata["error"] == "outline unavailable"
 
 

--- a/tests/unit/test_outline_client.py
+++ b/tests/unit/test_outline_client.py
@@ -9,6 +9,7 @@ from five08.clients.outline import (
     OutlineAPIError,
     OutlineClient,
     normalize_outline_api_base_url,
+    normalize_outline_web_base_url,
 )
 
 
@@ -23,6 +24,13 @@ def test_normalize_outline_api_base_url_accepts_api_url() -> None:
     assert (
         normalize_outline_api_base_url("https://outline.example.com/api/")
         == "https://outline.example.com/api"
+    )
+
+
+def test_normalize_outline_web_base_url_accepts_api_url() -> None:
+    assert (
+        normalize_outline_web_base_url("https://outline.example.com/wiki/api/")
+        == "https://outline.example.com/wiki"
     )
 
 
@@ -66,8 +74,10 @@ def test_invite_user_raises_on_http_error() -> None:
     response.text = "Forbidden"
 
     with patch("five08.clients.outline.requests.post", return_value=response):
-        with pytest.raises(OutlineAPIError, match="status=403"):
+        with pytest.raises(OutlineAPIError, match="status=403") as error:
             OutlineClient(api_key="outline-key").invite_user(email="jane@508.dev")
+
+    assert "Forbidden" not in str(error.value)
 
 
 def test_invite_user_raises_on_request_error() -> None:
@@ -77,3 +87,129 @@ def test_invite_user_raises_on_request_error() -> None:
     ):
         with pytest.raises(OutlineAPIError, match="request failed"):
             OutlineClient(api_key="outline-key").invite_user(email="jane@508.dev")
+
+
+def test_search_documents_posts_published_search_payload() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "ok": True,
+        "data": [
+            {
+                "context": "<b>Invoice</b> submissions are due on Friday.",
+                "ranking": 1.5,
+                "document": {
+                    "id": "doc-1",
+                    "title": "Invoice process",
+                    "url": "/doc/invoice-process-abc123",
+                    "updatedAt": "2026-07-20T12:00:00.000Z",
+                },
+            }
+        ],
+    }
+
+    with patch("five08.clients.outline.requests.post", return_value=response) as post:
+        results = OutlineClient(
+            api_key="wiki-key",
+            base_url="https://outline.example.com/",
+        ).search_documents(query="  invoice   due  ", limit=5)
+
+    post.assert_called_once_with(
+        "https://outline.example.com/api/documents.search",
+        headers={
+            "Accept": "application/json",
+            "Authorization": "Bearer wiki-key",
+            "Content-Type": "application/json",
+        },
+        json={
+            "query": "invoice due",
+            "limit": 5,
+            "offset": 0,
+            "statusFilter": ["published"],
+            "snippetMinWords": 12,
+            "snippetMaxWords": 30,
+        },
+        timeout=20.0,
+    )
+    assert len(results) == 1
+    assert results[0].context == "<b>Invoice</b> submissions are due on Friday."
+    assert results[0].ranking == 1.5
+    assert results[0].document.title == "Invoice process"
+    assert (
+        results[0].document.url
+        == "https://outline.example.com/doc/invoice-process-abc123"
+    )
+
+
+def test_search_documents_ignores_malformed_or_external_document_urls() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "ok": True,
+        "data": [
+            {"document": {"id": "missing-url", "title": "Missing URL"}},
+            {
+                "document": {
+                    "id": "external-url",
+                    "title": "External URL",
+                    "url": "https://attacker.example/doc/secret",
+                }
+            },
+        ],
+    }
+
+    with patch("five08.clients.outline.requests.post", return_value=response):
+        results = OutlineClient(api_key="wiki-key").search_documents(query="secret")
+
+    assert results == []
+
+
+def test_list_starred_documents_keeps_outline_star_order() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "ok": True,
+        "data": {
+            "stars": [{"documentId": "doc-2"}, {"documentId": "doc-1"}],
+            "documents": [
+                {
+                    "id": "doc-1",
+                    "title": "Member handbook",
+                    "url": "/doc/member-handbook-abc123",
+                },
+                {
+                    "id": "doc-2",
+                    "title": "Invoice process",
+                    "url": "/doc/invoice-process-def456",
+                },
+            ],
+        },
+    }
+
+    with patch("five08.clients.outline.requests.post", return_value=response) as post:
+        documents = OutlineClient(
+            api_key="wiki-key",
+            base_url="https://outline.example.com/wiki/api",
+        ).list_starred_documents(limit=6)
+
+    post.assert_called_once_with(
+        "https://outline.example.com/wiki/api/stars.list",
+        headers={
+            "Accept": "application/json",
+            "Authorization": "Bearer wiki-key",
+            "Content-Type": "application/json",
+        },
+        json={"limit": 6, "offset": 0},
+        timeout=20.0,
+    )
+    assert [document.id for document in documents] == ["doc-2", "doc-1"]
+    assert (
+        documents[0].url
+        == "https://outline.example.com/wiki/doc/invoice-process-def456"
+    )
+
+
+def test_search_documents_rejects_empty_query_without_calling_outline() -> None:
+    client = OutlineClient(api_key="wiki-key")
+    with pytest.raises(ValueError, match="must not be empty"):
+        client.search_documents(query="   ")

--- a/tests/unit/test_outline_client.py
+++ b/tests/unit/test_outline_client.py
@@ -164,6 +164,36 @@ def test_search_documents_ignores_malformed_or_external_document_urls() -> None:
     assert results == []
 
 
+def test_search_documents_preserves_same_instance_absolute_urls() -> None:
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {
+        "ok": True,
+        "data": [
+            {
+                "document": {
+                    "id": "doc-1",
+                    "title": "Member handbook",
+                    "url": (
+                        "https://outline.example.com/wiki/doc/member-handbook-abc123"
+                        "?source=search"
+                    ),
+                }
+            }
+        ],
+    }
+
+    with patch("five08.clients.outline.requests.post", return_value=response):
+        results = OutlineClient(
+            api_key="wiki-key",
+            base_url="https://outline.example.com/wiki/api",
+        ).search_documents(query="handbook")
+
+    assert results[0].document.url == (
+        "https://outline.example.com/wiki/doc/member-handbook-abc123"
+    )
+
+
 def test_list_starred_documents_keeps_outline_star_order() -> None:
     response = Mock()
     response.status_code = 200

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import five08.projects as projects_module
 import pytest
@@ -132,13 +132,32 @@ def test_mark_missing_erpnext_open_projects_skips_empty_seen_ids() -> None:
 
 
 def test_fetch_outline_document_wraps_transport_errors() -> None:
-    settings = SharedSettings(outline_admin_api_key="outline-key")
+    settings = SharedSettings(outline_contents_api_key="outline-key")
     with patch(
         "five08.projects.requests.post",
         side_effect=requests.Timeout("timed out"),
     ):
         with pytest.raises(ValueError, match="Outline document fetch failed"):
             fetch_outline_document(settings, document_id="doc-1")
+
+
+def test_fetch_outline_document_uses_the_contents_api_key() -> None:
+    settings = SharedSettings(outline_contents_api_key="contents-key")
+    response = Mock(status_code=200)
+    response.json.return_value = {"ok": True, "data": {"id": "doc-1"}}
+
+    with patch("five08.projects.requests.post", return_value=response) as request:
+        document = fetch_outline_document(settings, document_id="doc-1")
+
+    assert document == {"id": "doc-1"}
+    assert request.call_args.kwargs["headers"]["Authorization"] == "Bearer contents-key"
+
+
+def test_fetch_outline_document_does_not_use_the_admin_api_key() -> None:
+    settings = SharedSettings(outline_admin_api_key="invite-only-key")
+
+    with pytest.raises(ValueError, match="OUTLINE_CONTENTS_API_KEY"):
+        fetch_outline_document(settings, document_id="doc-1")
 
 
 def test_list_dashboard_projects_visibility_requires_erp_roster_row() -> None:

--- a/tests/unit/test_projects.py
+++ b/tests/unit/test_projects.py
@@ -132,7 +132,7 @@ def test_mark_missing_erpnext_open_projects_skips_empty_seen_ids() -> None:
 
 
 def test_fetch_outline_document_wraps_transport_errors() -> None:
-    settings = SharedSettings(outline_api_key="outline-key")
+    settings = SharedSettings(outline_admin_api_key="outline-key")
     with patch(
         "five08.projects.requests.post",
         side_effect=requests.Timeout("timed out"),

--- a/tests/unit/test_runtime_config.py
+++ b/tests/unit/test_runtime_config.py
@@ -255,6 +255,22 @@ def test_outline_admin_runtime_config_supports_legacy_dashboard_values(
     assert item["source"] == "database"
 
 
+def test_outline_contents_runtime_config_has_no_legacy_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = runtime_config_definition_for_key("OUTLINE_CONTENTS_API_KEY")
+
+    assert definition is not None
+    assert definition.primary_env_name == "OUTLINE_CONTENTS_API_KEY"
+    assert definition.legacy_keys == ()
+    assert runtime_config_definition_for_key("OUTLINE_DISCORD_MEMBER_API_KEY") is None
+    assert runtime_config_definition_for_key("OUTLINE_WIKI_API_KEY") is None
+
+    monkeypatch.setenv("OUTLINE_CONTENTS_API_KEY", "contents-key")
+
+    assert definition_is_env_locked(definition)
+
+
 def test_saving_outline_admin_runtime_config_removes_legacy_key(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_runtime_config.py
+++ b/tests/unit/test_runtime_config.py
@@ -11,6 +11,7 @@ from five08.runtime_config import (
     _load_db_values,
     coerce_runtime_config_value,
     definition_is_env_locked,
+    delete_runtime_config_value,
     invalidate_runtime_config_cache,
     list_runtime_config,
     mask_runtime_secret,
@@ -318,7 +319,17 @@ def test_saving_outline_admin_runtime_config_removes_legacy_key(
         for query, params in calls
     )
     assert any(
-        "DELETE FROM runtime_config_values" in query and params == ("OUTLINE_API_KEY",)
+        "UPPER(BTRIM(key)) = ANY(%s)" in query and params == (["OUTLINE_API_KEY"],)
+        for query, params in calls
+    )
+
+    calls.clear()
+
+    delete_runtime_config_value(settings, definition)
+
+    assert any(
+        "UPPER(BTRIM(key)) = ANY(%s)" in query
+        and params == (["OUTLINE_ADMIN_API_KEY", "OUTLINE_API_KEY"],)
         for query, params in calls
     )
 

--- a/tests/unit/test_runtime_config.py
+++ b/tests/unit/test_runtime_config.py
@@ -176,6 +176,137 @@ def test_env_value_locks_matching_runtime_config(
     assert definition_is_env_locked(definition)
 
 
+def test_outline_admin_runtime_config_supports_legacy_dashboard_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from five08 import runtime_config
+
+    definition = runtime_config_definition_for_key("OUTLINE_ADMIN_API_KEY")
+    assert definition is not None
+    assert runtime_config_definition_for_key("OUTLINE_API_KEY") is definition
+    assert definition.primary_env_name == "OUTLINE_ADMIN_API_KEY"
+
+    monkeypatch.setenv("CONFIG_SECRET_KEY", "unit-test-runtime-secret")
+    monkeypatch.setenv("RUNTIME_CONFIG_TEST_ENABLE", "true")
+    monkeypatch.delenv("OUTLINE_ADMIN_API_KEY", raising=False)
+    monkeypatch.delenv("OUTLINE_API_KEY", raising=False)
+    monkeypatch.setattr("five08.runtime_config._parse_dotenv_keys", lambda: {})
+
+    rows = [
+        {
+            "key": "OUTLINE_API_KEY",
+            "value": _encrypt_secret_value("legacy-admin-key"),
+        }
+    ]
+
+    class FakeCursor:
+        def __enter__(self) -> "FakeCursor":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def execute(self, query: str) -> None:
+            assert "runtime_config_values" in query
+
+        def fetchall(self) -> list[dict[str, str]]:
+            return rows
+
+    class FakeConnection:
+        def __enter__(self) -> "FakeConnection":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def cursor(self, **_: object) -> FakeCursor:
+            return FakeCursor()
+
+    monkeypatch.setattr(
+        "five08.runtime_config.psycopg.connect",
+        lambda _: FakeConnection(),
+    )
+    settings = WorkerSettings(espo_base_url="", espo_api_key="")
+    invalidate_runtime_config_cache(settings)
+
+    snapshot = runtime_config._load_db_snapshot(settings)
+
+    assert snapshot.values[definition.key] == "legacy-admin-key"
+    assert definition.key in snapshot.present_keys
+
+    rows.insert(
+        0,
+        {
+            "key": "OUTLINE_ADMIN_API_KEY",
+            "value": _encrypt_secret_value("preferred-admin-key"),
+        },
+    )
+    invalidate_runtime_config_cache(settings)
+
+    snapshot = runtime_config._load_db_snapshot(settings)
+
+    assert snapshot.values[definition.key] == "preferred-admin-key"
+    assert definition.key in snapshot.present_keys
+    item = next(
+        entry
+        for entry in list_runtime_config(settings)
+        if entry["key"] == "OUTLINE_ADMIN_API_KEY"
+    )
+    assert item["source"] == "database"
+
+
+def test_saving_outline_admin_runtime_config_removes_legacy_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    definition = runtime_config_definition_for_key("OUTLINE_ADMIN_API_KEY")
+    assert definition is not None
+    monkeypatch.setenv("CONFIG_SECRET_KEY", "unit-test-runtime-secret")
+    monkeypatch.delenv("OUTLINE_ADMIN_API_KEY", raising=False)
+    monkeypatch.delenv("OUTLINE_API_KEY", raising=False)
+    monkeypatch.setattr("five08.runtime_config._parse_dotenv_keys", lambda: {})
+
+    calls: list[tuple[str, object | None]] = []
+
+    class FakeCursor:
+        def __enter__(self) -> "FakeCursor":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def execute(self, query: str, params: object | None = None) -> None:
+            calls.append((query, params))
+
+    class FakeConnection:
+        def __enter__(self) -> "FakeConnection":
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            return None
+
+        def cursor(self, **_: object) -> FakeCursor:
+            return FakeCursor()
+
+    monkeypatch.setattr(
+        "five08.runtime_config.psycopg.connect",
+        lambda _: FakeConnection(),
+    )
+    settings = WorkerSettings(espo_base_url="", espo_api_key="")
+
+    set_runtime_config_value(settings, definition, "preferred-admin-key")
+
+    assert any(
+        "INSERT INTO runtime_config_values" in query
+        and params is not None
+        and params[0] == "OUTLINE_ADMIN_API_KEY"
+        for query, params in calls
+    )
+    assert any(
+        "DELETE FROM runtime_config_values" in query and params == ("OUTLINE_API_KEY",)
+        for query, params in calls
+    )
+
+
 def test_runtime_config_list_does_not_mask_env_secrets(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_wiki_cog.py
+++ b/tests/unit/test_wiki_cog.py
@@ -9,16 +9,26 @@ from five08.clients.outline import (
     OutlineDocumentSummary,
     OutlineSearchResult,
 )
-from five08.discord_bot.cogs.wiki import NO_MENTIONS, WikiCog
+from five08.discord_bot.cogs import wiki as wiki_module
+from five08.discord_bot.cogs.wiki import (
+    NO_MENTIONS,
+    OutlineWikiConfigurationError,
+    WikiCog,
+)
 
 
-def _make_interaction(role_names: list[str]) -> AsyncMock:
+def _make_interaction(
+    role_names: list[str],
+    *,
+    guild_id: int | None = 123,
+) -> AsyncMock:
     interaction = AsyncMock()
     interaction.response = AsyncMock()
     interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
     interaction.followup = AsyncMock()
     interaction.followup.send = AsyncMock()
+    interaction.guild_id = guild_id
     interaction.user = Mock()
     interaction.user.roles = [Mock(name=role_name) for role_name in role_names]
     for role, role_name in zip(interaction.user.roles, role_names, strict=True):
@@ -44,6 +54,11 @@ def _document(
 @pytest.fixture
 def cog() -> WikiCog:
     return WikiCog(Mock())
+
+
+@pytest.fixture(autouse=True)
+def configure_wiki_guild(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(wiki_module.settings, "discord_server_id", "123")
 
 
 @pytest.mark.asyncio
@@ -132,18 +147,69 @@ async def test_wiki_handles_outline_failure_without_exposing_error(
 
 
 @pytest.mark.asyncio
+async def test_wiki_rejects_other_guild_before_contacting_outline(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"], guild_id=456)
+    cog._search = Mock()
+
+    await cog.wiki.callback(cog, interaction, "invoice")
+
+    cog._search.assert_not_called()
+    interaction.response.defer.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once_with(
+        "This command is only available in the configured co-op server.",
+        allowed_mentions=NO_MENTIONS,
+        ephemeral=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_wiki_requires_a_configured_guild(
+    cog: WikiCog,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(wiki_module.settings, "discord_server_id", None)
+    interaction = _make_interaction(["Member"])
+    cog._quick_links = Mock()
+
+    await cog.wiki.callback(cog, interaction)
+
+    cog._quick_links.assert_not_called()
+    interaction.response.defer.assert_not_awaited()
+    assert (
+        "configured co-op server"
+        in interaction.response.send_message.await_args.args[0]
+    )
+
+
+@pytest.mark.asyncio
 async def test_wiki_reports_missing_configuration(cog: WikiCog) -> None:
     interaction = _make_interaction(["Member"])
     with patch.object(
         cog,
         "_quick_links",
-        side_effect=ValueError("Outline wiki search is not configured."),
+        side_effect=OutlineWikiConfigurationError(
+            "Outline wiki search is not configured."
+        ),
     ):
         await cog.wiki.callback(cog, interaction)
 
     message = interaction.followup.send.await_args.args[0]
     assert "not configured" in message
     assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_does_not_report_unexpected_value_error_as_configuration(
+    cog: WikiCog,
+) -> None:
+    interaction = _make_interaction(["Member"])
+    cog._search = Mock(side_effect=ValueError("unexpected client input"))
+
+    await cog.wiki.callback(cog, interaction, "invoice")
+
+    message = interaction.followup.send.await_args.args[0]
+    assert "temporarily unavailable" in message
+    assert "not configured" not in message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_wiki_cog.py
+++ b/tests/unit/test_wiki_cog.py
@@ -1,0 +1,158 @@
+"""Unit tests for the Discord Outline wiki cog."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from five08.clients.outline import (
+    OutlineAPIError,
+    OutlineDocumentSummary,
+    OutlineSearchResult,
+)
+from five08.discord_bot.cogs.wiki import NO_MENTIONS, WikiCog
+
+
+def _make_interaction(role_names: list[str]) -> AsyncMock:
+    interaction = AsyncMock()
+    interaction.response = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = AsyncMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = Mock()
+    interaction.user.roles = [Mock(name=role_name) for role_name in role_names]
+    for role, role_name in zip(interaction.user.roles, role_names, strict=True):
+        role.name = role_name
+    return interaction
+
+
+def _document(
+    *,
+    document_id: str = "document-1",
+    title: str = "Member handbook",
+    url: str = "https://outline.example.test/doc/member-handbook-abc123",
+    updated_at: str | None = "2026-07-20T12:00:00.000Z",
+) -> OutlineDocumentSummary:
+    return OutlineDocumentSummary(
+        id=document_id,
+        title=title,
+        url=url,
+        updated_at=updated_at,
+    )
+
+
+@pytest.fixture
+def cog() -> WikiCog:
+    return WikiCog(Mock())
+
+
+@pytest.mark.asyncio
+async def test_wiki_query_returns_private_search_embed(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"])
+    result = OutlineSearchResult(
+        document=_document(),
+        context="<b>@everyone</b> submits **invoices** by Friday.",
+        ranking=1.0,
+    )
+    cog._search = Mock(return_value=[result])
+
+    await cog.wiki.callback(cog, interaction, "invoice process")
+
+    interaction.response.defer.assert_awaited_once_with(ephemeral=True)
+    sent = interaction.followup.send.await_args
+    assert sent.kwargs["ephemeral"] is True
+    assert sent.kwargs["allowed_mentions"] is NO_MENTIONS
+    embed = sent.kwargs["embed"]
+    assert "invoice process" in embed.title
+    assert len(embed.fields) == 1
+    assert "<b>" not in embed.fields[0].value
+    assert "@everyone" not in embed.fields[0].value
+    assert "Open in Outline" in embed.fields[0].value
+
+
+@pytest.mark.asyncio
+async def test_wiki_without_query_shows_starred_quick_links(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"])
+    cog._quick_links = Mock(
+        return_value=[
+            _document(document_id="one", title="Member handbook"),
+            _document(document_id="two", title="Getting paid"),
+        ]
+    )
+
+    await cog.wiki.callback(cog, interaction)
+
+    cog._quick_links.assert_called_once_with()
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "Co-op Wiki"
+    assert "Member handbook" in embed.description
+    assert "Getting paid" in embed.description
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_query_with_no_results_explains_search_syntax(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"])
+    cog._search = Mock(return_value=[])
+
+    await cog.wiki.callback(cog, interaction, "does not exist")
+
+    embed = interaction.followup.send.await_args.kwargs["embed"]
+    assert embed.title == "No wiki matches"
+    assert "quoted phrases" in embed.description
+    assert "OR" in embed.description
+
+
+@pytest.mark.asyncio
+async def test_wiki_rejects_overlong_query_before_calling_outline(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"])
+    cog._search = Mock()
+
+    await cog.wiki.callback(cog, interaction, "x" * 201)
+
+    cog._search.assert_not_called()
+    message = interaction.followup.send.await_args.args[0]
+    assert "200 characters or fewer" in message
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_handles_outline_failure_without_exposing_error(
+    cog: WikiCog,
+) -> None:
+    interaction = _make_interaction(["Member"])
+    cog._search = Mock(side_effect=OutlineAPIError("private API detail"))
+
+    await cog.wiki.callback(cog, interaction, "invoice")
+
+    message = interaction.followup.send.await_args.args[0]
+    assert "temporarily unavailable" in message
+    assert "private API detail" not in message
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_reports_missing_configuration(cog: WikiCog) -> None:
+    interaction = _make_interaction(["Member"])
+    with patch.object(
+        cog,
+        "_quick_links",
+        side_effect=ValueError("Outline wiki search is not configured."),
+    ):
+        await cog.wiki.callback(cog, interaction)
+
+    message = interaction.followup.send.await_args.args[0]
+    assert "not configured" in message
+    assert interaction.followup.send.await_args.kwargs["ephemeral"] is True
+
+
+@pytest.mark.asyncio
+async def test_wiki_requires_member_role(cog: WikiCog) -> None:
+    interaction = _make_interaction([])
+
+    await cog.wiki.callback(cog, interaction, "invoice")
+
+    interaction.response.send_message.assert_awaited_once()
+    assert "Member" in interaction.response.send_message.await_args.args[0]
+    interaction.response.defer.assert_not_awaited()
+    interaction.followup.send.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Add a Member-only, ephemeral `/wiki` slash command for published Outline search results and starred quick links.
- Add a dedicated `OUTLINE_WIKI_API_KEY` setting, keeping it separate from the invitation token.
- Validate same-instance document links, sanitize displayed snippets, and document least-privilege setup.

## Impact

Members can find member-safe co-op documentation from Discord without exposing search queries or snippets in audit logs.

## Validation

- `uv run pytest tests/unit/test_outline_client.py tests/unit/test_wiki_cog.py tests/unit/test_bot.py tests/unit/test_discord_command_metadata.py -q` — 34 passed
- `./.venv/bin/ruff check apps/discord_bot/src/five08/discord_bot/cogs/wiki.py packages/shared/src/five08/clients/outline.py tests/unit/test_wiki_cog.py tests/unit/test_outline_client.py tests/unit/test_bot.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Splits secrets and tightens guild/scoping for wiki access, but deployments must configure two Outline keys correctly and migrate from OUTLINE_API_KEY to avoid invite credentials being used for member content.
> 
> **Overview**
> Introduces a **Member-only, ephemeral `/wiki`** command that searches published Outline docs or shows starred quick links, restricted to the configured co-op guild via `DISCORD_SERVER_ID`.
> 
> **Outline credentials are split:** `OUTLINE_ADMIN_API_KEY` (with `OUTLINE_API_KEY` fallback) stays for invitations and account provisioning; a new **`OUTLINE_CONTENTS_API_KEY`** powers `/wiki` and dashboard project wiki matching so privileged invite keys are not used for member reads. Runtime config and settings support migrating legacy dashboard/env values and dropping old `OUTLINE_API_KEY` rows when the admin key is saved.
> 
> The shared **`OutlineClient`** gains read-only `documents.search` and `stars.list`, same-instance URL validation, and less verbose API errors. **`fetch_outline_document`** now requires the contents key. Compose wires **`POSTGRES_URL`** into the discord bot service for runtime config DB access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e00da794a089d5ee315ca041e2a70ffb96f1b5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the member-only `/wiki` command for private, read-only wiki searches.
  * Search supports quoted phrases, `OR`, and excluded terms, returning excerpts, last-updated dates, and document links.
  * Without a query, `/wiki` shows curated starred quick links.
* **Security & Reliability**
  * `/wiki` responses are ephemeral, with mention and content sanitization; wiki search details aren’t audit logged.
  * Introduced dedicated wiki/member and admin access keys, with clearer configuration and temporary-unavailable messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->